### PR TITLE
feat: add stop cmd

### DIFF
--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -190,14 +190,25 @@ pub struct StartSimnet {
 
 #[derive(Parser, PartialEq, Clone, Debug)]
 pub struct StopCommand {
+    /// RPC host of the running Surfpool instance. Defaults to localhost.
+    #[arg(long = "host", short = 'o', value_name = "HOST")]
+    pub host: Option<String>,
+    /// RPC port of the running Surfpool instance. Required unless --rpc-url is provided.
+    #[arg(
+        long = "port",
+        short = 'p',
+        required_unless_present = "rpc_url",
+        value_name = "PORT"
+    )]
+    pub port: Option<u16>,
     /// Full RPC URL of the running Surfpool instance.
     #[arg(
         long = "rpc-url",
         short = 'u',
-        default_value_t = format!("http://{DEFAULT_NETWORK_HOST}:{DEFAULT_RPC_PORT}"),
+        conflicts_with_all = ["host", "port"],
         value_name = "RPC_URL"
     )]
-    pub rpc_url: String,
+    pub rpc_url: Option<String>,
 }
 
 #[derive(Args, PartialEq, Clone, Debug)]
@@ -978,7 +989,7 @@ fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
 }
 
 async fn handle_stop_command(cmd: StopCommand) -> Result<(), String> {
-    let rpc_url = cmd.rpc_url.trim_end_matches('/').to_string();
+    let rpc_url = get_stop_rpc_url(&cmd);
     let response = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()
@@ -1009,6 +1020,18 @@ async fn handle_stop_command(cmd: StopCommand) -> Result<(), String> {
     parse_stop_response(&body)?;
     println!("Surfpool stop requested");
     Ok(())
+}
+
+fn get_stop_rpc_url(cmd: &StopCommand) -> String {
+    if let Some(rpc_url) = &cmd.rpc_url {
+        return rpc_url.trim_end_matches('/').to_string();
+    }
+
+    let host = cmd.host.as_deref().unwrap_or(DEFAULT_NETWORK_HOST);
+    let port = cmd
+        .port
+        .expect("--port is required when --rpc-url is absent");
+    format!("http://{host}:{port}")
 }
 
 fn parse_stop_response(body: &str) -> Result<(), String> {
@@ -1290,20 +1313,50 @@ mod tests {
     }
 
     #[test]
-    fn stop_parser_uses_default_rpc_endpoint() {
-        let cmd = parse_stop(&["surfpool", "stop"]);
+    fn stop_parser_requires_an_explicit_target() {
+        let err = Opts::try_parse_from(["surfpool", "stop"])
+            .expect_err("stop should require a port or RPC URL");
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn stop_parser_uses_default_host_with_port() {
+        let cmd = parse_stop(&["surfpool", "stop", "--port", "8899"]);
 
         assert_eq!(
-            cmd.rpc_url,
+            get_stop_rpc_url(&cmd),
             format!("http://{DEFAULT_NETWORK_HOST}:{DEFAULT_RPC_PORT}")
         );
+    }
+
+    #[test]
+    fn stop_parser_accepts_custom_host_and_port() {
+        let cmd = parse_stop(&["surfpool", "stop", "--host", "0.0.0.0", "--port", "8898"]);
+
+        assert_eq!(get_stop_rpc_url(&cmd), "http://0.0.0.0:8898");
     }
 
     #[test]
     fn stop_parser_accepts_custom_rpc_url() {
         let cmd = parse_stop(&["surfpool", "stop", "--rpc-url", "http://localhost:1234/"]);
 
-        assert_eq!(cmd.rpc_url, "http://localhost:1234/");
+        assert_eq!(get_stop_rpc_url(&cmd), "http://localhost:1234");
+    }
+
+    #[test]
+    fn stop_parser_rejects_mixed_target_options() {
+        let err = Opts::try_parse_from([
+            "surfpool",
+            "stop",
+            "--port",
+            "8899",
+            "--rpc-url",
+            "http://localhost:1234",
+        ])
+        .expect_err("RPC URL and host/port options should conflict");
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -211,6 +211,20 @@ pub struct StopCommand {
     pub rpc_url: Option<String>,
 }
 
+impl StopCommand {
+    fn get_stop_rpc_url(self: &Self) -> String {
+        if let Some(rpc_url) = &self.rpc_url {
+            return rpc_url.trim_end_matches('/').to_string();
+        }
+
+        let host = self.host.as_deref().unwrap_or(DEFAULT_NETWORK_HOST);
+        let port = self
+            .port
+            .expect("--port is required when --rpc-url is absent");
+        format!("http://{host}:{port}")
+    }
+}
+
 #[derive(Args, PartialEq, Clone, Debug)]
 #[command(next_help_heading = "Network & Ports")]
 pub struct StartNetworkOptions {
@@ -989,7 +1003,7 @@ fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
 }
 
 async fn handle_stop_command(cmd: StopCommand) -> Result<(), String> {
-    let rpc_url = get_stop_rpc_url(&cmd);
+    let rpc_url = cmd.get_stop_rpc_url();
     let response = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()
@@ -1020,18 +1034,6 @@ async fn handle_stop_command(cmd: StopCommand) -> Result<(), String> {
     parse_stop_response(&body)?;
     println!("Surfpool stop requested");
     Ok(())
-}
-
-fn get_stop_rpc_url(cmd: &StopCommand) -> String {
-    if let Some(rpc_url) = &cmd.rpc_url {
-        return rpc_url.trim_end_matches('/').to_string();
-    }
-
-    let host = cmd.host.as_deref().unwrap_or(DEFAULT_NETWORK_HOST);
-    let port = cmd
-        .port
-        .expect("--port is required when --rpc-url is absent");
-    format!("http://{host}:{port}")
 }
 
 fn parse_stop_response(body: &str) -> Result<(), String> {
@@ -1325,7 +1327,7 @@ mod tests {
         let cmd = parse_stop(&["surfpool", "stop", "--port", "8899"]);
 
         assert_eq!(
-            get_stop_rpc_url(&cmd),
+            cmd.get_stop_rpc_url(),
             format!("http://{DEFAULT_NETWORK_HOST}:{DEFAULT_RPC_PORT}")
         );
     }
@@ -1334,14 +1336,14 @@ mod tests {
     fn stop_parser_accepts_custom_host_and_port() {
         let cmd = parse_stop(&["surfpool", "stop", "--host", "0.0.0.0", "--port", "8898"]);
 
-        assert_eq!(get_stop_rpc_url(&cmd), "http://0.0.0.0:8898");
+        assert_eq!(cmd.get_stop_rpc_url(), "http://0.0.0.0:8898");
     }
 
     #[test]
     fn stop_parser_accepts_custom_rpc_url() {
         let cmd = parse_stop(&["surfpool", "stop", "--rpc-url", "http://localhost:1234/"]);
 
-        assert_eq!(get_stop_rpc_url(&cmd), "http://localhost:1234");
+        assert_eq!(cmd.get_stop_rpc_url(), "http://localhost:1234");
     }
 
     #[test]

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -114,6 +114,9 @@ enum Command {
     /// Start a local Surfnet
     #[clap(name = "start", bin_name = "start", aliases = &["simnet"])]
     Simnet(StartSimnet),
+    /// Stop a running Surfpool instance
+    #[clap(name = "stop", bin_name = "stop")]
+    Stop(StopCommand),
     /// Generate shell completion scripts
     #[clap(name = "completions", bin_name = "completions", aliases = &["completion"])]
     Completions(Completions),
@@ -183,6 +186,29 @@ pub struct StartSimnet {
         hide = true
     )]
     pub subgraph_db: Option<String>,
+}
+
+#[derive(Parser, PartialEq, Clone, Debug)]
+pub struct StopCommand {
+    /// RPC host of the running Surfpool instance.
+    #[arg(
+        long = "host",
+        short = 'o',
+        default_value = DEFAULT_NETWORK_HOST,
+        value_name = "HOST"
+    )]
+    pub host: String,
+    /// RPC port of the running Surfpool instance.
+    #[arg(
+        long = "port",
+        short = 'p',
+        default_value_t = DEFAULT_RPC_PORT,
+        value_name = "PORT"
+    )]
+    pub port: u16,
+    /// Full RPC URL of the running Surfpool instance.
+    #[arg(long = "rpc-url", short = 'u', value_name = "RPC_URL")]
+    pub rpc_url: Option<String>,
 }
 
 #[derive(Args, PartialEq, Clone, Debug)]
@@ -949,6 +975,7 @@ fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
             }
             hiro_system_kit::nestable_block_on(simnet::handle_start_local_surfnet_command(cmd, ctx))
         }
+        Command::Stop(cmd) => hiro_system_kit::nestable_block_on(handle_stop_command(cmd)),
         Command::Completions(cmd) => {
             hiro_system_kit::nestable_block_on(generate_completion_helpers(cmd))
         }
@@ -959,6 +986,58 @@ fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
         Command::Mcp => hiro_system_kit::nestable_block_on(handle_mcp_command(ctx)),
         Command::Update(cmd) => hiro_system_kit::nestable_block_on(handle_update_command(cmd)),
     }
+}
+
+async fn handle_stop_command(cmd: StopCommand) -> Result<(), String> {
+    let rpc_url = stop_rpc_url(&cmd);
+    let response = reqwest::Client::new()
+        .post(&rpc_url)
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "exit",
+            "params": [],
+        }))
+        .send()
+        .await
+        .map_err(|e| format!("failed to connect to Surfpool RPC at {rpc_url}: {e}"))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("failed to read Surfpool RPC response from {rpc_url}: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "Surfpool RPC at {rpc_url} returned HTTP {status}: {body}"
+        ));
+    }
+
+    parse_stop_response(&body)?;
+    println!("Surfpool stop requested");
+    Ok(())
+}
+
+fn stop_rpc_url(cmd: &StopCommand) -> String {
+    match &cmd.rpc_url {
+        Some(rpc_url) => rpc_url.trim_end_matches('/').to_string(),
+        None => format!("http://{}:{}", cmd.host, cmd.port),
+    }
+}
+
+fn parse_stop_response(body: &str) -> Result<(), String> {
+    let value = serde_json::from_str::<serde_json::Value>(body)
+        .map_err(|e| format!("failed to parse Surfpool RPC response: {e}: {body}"))?;
+
+    if let Some(error) = value.get("error").filter(|error| !error.is_null()) {
+        if let Some(message) = error.get("message").and_then(|message| message.as_str()) {
+            return Err(format!("Surfpool RPC returned error: {message}"));
+        }
+        return Err(format!("Surfpool RPC returned error: {error}"));
+    }
+
+    Ok(())
 }
 
 async fn generate_completion_helpers(cmd: Completions) -> Result<(), String> {
@@ -1126,6 +1205,16 @@ mod tests {
         }
     }
 
+    fn parse_stop(args: &[&str]) -> StopCommand {
+        match Opts::try_parse_from(args)
+            .expect("stop args should parse")
+            .command
+        {
+            Command::Stop(cmd) => cmd,
+            command => panic!("expected stop command, got {command:?}"),
+        }
+    }
+
     #[test]
     fn start_help_groups_related_flags() {
         let help = start_long_help();
@@ -1204,5 +1293,61 @@ mod tests {
     fn start_parser_accepts_hidden_deprecated_subgraph_db() {
         let cmd = parse_start(&["surfpool", "start", "--subgraph-db", "./legacy.sqlite"]);
         assert_eq!(cmd.subgraph_db.as_deref(), Some("./legacy.sqlite"));
+    }
+
+    #[test]
+    fn stop_parser_uses_default_rpc_endpoint() {
+        let cmd = parse_stop(&["surfpool", "stop"]);
+
+        assert_eq!(
+            stop_rpc_url(&cmd),
+            format!("http://{DEFAULT_NETWORK_HOST}:{DEFAULT_RPC_PORT}")
+        );
+    }
+
+    #[test]
+    fn stop_parser_accepts_custom_host_and_port() {
+        let cmd = parse_stop(&["surfpool", "stop", "--host", "0.0.0.0", "--port", "8898"]);
+
+        assert_eq!(stop_rpc_url(&cmd), "http://0.0.0.0:8898");
+    }
+
+    #[test]
+    fn stop_parser_prefers_rpc_url() {
+        let cmd = parse_stop(&[
+            "surfpool",
+            "stop",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8898",
+            "--rpc-url",
+            "http://localhost:1234/",
+        ]);
+
+        assert_eq!(stop_rpc_url(&cmd), "http://localhost:1234");
+    }
+
+    #[test]
+    fn parse_stop_response_accepts_success() {
+        parse_stop_response(r#"{"jsonrpc":"2.0","result":null,"id":1}"#)
+            .expect("successful response should parse");
+    }
+
+    #[test]
+    fn parse_stop_response_reports_rpc_error_message() {
+        let err = parse_stop_response(
+            r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}"#,
+        )
+        .expect_err("rpc error should fail");
+
+        assert_eq!(err, "Surfpool RPC returned error: Method not found");
+    }
+
+    #[test]
+    fn parse_stop_response_reports_invalid_json() {
+        let err = parse_stop_response("not json").expect_err("invalid json should fail");
+
+        assert!(err.contains("failed to parse Surfpool RPC response"));
     }
 }

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -190,25 +190,14 @@ pub struct StartSimnet {
 
 #[derive(Parser, PartialEq, Clone, Debug)]
 pub struct StopCommand {
-    /// RPC host of the running Surfpool instance.
-    #[arg(
-        long = "host",
-        short = 'o',
-        default_value = DEFAULT_NETWORK_HOST,
-        value_name = "HOST"
-    )]
-    pub host: String,
-    /// RPC port of the running Surfpool instance.
-    #[arg(
-        long = "port",
-        short = 'p',
-        default_value_t = DEFAULT_RPC_PORT,
-        value_name = "PORT"
-    )]
-    pub port: u16,
     /// Full RPC URL of the running Surfpool instance.
-    #[arg(long = "rpc-url", short = 'u', value_name = "RPC_URL")]
-    pub rpc_url: Option<String>,
+    #[arg(
+        long = "rpc-url",
+        short = 'u',
+        default_value_t = format!("http://{DEFAULT_NETWORK_HOST}:{DEFAULT_RPC_PORT}"),
+        value_name = "RPC_URL"
+    )]
+    pub rpc_url: String,
 }
 
 #[derive(Args, PartialEq, Clone, Debug)]
@@ -989,7 +978,7 @@ fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
 }
 
 async fn handle_stop_command(cmd: StopCommand) -> Result<(), String> {
-    let rpc_url = stop_rpc_url(&cmd);
+    let rpc_url = cmd.rpc_url.trim_end_matches('/').to_string();
     let response = reqwest::Client::new()
         .post(&rpc_url)
         .json(&serde_json::json!({
@@ -1017,13 +1006,6 @@ async fn handle_stop_command(cmd: StopCommand) -> Result<(), String> {
     parse_stop_response(&body)?;
     println!("Surfpool stop requested");
     Ok(())
-}
-
-fn stop_rpc_url(cmd: &StopCommand) -> String {
-    match &cmd.rpc_url {
-        Some(rpc_url) => rpc_url.trim_end_matches('/').to_string(),
-        None => format!("http://{}:{}", cmd.host, cmd.port),
-    }
 }
 
 fn parse_stop_response(body: &str) -> Result<(), String> {
@@ -1300,32 +1282,16 @@ mod tests {
         let cmd = parse_stop(&["surfpool", "stop"]);
 
         assert_eq!(
-            stop_rpc_url(&cmd),
+            cmd.rpc_url,
             format!("http://{DEFAULT_NETWORK_HOST}:{DEFAULT_RPC_PORT}")
         );
     }
 
     #[test]
-    fn stop_parser_accepts_custom_host_and_port() {
-        let cmd = parse_stop(&["surfpool", "stop", "--host", "0.0.0.0", "--port", "8898"]);
+    fn stop_parser_accepts_custom_rpc_url() {
+        let cmd = parse_stop(&["surfpool", "stop", "--rpc-url", "http://localhost:1234/"]);
 
-        assert_eq!(stop_rpc_url(&cmd), "http://0.0.0.0:8898");
-    }
-
-    #[test]
-    fn stop_parser_prefers_rpc_url() {
-        let cmd = parse_stop(&[
-            "surfpool",
-            "stop",
-            "--host",
-            "0.0.0.0",
-            "--port",
-            "8898",
-            "--rpc-url",
-            "http://localhost:1234/",
-        ]);
-
-        assert_eq!(stop_rpc_url(&cmd), "http://localhost:1234");
+        assert_eq!(cmd.rpc_url, "http://localhost:1234/");
     }
 
     #[test]

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -979,7 +979,10 @@ fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
 
 async fn handle_stop_command(cmd: StopCommand) -> Result<(), String> {
     let rpc_url = cmd.rpc_url.trim_end_matches('/').to_string();
-    let response = reqwest::Client::new()
+    let response = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("failed to create Surfpool RPC client: {e}"))?
         .post(&rpc_url)
         .json(&serde_json::json!({
             "jsonrpc": "2.0",

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -1023,6 +1023,7 @@ fn parse_stop_response(body: &str) -> Result<(), String> {
     }
 
     if value.get("jsonrpc").and_then(|version| version.as_str()) != Some("2.0")
+        || value.get("id").and_then(|id| id.as_i64()) != Some(1)
         || value.get("result").is_none()
     {
         return Err(format!(

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -1022,6 +1022,14 @@ fn parse_stop_response(body: &str) -> Result<(), String> {
         return Err(format!("Surfpool RPC returned error: {error}"));
     }
 
+    if value.get("jsonrpc").and_then(|version| version.as_str()) != Some("2.0")
+        || value.get("result").is_none()
+    {
+        return Err(format!(
+            "Surfpool RPC returned an invalid JSON-RPC response: {body}"
+        ));
+    }
+
     Ok(())
 }
 
@@ -1318,5 +1326,26 @@ mod tests {
         let err = parse_stop_response("not json").expect_err("invalid json should fail");
 
         assert!(err.contains("failed to parse Surfpool RPC response"));
+    }
+
+    #[test]
+    fn parse_stop_response_rejects_non_rpc_json() {
+        let err = parse_stop_response(r#"{"status":"ok"}"#).expect_err("non-RPC json should fail");
+
+        assert_eq!(
+            err,
+            r#"Surfpool RPC returned an invalid JSON-RPC response: {"status":"ok"}"#
+        );
+    }
+
+    #[test]
+    fn parse_stop_response_rejects_rpc_response_without_result() {
+        let err = parse_stop_response(r#"{"jsonrpc":"2.0","id":1}"#)
+            .expect_err("RPC response without result should fail");
+
+        assert_eq!(
+            err,
+            r#"Surfpool RPC returned an invalid JSON-RPC response: {"jsonrpc":"2.0","id":1}"#
+        );
     }
 }

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -69,13 +69,15 @@ use super::{
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
     helpers::time_travel::calculate_time_travel_clock,
-    rpc::full::{
-        ComparisonFilter, RpcGetTransactionsForAddressConfig, RpcTransactionForAddressEntry,
-        RpcTransactionForAddressFullInfo, RpcTransactionForAddressSignatureInfo,
-        RpcTransactionsForAddressResult, SortOrder, TransactionsForAddressDetails,
-        TransactionsForAddressStatusFilter, TransactionsForAddressTokenFilter,
+    rpc::{
+        full::{
+            ComparisonFilter, RpcGetTransactionsForAddressConfig, RpcTransactionForAddressEntry,
+            RpcTransactionForAddressFullInfo, RpcTransactionForAddressSignatureInfo,
+            RpcTransactionsForAddressResult, SortOrder, TransactionsForAddressDetails,
+            TransactionsForAddressStatusFilter, TransactionsForAddressTokenFilter,
+        },
+        utils::{convert_transaction_metadata_from_canonical, verify_pubkey},
     },
-    rpc::utils::{convert_transaction_metadata_from_canonical, verify_pubkey},
     storage::StorageResult,
     surfnet::FINALIZATION_SLOT_THRESHOLD,
     types::{


### PR DESCRIPTION
Closes #629 

Add stop command that internally does an RPC request with "exit" - better UX

```bash
surfpool stop
```
<img width="1413" height="204" alt="image" src="https://github.com/user-attachments/assets/9f9a5131-2a94-44dc-8c51-d0ad202512c7" />

I also tried the `stop` command in the PR #704 and it works with the --daemon flag : it stops the process.
