### PR TITLE
docs: document Studio UI build inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ cd surfpool
 cargo surfpool-install
 ```
 
+Source builds include the bundled Surfpool Studio UI. By default, the build script
+downloads the latest `studio-dist.zip` from
+[`solana-foundation/surfpool-web-ui`](https://github.com/solana-foundation/surfpool-web-ui).
+To make the build reproducible or use a local Studio build, either pin a release
+with `STUDIO_UI_VERSION=<tag>` or point `STUDIO_UI_DIST` at a pre-built
+`studio-dist.zip`:
+
+```console
+STUDIO_UI_VERSION=0.2.0-alpha.0 cargo surfpool-install
+STUDIO_UI_DIST=/path/to/studio-dist.zip cargo surfpool-install
+```
+
 Surfpool can also be used through our public [docker image](https://hub.docker.com/r/surfpool/surfpool):
 
 ```console


### PR DESCRIPTION
## Summary
- document how source builds choose the bundled Surfpool Studio UI assets
- mention `STUDIO_UI_VERSION` for pinning a released `studio-dist.zip`
- mention `STUDIO_UI_DIST` for sandboxed or local builds that already have a pre-built Studio zip

## Context
`crates/studio/build.rs` already supports these inputs, and #628 added `STUDIO_UI_DIST` for sandbox builds. The README source-build path currently only shows `cargo surfpool-install`, so contributors have to read the build script to find the supported knobs.

Related to #588.

## Test Plan
- `git diff --check`
- `cargo test -p surfpool-cli public_service_url -- --nocapture`
- `cargo test -p surfpool-cli default_public_host -- --nocapture`