### PR TITLE
feature: Replay onchain transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11342,6 +11342,7 @@ dependencies = [
  "solana-keypair",
  "solana-message 3.0.1",
  "solana-pubkey 3.0.0",
+ "solana-signature",
  "solana-signer",
  "solana-system-interface 2.0.0",
  "solana-transaction",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -48,6 +48,7 @@ solana-epoch-info = { workspace = true }
 solana-keypair = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
+solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -702,6 +702,9 @@ fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
         Command::List(cmd) => hiro_system_kit::nestable_block_on(handle_list_command(cmd, ctx)),
         Command::Cloud(cmd) => hiro_system_kit::nestable_block_on(handle_cloud_commands(cmd)),
         Command::Mcp => hiro_system_kit::nestable_block_on(handle_mcp_command(ctx)),
+        Command::Replay(cmd) => {
+            hiro_system_kit::nestable_block_on(replay::handle_replay_command(cmd, ctx))
+        }
     }
 }
 

--- a/crates/cli/src/cli/replay/mod.rs
+++ b/crates/cli/src/cli/replay/mod.rs
@@ -1,0 +1,166 @@
+use std::{fs, str::FromStr};
+
+use log::info;
+use solana_signature::Signature;
+use surfpool_core::surfnet::{remote::SurfnetRemoteClient, svm::SurfnetSvm};
+use surfpool_types::{ReplayConfig, ReplayResult, SimnetCommand};
+
+use super::{Context, ReplayCommand};
+
+/// Handles the replay command by fetching and re-executing transactions from mainnet.
+///
+/// This is a lightweight standalone handler that initializes an ephemeral SVM
+/// without a full RPC server. For interactive use with full surfpool features,
+/// use `surfpool start` with the `surfnet_replayTransaction` RPC method instead.
+pub async fn handle_replay_command(cmd: ReplayCommand, _ctx: &Context) -> Result<(), String> {
+    // Step 1: Parse signatures from args or file
+    let signatures = if let Some(file_path) = &cmd.from_file {
+        parse_signatures_from_file(file_path)?
+    } else if cmd.signatures.is_empty() {
+        return Err(
+            "No transaction signatures provided. Use positional args or --from-file".to_string(),
+        );
+    } else {
+        cmd.signatures
+            .iter()
+            .map(|s| Signature::from_str(s))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Invalid signature: {}", e))?
+    };
+
+    if signatures.is_empty() {
+        return Err("No transaction signatures provided".to_string());
+    }
+
+    // Step 2: Determine RPC URL
+    let rpc_url = cmd.datasource_rpc_url();
+    println!("Fetching transactions from: {}", rpc_url);
+
+    // Step 3: Initialize ephemeral SVM (no persistence, no RPC server overhead)
+    let (surfnet_svm, _simnet_events_rx, _geyser_events_rx) =
+        SurfnetSvm::new_with_db(None, "replay")
+            .map_err(|e| format!("Failed to initialize SVM: {}", e))?;
+
+    // Step 4: Create command channel (needed for time travel coordination)
+    let (simnet_commands_tx, _simnet_commands_rx): (
+        crossbeam_channel::Sender<SimnetCommand>,
+        crossbeam_channel::Receiver<SimnetCommand>,
+    ) = crossbeam_channel::unbounded();
+
+    let svm_locker = surfpool_core::surfnet::locker::SurfnetSvmLocker::new(surfnet_svm);
+
+    // Step 5: Create remote client for mainnet data fetching
+    let remote_client = SurfnetRemoteClient::new(&rpc_url);
+
+    // Step 6: Build replay config from CLI flags
+    let replay_config = ReplayConfig {
+        profile: Some(cmd.profile),
+        time_travel: Some(!cmd.skip_time_travel),
+    };
+
+    // Step 7: Replay each transaction
+    let mut results: Vec<ReplayResult> = Vec::new();
+    let total = signatures.len();
+
+    for (i, signature) in signatures.iter().enumerate() {
+        println!(
+            "\n[{}/{}] Replaying: {}",
+            i + 1,
+            total,
+            signature
+        );
+
+        match svm_locker
+            .replay_transaction(
+                &remote_client,
+                *signature,
+                replay_config.clone(),
+                simnet_commands_tx.clone(),
+            )
+            .await
+        {
+            Ok(result) => {
+                print_replay_result(&result);
+                results.push(result);
+            }
+            Err(e) => {
+                eprintln!("  Error: {}", e);
+                // Continue with other transactions
+            }
+        }
+    }
+
+    // Step 8: Output results to file if requested
+    if let Some(output_path) = &cmd.output {
+        let json = serde_json::to_string_pretty(&results)
+            .map_err(|e| format!("Failed to serialize results: {}", e))?;
+        fs::write(output_path, json)
+            .map_err(|e| format!("Failed to write output file: {}", e))?;
+        info!("Results written to {}", output_path);
+        println!("\nResults written to: {}", output_path);
+    }
+
+    // Summary
+    let successful = results.iter().filter(|r| r.success).count();
+    let failed = results.len() - successful;
+    println!(
+        "\n=== Summary ===\nTotal: {} | Success: {} | Failed: {}",
+        total, successful, failed
+    );
+
+    Ok(())
+}
+
+/// Parses transaction signatures from a file (one per line).
+fn parse_signatures_from_file(file_path: &str) -> Result<Vec<Signature>, String> {
+    let content =
+        fs::read_to_string(file_path).map_err(|e| format!("Failed to read file: {}", e))?;
+
+    content
+        .lines()
+        .filter(|line| !line.trim().is_empty() && !line.trim().starts_with('#'))
+        .map(|line| {
+            Signature::from_str(line.trim())
+                .map_err(|e| format!("Invalid signature '{}': {}", line.trim(), e))
+        })
+        .collect()
+}
+
+/// Prints a human-readable summary of a replay result.
+fn print_replay_result(result: &ReplayResult) {
+    println!("\n--- Transaction {} ---", result.signature);
+    println!(
+        "Status: {}",
+        if result.success { "SUCCESS" } else { "FAILED" }
+    );
+    println!(
+        "Original slot: {} | Replay slot: {}",
+        result.original_slot, result.replay_slot
+    );
+
+    if let Some(block_time) = result.original_block_time {
+        if let Some(dt) = chrono::DateTime::from_timestamp(block_time, 0) {
+            println!("Original time: {}", dt.format("%Y-%m-%d %H:%M:%S UTC"));
+        }
+    }
+
+    println!("Compute units: {}", result.compute_units_consumed);
+
+    if let Some(ref error) = result.error {
+        println!("Error: {}", error);
+    }
+
+    if !result.logs.is_empty() {
+        println!("Logs ({}):", result.logs.len());
+        for log in result.logs.iter().take(10) {
+            println!("  {}", log);
+        }
+        if result.logs.len() > 10 {
+            println!("  ... and {} more", result.logs.len() - 10);
+        }
+    }
+
+    if let Some(ref warning) = result.state_warning {
+        println!("Warning: {}", warning);
+    }
+}

--- a/crates/cli/src/cli/replay/mod.rs
+++ b/crates/cli/src/cli/replay/mod.rs
@@ -3,7 +3,7 @@ use std::{fs, str::FromStr};
 use log::info;
 use solana_signature::Signature;
 use surfpool_core::surfnet::{remote::SurfnetRemoteClient, svm::SurfnetSvm};
-use surfpool_types::{ReplayConfig, ReplayResult, SimnetCommand};
+use surfpool_types::{channel, ReplayConfig, ReplayResult, SimnetCommand};
 
 use super::{Context, ReplayCommand};
 
@@ -43,9 +43,9 @@ pub async fn handle_replay_command(cmd: ReplayCommand, _ctx: &Context) -> Result
 
     // Step 4: Create command channel (needed for time travel coordination)
     let (simnet_commands_tx, _simnet_commands_rx): (
-        crossbeam_channel::Sender<SimnetCommand>,
-        crossbeam_channel::Receiver<SimnetCommand>,
-    ) = crossbeam_channel::unbounded();
+        channel::Sender<SimnetCommand>,
+        channel::Receiver<SimnetCommand>,
+    ) = channel::unbounded();
 
     let svm_locker = surfpool_core::surfnet::locker::SurfnetSvmLocker::new(surfnet_svm);
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -449,6 +449,38 @@ impl SurfpoolError {
         error.message = format!("Expected profile not found for key {key}");
         Self(error)
     }
+
+    pub fn replay_requires_remote() -> Self {
+        let mut error = Error::internal_error();
+        error.message = "Transaction replay requires a remote RPC connection".to_string();
+        error.data = Some(json!(
+            "Start surfpool with --rpc-url or --network to enable replay"
+        ));
+        Self(error)
+    }
+
+    pub fn replay_transaction_decode<S, E>(signature: S, e: E) -> Self
+    where
+        S: Display,
+        E: Display,
+    {
+        let mut error = Error::internal_error();
+        error.message = format!("Failed to decode transaction {signature}");
+        error.data = Some(json!(e.to_string()));
+        Self(error)
+    }
+
+    pub fn replay_unsupported_encoding<S>(signature: S, encoding: &str) -> Self
+    where
+        S: Display,
+    {
+        let mut error = Error::internal_error();
+        error.message = format!("Unsupported transaction encoding for replay: {encoding}");
+        error.data = Some(json!(format!(
+            "Transaction {signature} uses unsupported encoding. Expected base64."
+        )));
+        Self(error)
+    }
 }
 
 impl From<StorageError> for SurfpoolError {

--- a/crates/core/src/rpc/utils.rs
+++ b/crates/core/src/rpc/utils.rs
@@ -77,7 +77,7 @@ fn verify_hash(input: &str) -> Result<Hash> {
         .map_err(|e| Error::invalid_params(format!("Invalid param: {e:?}")))
 }
 
-fn verify_signature(input: &str) -> Result<Signature> {
+pub fn verify_signature(input: &str) -> Result<Signature> {
     input
         .parse()
         .map_err(|e| Error::invalid_params(format!("Invalid param: {e:?}")))

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -1257,6 +1257,56 @@ impl RunbookExecutionStatusReport {
     }
 }
 
+/// Configuration for transaction replay.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplayConfig {
+    /// Enable transaction profiling to capture detailed execution metrics.
+    #[serde(default)]
+    pub profile: Option<bool>,
+    /// Time travel to the transaction's original slot before execution.
+    #[serde(default)]
+    pub time_travel: Option<bool>,
+}
+
+impl ReplayConfig {
+    pub fn should_profile(&self) -> bool {
+        self.profile.unwrap_or(true)
+    }
+
+    pub fn should_time_travel(&self) -> bool {
+        self.time_travel.unwrap_or(true)
+    }
+}
+
+/// Result of replaying a transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplayResult {
+    /// The signature of the replayed transaction.
+    pub signature: String,
+    /// The slot at which the transaction was originally executed.
+    pub original_slot: Slot,
+    /// The slot at which the transaction was replayed.
+    pub replay_slot: Slot,
+    /// Block time of the original transaction (unix timestamp).
+    pub original_block_time: Option<i64>,
+    /// Whether the replay execution succeeded.
+    pub success: bool,
+    /// Execution log messages.
+    pub logs: Vec<String>,
+    /// Compute units consumed during execution.
+    pub compute_units_consumed: u64,
+    /// Error message if execution failed.
+    pub error: Option<String>,
+    /// Detailed profile result (if profiling was enabled).
+    pub profile_result: Option<UiKeyedProfileResult>,
+    /// Accounts used in the transaction.
+    pub accounts_used: Vec<String>,
+    /// Warning about state differences (historical vs current).
+    pub state_warning: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;


### PR DESCRIPTION
Issue: [Replay On-Chain transactions](https://github.com/txtx/surfpool/issues/505)

## Summary
Add the ability to replay On-Chain transactions locally for debugging and analysis. This feature enables developers to:
- Reproduce and debug production transactions in an isolated environment
- Analyze transaction execution with full profiling data
- Test protocol behavior against real historical transactions

## Changes

| File | Description |
|------|-------------|
| `crates/types/src/types.rs` | Add `ReplayConfig` and `ReplayResult` types |
| `crates/core/src/error.rs` | Add replay-specific error variants |
| `crates/core/src/surfnet/locker.rs` | Add `replay_transaction` method with blockhash replacement |
| `crates/core/src/rpc/surfnet_cheatcodes.rs` | Add `surfnet_replayTransaction` RPC method |
| `crates/cli/src/cli/mod.rs` | Add `ReplayCommand` struct and CLI wiring |
| `crates/cli/src/cli/replay/mod.rs` | New standalone CLI handler |
| `crates/cli/Cargo.toml` | Add `solana-signature` dependency |

## Usage

**CLI (standalone):**
```bash
surfpool replay <TX_SIGNATURE> -n mainnet --profile
surfpool replay --from-file sigs.txt -n mainnet -o results.json
TX_SIGNATURES=sig1,sig2 surfpool replay -n mainnet
```

**RPC method (with running surfpool):**
```bash
curl -X POST http://127.0.0.1:8899 -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"surfnet_replayTransaction","params":["<SIG>",{"profile":true}]}'
```

Test plan
[x] Replay single mainnet transaction via CLI
[x] Replay transaction via RPC method with surfpool start -n mainnet
[x] Verify profiling data includes account state diffs
[x] Verify compute units and logs match expected values
