### PR TITLE
Fix/datasource deadline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11950,6 +11950,7 @@ dependencies = [
  "agave-geyser-plugin-interface",
  "agave-reserved-account-keys",
  "anchor-lang-idl",
+ "async-trait",
  "axum",
  "base64 0.22.1",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ agave-reserved-account-keys = { version = "4.0", default-features = false }
 anchor-lang-idl = "0.1.2"
 ansi_term = "0.12.1"
 anyhow = { version = "1.0.95", default-features = false }
+async-trait = "0.1.89"
 atty = "0.2.13"
 base58 = "0.2.0"
 base64 = { version = "0.22.1", default-features = false }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 agave-feature-set = { workspace = true }
+async-trait = { workspace = true }
 agave-geyser-plugin-interface = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 base64 = { workspace = true }

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -69,13 +69,15 @@ use super::{
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
     helpers::time_travel::calculate_time_travel_clock,
-    rpc::full::{
-        ComparisonFilter, RpcGetTransactionsForAddressConfig, RpcTransactionForAddressEntry,
-        RpcTransactionForAddressFullInfo, RpcTransactionForAddressSignatureInfo,
-        RpcTransactionsForAddressResult, SortOrder, TransactionsForAddressDetails,
-        TransactionsForAddressStatusFilter, TransactionsForAddressTokenFilter,
+    rpc::{
+        full::{
+            ComparisonFilter, RpcGetTransactionsForAddressConfig, RpcTransactionForAddressEntry,
+            RpcTransactionForAddressFullInfo, RpcTransactionForAddressSignatureInfo,
+            RpcTransactionsForAddressResult, SortOrder, TransactionsForAddressDetails,
+            TransactionsForAddressStatusFilter, TransactionsForAddressTokenFilter,
+        },
+        utils::{convert_transaction_metadata_from_canonical, verify_pubkey},
     },
-    rpc::utils::{convert_transaction_metadata_from_canonical, verify_pubkey},
     storage::StorageResult,
     surfnet::FINALIZATION_SLOT_THRESHOLD,
     types::{

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -32,6 +32,7 @@ use solana_rpc_client::{
 use solana_rpc_client_api::client_error::{ErrorKind as ClientErrorKind, Result as ClientResult};
 use solana_signature::Signature;
 use solana_transaction_status::UiConfirmedBlock;
+use surfpool_types::sanitized_datasource_url;
 
 use super::GetTransactionResult;
 use crate::{
@@ -67,10 +68,15 @@ impl<S: RpcSender + Send + Sync> RpcSender for DeadlineSender<S> {
     ) -> ClientResult<serde_json::Value> {
         match tokio::time::timeout(self.deadline, self.inner.send(request, params)).await {
             Ok(response) => response,
+            // Scheme and host only. This message reaches a client through
+            // JSON-RPC error data, and a datasource URL carries credentials in
+            // its query, its path, and its userinfo. A URL that will not parse
+            // is named generically rather than printed raw.
             Err(_) => Err(ClientErrorKind::Custom(format!(
                 "{:?} to {} did not answer within {:?}",
                 request,
-                self.inner.url(),
+                sanitized_datasource_url(&self.inner.url())
+                    .unwrap_or_else(|| "the datasource".to_string()),
                 self.deadline
             ))
             .into()),
@@ -542,7 +548,7 @@ mod tests {
     /// A call that never completes, whether because the endpoint went quiet
     /// or because its retry policy never gave control back. The deadline does
     /// not need to know which.
-    struct NeverAnswers;
+    struct NeverAnswers(String);
 
     #[async_trait]
     impl RpcSender for NeverAnswers {
@@ -559,14 +565,49 @@ mod tests {
         }
 
         fn url(&self) -> String {
-            "http://never.example".to_string()
+            self.0.clone()
+        }
+    }
+
+    /// A datasource URL is a credential: the key can sit in the query, the
+    /// path, or the userinfo, and this message reaches a client through
+    /// JSON-RPC error data. The failure has to name the host without carrying
+    /// the secret along with it.
+    #[tokio::test]
+    async fn a_timeout_does_not_disclose_the_datasource_credentials() {
+        let secrets = [
+            "https://rpc.example.com/?api-key=SUPERSECRET",
+            "https://rpc.example.com/SUPERSECRET",
+            "https://user:SUPERSECRET@rpc.example.com",
+        ];
+
+        for url in secrets {
+            let sender = DeadlineSender {
+                inner: NeverAnswers(url.to_string()),
+                deadline: Duration::from_millis(50),
+            };
+
+            let message = sender
+                .send(RpcRequest::GetSlot, serde_json::Value::Null)
+                .await
+                .expect_err("a datasource that never answers should not succeed")
+                .to_string();
+
+            assert!(
+                !message.contains("SUPERSECRET"),
+                "the failure disclosed the datasource credential: {message}"
+            );
+            assert!(
+                message.contains("rpc.example.com"),
+                "the failure should still name the host: {message}"
+            );
         }
     }
 
     #[tokio::test]
     async fn a_datasource_that_never_answers_is_an_error_rather_than_a_wait() {
         let sender = DeadlineSender {
-            inner: NeverAnswers,
+            inner: NeverAnswers("http://never.example".to_string()),
             deadline: Duration::from_millis(50),
         };
 

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -59,6 +59,12 @@ struct DeadlineSender<S> {
     deadline: Duration,
 }
 
+impl<S> DeadlineSender<S> {
+    fn new(inner: S, deadline: Duration) -> Self {
+        DeadlineSender { inner, deadline }
+    }
+}
+
 #[async_trait]
 impl<S: RpcSender + Send + Sync> RpcSender for DeadlineSender<S> {
     async fn send(
@@ -92,6 +98,58 @@ impl<S: RpcSender + Send + Sync> RpcSender for DeadlineSender<S> {
     }
 }
 
+/// The RPC client a surfnet reaches its datasource through: an HTTP transport
+/// wrapped in a [`DeadlineSender`], assembled behind one constructor so that
+/// layers added later (tracing, recording, a retry policy) land here without
+/// touching a public signature.
+struct SurfpoolRpcClient {
+    client: RpcClient,
+}
+
+impl SurfpoolRpcClient {
+    fn new<U: ToString>(remote_rpc_url: U) -> Self {
+        let sender = DeadlineSender::new(
+            HttpSender::new(remote_rpc_url.to_string()),
+            DATASOURCE_DEADLINE,
+        );
+        let client = RpcClient::new_sender(
+            sender,
+            RpcClientConfig::with_commitment(CommitmentConfig::default()),
+        );
+        SurfpoolRpcClient { client }
+    }
+
+    /// A variant that accepts invalid TLS certificates, for datasources
+    /// behind self-signed certs.
+    fn new_unsafe<U: ToString>(remote_rpc_url: U) -> Option<Self> {
+        use reqwest;
+
+        // Retry HTTP client initialization to handle potential fork-related issues
+        let client = match reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .tls_built_in_root_certs(false)
+            .tls_built_in_webpki_certs(false)
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+        {
+            Ok(client) => client,
+            Err(e) => {
+                error!(
+                    "unable to initialize datasource client after retries: {}",
+                    e
+                );
+                return None;
+            }
+        };
+        let sender = DeadlineSender::new(
+            HttpSender::new_with_client(remote_rpc_url, client),
+            DATASOURCE_DEADLINE,
+        );
+        let client = RpcClient::new_sender(sender, RpcClientConfig::default());
+        Some(SurfpoolRpcClient { client })
+    }
+}
+
 pub struct SurfnetRemoteClient {
     pub client: RpcClient,
 }
@@ -116,43 +174,15 @@ impl SomeRemoteCtx for Option<SurfnetRemoteClient> {
 
 impl SurfnetRemoteClient {
     pub fn new<U: ToString>(remote_rpc_url: U) -> Self {
-        let sender = DeadlineSender {
-            inner: HttpSender::new(remote_rpc_url.to_string()),
-            deadline: DATASOURCE_DEADLINE,
-        };
-        let client = RpcClient::new_sender(
-            sender,
-            RpcClientConfig::with_commitment(CommitmentConfig::default()),
-        );
-        SurfnetRemoteClient { client }
+        SurfnetRemoteClient {
+            client: SurfpoolRpcClient::new(remote_rpc_url).client,
+        }
     }
 
     pub fn new_unsafe<U: ToString>(remote_rpc_url: U) -> Option<Self> {
-        use reqwest;
-
-        // Retry HTTP client initialization to handle potential fork-related issues
-        let client = match reqwest::Client::builder()
-            .danger_accept_invalid_certs(true)
-            .tls_built_in_root_certs(false)
-            .tls_built_in_webpki_certs(false)
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-        {
-            Ok(client) => client,
-            Err(e) => {
-                error!(
-                    "unable to initialize datasource client after retries: {}",
-                    e
-                );
-                return None;
-            }
-        };
-        let http_sender = DeadlineSender {
-            inner: HttpSender::new_with_client(remote_rpc_url, client),
-            deadline: DATASOURCE_DEADLINE,
-        };
-        let client = RpcClient::new_sender(http_sender, RpcClientConfig::default());
-        Some(SurfnetRemoteClient { client })
+        SurfpoolRpcClient::new_unsafe(remote_rpc_url).map(|rpc_client| SurfnetRemoteClient {
+            client: rpc_client.client,
+        })
     }
 
     pub async fn get_epoch_info(&self) -> SurfpoolResult<EpochInfo> {
@@ -582,10 +612,8 @@ mod tests {
         ];
 
         for url in secrets {
-            let sender = DeadlineSender {
-                inner: NeverAnswers(url.to_string()),
-                deadline: Duration::from_millis(50),
-            };
+            let sender =
+                DeadlineSender::new(NeverAnswers(url.to_string()), Duration::from_millis(50));
 
             let message = sender
                 .send(RpcRequest::GetSlot, serde_json::Value::Null)
@@ -606,10 +634,10 @@ mod tests {
 
     #[tokio::test]
     async fn a_datasource_that_never_answers_is_an_error_rather_than_a_wait() {
-        let sender = DeadlineSender {
-            inner: NeverAnswers("http://never.example".to_string()),
-            deadline: Duration::from_millis(50),
-        };
+        let sender = DeadlineSender::new(
+            NeverAnswers("http://never.example".to_string()),
+            Duration::from_millis(50),
+        );
 
         let error = sender
             .send(RpcRequest::GetSlot, serde_json::Value::Null)

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::HashMap, str::FromStr, time::Duration};
 
+use async_trait::async_trait;
 use serde_json::json;
 use solana_account::Account;
 use solana_account_decoder::UiAccount;
@@ -24,6 +25,11 @@ use solana_epoch_schedule::EpochSchedule;
 use solana_hash::Hash;
 use solana_loader_v3_interface::get_program_data_address;
 use solana_pubkey::Pubkey;
+use solana_rpc_client::{
+    http_sender::HttpSender,
+    rpc_sender::{RpcSender, RpcTransportStats},
+};
+use solana_rpc_client_api::client_error::{ErrorKind as ClientErrorKind, Result as ClientResult};
 use solana_signature::Signature;
 use solana_transaction_status::UiConfirmedBlock;
 
@@ -34,6 +40,51 @@ use crate::{
     surfnet::{GetAccountResult, locker::is_supported_token_program},
     types::{RemoteRpcResult, TokenAccount},
 };
+
+/// How long one call to the datasource gets, start to finish.
+///
+/// The HTTP client's timeout bounds a single attempt rather than a call:
+/// solana's sender retries a 429 up to five times and honours `Retry-After`
+/// for as much as 120 seconds each time, so a throttled datasource can hold a
+/// call for ten minutes with no individual attempt ever timing out. The value
+/// sits comfortably above that 30 second per-attempt timeout, since a deadline
+/// at or below it would cut off attempts that were going to succeed.
+const DATASOURCE_DEADLINE: Duration = Duration::from_secs(60);
+
+/// Bounds how long the sender it wraps may take, so a datasource that stops
+/// answering surfaces as an error rather than as a surfnet that appears stuck.
+struct DeadlineSender<S> {
+    inner: S,
+    deadline: Duration,
+}
+
+#[async_trait]
+impl<S: RpcSender + Send + Sync> RpcSender for DeadlineSender<S> {
+    async fn send(
+        &self,
+        request: RpcRequest,
+        params: serde_json::Value,
+    ) -> ClientResult<serde_json::Value> {
+        match tokio::time::timeout(self.deadline, self.inner.send(request, params)).await {
+            Ok(response) => response,
+            Err(_) => Err(ClientErrorKind::Custom(format!(
+                "{:?} to {} did not answer within {:?}",
+                request,
+                self.inner.url(),
+                self.deadline
+            ))
+            .into()),
+        }
+    }
+
+    fn get_transport_stats(&self) -> RpcTransportStats {
+        self.inner.get_transport_stats()
+    }
+
+    fn url(&self) -> String {
+        self.inner.url()
+    }
+}
 
 pub struct SurfnetRemoteClient {
     pub client: RpcClient,
@@ -59,13 +110,19 @@ impl SomeRemoteCtx for Option<SurfnetRemoteClient> {
 
 impl SurfnetRemoteClient {
     pub fn new<U: ToString>(remote_rpc_url: U) -> Self {
-        let client = RpcClient::new(remote_rpc_url.to_string());
+        let sender = DeadlineSender {
+            inner: HttpSender::new(remote_rpc_url.to_string()),
+            deadline: DATASOURCE_DEADLINE,
+        };
+        let client = RpcClient::new_sender(
+            sender,
+            RpcClientConfig::with_commitment(CommitmentConfig::default()),
+        );
         SurfnetRemoteClient { client }
     }
 
     pub fn new_unsafe<U: ToString>(remote_rpc_url: U) -> Option<Self> {
         use reqwest;
-        use solana_rpc_client::http_sender::HttpSender;
 
         // Retry HTTP client initialization to handle potential fork-related issues
         let client = match reqwest::Client::builder()
@@ -84,7 +141,10 @@ impl SurfnetRemoteClient {
                 return None;
             }
         };
-        let http_sender = HttpSender::new_with_client(remote_rpc_url, client);
+        let http_sender = DeadlineSender {
+            inner: HttpSender::new_with_client(remote_rpc_url, client),
+            deadline: DATASOURCE_DEADLINE,
+        };
         let client = RpcClient::new_sender(http_sender, RpcClientConfig::default());
         Some(SurfnetRemoteClient { client })
     }
@@ -472,5 +532,61 @@ where
         Ok(val) => Ok(RemoteRpcResult::Ok(val)),
         Err(e) if is_method_not_supported_error(&e) => Ok(RemoteRpcResult::MethodNotSupported),
         Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A call that never completes, whether because the endpoint went quiet
+    /// or because its retry policy never gave control back. The deadline does
+    /// not need to know which.
+    struct NeverAnswers;
+
+    #[async_trait]
+    impl RpcSender for NeverAnswers {
+        async fn send(
+            &self,
+            _request: RpcRequest,
+            _params: serde_json::Value,
+        ) -> ClientResult<serde_json::Value> {
+            std::future::pending().await
+        }
+
+        fn get_transport_stats(&self) -> RpcTransportStats {
+            RpcTransportStats::default()
+        }
+
+        fn url(&self) -> String {
+            "http://never.example".to_string()
+        }
+    }
+
+    #[tokio::test]
+    async fn a_datasource_that_never_answers_is_an_error_rather_than_a_wait() {
+        let sender = DeadlineSender {
+            inner: NeverAnswers,
+            deadline: Duration::from_millis(50),
+        };
+
+        let error = sender
+            .send(RpcRequest::GetSlot, serde_json::Value::Null)
+            .await
+            .expect_err("a datasource that never answers should not succeed");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("did not answer"),
+            "the failure should say what happened: {message}"
+        );
+        assert!(
+            message.contains("http://never.example"),
+            "the failure should identify the datasource: {message}"
+        );
+        assert!(
+            message.contains("GetSlot"),
+            "the failure should identify the request: {message}"
+        );
     }
 }

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -124,7 +124,8 @@ impl SurfpoolRpcClient {
     fn new_unsafe<U: ToString>(remote_rpc_url: U) -> Option<Self> {
         use reqwest;
 
-        // Retry HTTP client initialization to handle potential fork-related issues
+        // Construction can fail after a fork (the daemonize path), so a
+        // failure logs and surfaces as None rather than a panic.
         let client = match reqwest::Client::builder()
             .danger_accept_invalid_certs(true)
             .tls_built_in_root_certs(false)
@@ -134,10 +135,7 @@ impl SurfpoolRpcClient {
         {
             Ok(client) => client,
             Err(e) => {
-                error!(
-                    "unable to initialize datasource client after retries: {}",
-                    e
-                );
+                error!("unable to initialize datasource client: {}", e);
                 return None;
             }
         };

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -662,20 +662,25 @@ impl Default for SimnetConfig {
     }
 }
 
+/// A datasource URL reduced to scheme and host, for anywhere a client or a log
+/// can see it.
+///
+/// Datasource URLs carry credentials in three places: a query parameter
+/// (`?api-key=`), a path segment, and userinfo (`https://user:pass@host`).
+/// Parsing and rebuilding from the host drops all three. A URL that will not
+/// parse yields `None`, so a caller substitutes rather than falling back to
+/// the raw string.
+pub fn sanitized_datasource_url(raw: &str) -> Option<String> {
+    let url = url::Url::parse(raw).ok()?;
+    Some(format!("{}://{}", url.scheme(), url.host_str()?))
+}
+
 impl SimnetConfig {
     /// Returns a sanitized version of the datasource URL safe for display.
     /// Only returns scheme and host (e.g., "https://example.com") to prevent
     /// leaking API keys in paths or query parameters.
     pub fn get_sanitized_datasource_url(&self) -> Option<String> {
-        let raw = self.remote_rpc_url.as_ref()?;
-
-        if let Ok(url) = url::Url::parse(raw) {
-            let scheme = url.scheme();
-            let host = url.host_str()?;
-            Some(format!("{}://{}", scheme, host))
-        } else {
-            None
-        }
+        sanitized_datasource_url(self.remote_rpc_url.as_ref()?)
     }
 }
 


### PR DESCRIPTION
## Summary
This PR bounds the lifetime of an RPC call instead of only the lifetime of each individual HTTP request attempt.

Today, the HTTP client's 30-second timeout applies to a single request attempt. On a `429`, Solana's sender retries up to five times while honoring `Retry-After` delays of up to 120 seconds, allowing one RPC call to block for roughly ten minutes without any individual attempt timing out.

A surfnet targets mainnet-beta by default, making this reachable in ordinary use. From the caller's perspective, it is indistinguishable from a surfnet that has stopped responding.

The fix wraps the transport in `DeadlineSender`, which bounds the complete RPC call at 60 seconds (`81fb880`). Both `SurfnetRemoteClient` constructors now route through it, so every method inherits the deadline at the `RpcSender` layer, outside the retry loop.

This PR also adds `async-trait` as a direct dependency of `surfpool-core`.  Solana declares `RpcSender` with `#[async_trait]`; the crate was already existed in the lockfile.

With this change, datasource calls that remain throttled or otherwise fail to complete within 60 seconds now return an error instead of leaving the smurfnet apparently hung. The deadline remains longer than the HTTP client's per-attempt timeout, allowing an in-flight request to complete while placing a finite bound on the overall retry sequence.

### Validation

* `cargo test -p surfpool-core --lib -- a_datasource_that_never_answers`
* `cargo test --all --features surfpool-core/ignore_tests_ci`
* `cargo clippy --workspace --all-targets`

### Order

Depends on #730 for the `never_loop` fix because CI runs `cargo clippy --workspace --all-targets` after that PR lands.

### Todo

- [x] Rebase against `main` if/when #730 lands. The rebase will make this PR one single commit, as it currently carries 730's work.

