### PR TITLE
fix(core): stop double-dividing block_time in getTransaction/getBlock responses

### DIFF
--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -3371,6 +3371,16 @@ mod tests {
             block.signatures.is_none() || block.signatures.as_ref().unwrap().is_empty(),
             "Reconstructed empty block should have no signatures"
         );
+
+        // blockTime must be unix SECONDS (the header stores seconds since #428; a
+        // stale ms->s division here once returned seconds/1000 — ~1000x off, which
+        // this window catches without wall-clock flakiness).
+        let block_time = block.block_time.expect("block has a blockTime");
+        let now = chrono::Utc::now().timestamp();
+        assert!(
+            (now - block_time).abs() < 600,
+            "getBlock blockTime must be unix seconds: got {block_time}, now {now}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -3457,6 +3467,14 @@ mod tests {
         };
 
         setup.process_txs(vec![tx.clone()]).await;
+        // Confirm the block so it is stored — getTransaction sources blockTime
+        // from the stored BlockHeader (null while the block is unconfirmed).
+        setup
+            .context
+            .svm_locker
+            .confirm_current_block(&None)
+            .await
+            .unwrap();
 
         let res = setup
             .rpc
@@ -3516,6 +3534,28 @@ mod tests {
                 block_time: res.block_time, // Using the same values to avoid flakyness
                 transaction_index: None,
             }
+        );
+
+        // blockTime must be unix SECONDS and agree with the getBlockTime surface
+        // (the #401/#428 unit regression made getTransaction return seconds/1000
+        // while getBlockTime was correct; the self-comparison above couldn't catch
+        // it). The 600s window never flakes yet is ~6 orders of magnitude tighter
+        // than a unit error.
+        let block_time = res.block_time.expect("executed tx has a blockTime");
+        let now = chrono::Utc::now().timestamp();
+        assert!(
+            (now - block_time).abs() < 600,
+            "getTransaction blockTime must be unix seconds: got {block_time}, now {now}"
+        );
+        let via_get_block_time = setup
+            .rpc
+            .get_block_time(Some(setup.context.clone()), res.slot)
+            .await
+            .unwrap()
+            .expect("getBlockTime for the tx's slot");
+        assert_eq!(
+            block_time, via_get_block_time,
+            "getTransaction and getBlockTime must report the same blockTime"
         );
     }
 

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -1113,7 +1113,7 @@ impl SurfnetSvmLocker {
             let block_time = svm_reader
                 .blocks
                 .get(&slot)?
-                .map(|b| (b.block_time / 1_000) as UnixTimestamp)
+                .map(|b| b.block_time as UnixTimestamp)
                 .unwrap_or(0);
             let encoded = transaction_with_status_meta.encode(
                 config.encoding.unwrap_or(UiTransactionEncoding::JsonParsed),

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -1111,7 +1111,10 @@ impl SurfnetSvmLocker {
             let (transaction_with_status_meta, _) = entry.expect_processed();
             let slot = transaction_with_status_meta.slot;
             // `None` (spec: null) when the block isn't stored — never a fake 0.
-            let block_time = svm_reader.blocks.get(&slot)?.map(|b| b.block_time as UnixTimestamp);
+            let block_time = svm_reader
+                .blocks
+                .get(&slot)?
+                .map(|b| b.block_time as UnixTimestamp);
             let encoded = transaction_with_status_meta.encode(
                 config.encoding.unwrap_or(UiTransactionEncoding::JsonParsed),
                 config.max_supported_transaction_version,

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -1110,11 +1110,8 @@ impl SurfnetSvmLocker {
 
             let (transaction_with_status_meta, _) = entry.expect_processed();
             let slot = transaction_with_status_meta.slot;
-            let block_time = svm_reader
-                .blocks
-                .get(&slot)?
-                .map(|b| b.block_time as UnixTimestamp)
-                .unwrap_or(0);
+            // `None` (spec: null) when the block isn't stored — never a fake 0.
+            let block_time = svm_reader.blocks.get(&slot)?.map(|b| b.block_time as UnixTimestamp);
             let encoded = transaction_with_status_meta.encode(
                 config.encoding.unwrap_or(UiTransactionEncoding::JsonParsed),
                 config.max_supported_transaction_version,
@@ -1125,7 +1122,7 @@ impl SurfnetSvmLocker {
                 EncodedConfirmedTransactionWithStatusMeta {
                     slot,
                     transaction: encoded,
-                    block_time: Some(block_time),
+                    block_time,
                     transaction_index: None,
                 },
                 latest_absolute_slot,

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -3055,7 +3055,7 @@ impl SurfnetSvm {
             signatures,
             rewards: if show_rewards { Some(vec![]) } else { None },
             num_reward_partitions: None,
-            block_time: Some(block.block_time / 1000),
+            block_time: Some(block.block_time),
             block_height: Some(block.block_height),
         };
         Ok(Some(block))


### PR DESCRIPTION
## Summary

`getTransaction` and `getBlock` currently return `blockTime` as **unix seconds divided by 1000** (e.g. `1782985` instead of `1782985020`), disagreeing with `getBlockTime` and with the `Clock` sysvar the programs execute under.

## Root cause

`BlockHeader.block_time` has been stored in **seconds** since #428 ("fix: block time in secs instead of ms"), which moved the ms→s conversion to the write side:

- block store on confirmation: `block_time: self.updated_at as i64 / 1_000`
- sparse-block reconstruction: `calculate_block_time_for_slot(slot) / 1_000`
- (the unit test pins this: "1020000ms = 1020 seconds")

But two read paths still carry the ms→s division that was only correct **before** #428 (added by #401 back when the header held milliseconds):

- `get_transaction_local` (`crates/core/src/surfnet/locker.rs`): `.map(|b| (b.block_time / 1_000) as UnixTimestamp)`
- the `getBlock` response builder (`crates/core/src/surfnet/svm.rs`): `block_time: Some(block.block_time / 1000)`

`getBlockTime` was already corrected (#484) and the Clock sysvar path is computed independently, so today the clock surfaces disagree with each other.

## Reproduction

Against a running surfnet, execute any transaction and compare:

1. `getTransaction(sig).blockTime` → a value ~1000× too small (e.g. `1782985`),
2. `getBlockTime(slot)` and the `Clock` sysvar's `unix_timestamp` → correct unix seconds (e.g. `1782985020`).

Per the Solana RPC spec all three should agree (estimated production time as unix seconds).

## Fix

Remove the two stale divisions so all block-time surfaces (`getTransaction`, `getBlock`, `getBlockTime`, `Clock` sysvar) report unix seconds. The only existing `block_time` assertion targets header storage (seconds) and is unaffected.