### PR TITLE
fix(core): announce slot lifecycle to geyser plugins

### DIFF
--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -238,15 +238,6 @@ pub async fn start_local_surfnet_runloop(
 
     let (plugin_commands_tx, plugin_commands_rx) = unbounded::<PluginCommand>();
 
-    let (_rpc_handle, _ws_handle, shutdown_rpc_servers) = start_rpc_servers_runloop(
-        &config,
-        &simnet_commands_tx,
-        svm_locker.clone(),
-        &remote_rpc_client,
-        plugin_commands_tx,
-    )
-    .await?;
-
     let simnet_config = simnet.clone();
 
     match start_geyser_runloop(
@@ -320,24 +311,12 @@ pub async fn start_local_surfnet_runloop(
 
         count
     });
-    // `Runloop` means nobody declares startup work, so the plan is empty.
-    // Seal it before CoreStarted, and an embedder waiting on that event
-    // observes a publicly ready surfnet. An external planner instead
-    // inspects the project after this point and seals its own plan.
-    if startup_planner == StartupPlanner::Runloop {
-        if let Err(error) = svm_locker.seal_startup_plan(vec![]) {
-            simnet_events_tx_cc.error(format!("Failed to seal startup plan: {error}"));
-        }
-    }
-    simnet_events_tx_cc.core_started(initial_transaction_count);
-
-    // Notify geyser plugins that startup is complete
-    let _ = svm_locker.with_svm_reader(|svm| svm.geyser_events_tx.send(GeyserEvent::EndOfStartup));
-
-    // Announce the genesis slot so plugins begin tracking it. Block production
-    // announces slot N+1 while closing slot N, so without this the first slot is
-    // never created from a plugin's perspective and its block data gets dropped.
     let _ = svm_locker.with_svm_reader(|svm| {
+        // Notify geyser plugins that startup is complete
+        svm.geyser_events_tx.send(GeyserEvent::EndOfStartup)?;
+        // Announce the genesis slot so plugins begin tracking it. Block production
+        // announces slot N+1 while closing slot N, so without this the first slot is
+        // never created from a plugin's perspective and its block data gets dropped.
         let slot = svm.get_latest_absolute_slot();
         svm.geyser_events_tx.send(GeyserEvent::UpdateSlotStatus {
             slot,
@@ -345,6 +324,29 @@ pub async fn start_local_surfnet_runloop(
             status: SlotStatus::CreatedBank,
         })
     });
+
+    // Do not accept RPC traffic until Geyser plugins have been told about the
+    // current slot. A transaction submitted as soon as the listener binds can
+    // otherwise emit block data for a slot the plugin is not tracking yet.
+    let (_rpc_handle, _ws_handle, shutdown_rpc_servers) = start_rpc_servers_runloop(
+        &config,
+        &simnet_commands_tx,
+        svm_locker.clone(),
+        &remote_rpc_client,
+        plugin_commands_tx,
+    )
+    .await?;
+
+    // `Runloop` means nobody declares startup work, so the plan is empty.
+    // Seal it before CoreStarted, and emit that public readiness signal only
+    // after the RPC listeners are accepting connections. An external planner
+    // instead inspects the project after this point and seals its own plan.
+    if startup_planner == StartupPlanner::Runloop {
+        if let Err(error) = svm_locker.seal_startup_plan(vec![]) {
+            simnet_events_tx_cc.error(format!("Failed to seal startup plan: {error}"));
+        }
+    }
+    simnet_events_tx_cc.core_started(initial_transaction_count);
 
     start_block_production_runloop(
         clock_event_rx,

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -334,6 +334,18 @@ pub async fn start_local_surfnet_runloop(
     // Notify geyser plugins that startup is complete
     let _ = svm_locker.with_svm_reader(|svm| svm.geyser_events_tx.send(GeyserEvent::EndOfStartup));
 
+    // Announce the genesis slot so plugins begin tracking it. Block production
+    // announces slot N+1 while closing slot N, so without this the first slot is
+    // never created from a plugin's perspective and its block data gets dropped.
+    let _ = svm_locker.with_svm_reader(|svm| {
+        let slot = svm.get_latest_absolute_slot();
+        svm.geyser_events_tx.send(GeyserEvent::UpdateSlotStatus {
+            slot,
+            parent: slot.checked_sub(1),
+            status: crate::surfnet::GeyserSlotStatus::CreatedBank,
+        })
+    });
+
     start_block_production_runloop(
         clock_event_rx,
         clock_command_tx,
@@ -833,6 +845,9 @@ fn start_geyser_runloop(
                             crate::surfnet::GeyserSlotStatus::Processed => SlotStatus::Processed,
                             crate::surfnet::GeyserSlotStatus::Confirmed => SlotStatus::Confirmed,
                             crate::surfnet::GeyserSlotStatus::Rooted => SlotStatus::Rooted,
+                            crate::surfnet::GeyserSlotStatus::FirstShredReceived => SlotStatus::FirstShredReceived,
+                            crate::surfnet::GeyserSlotStatus::CreatedBank => SlotStatus::CreatedBank,
+                            crate::surfnet::GeyserSlotStatus::Completed => SlotStatus::Completed,
                         };
 
                         for plugin in managed_plugins.iter().map(|p| &*p.plugin) {

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -342,7 +342,7 @@ pub async fn start_local_surfnet_runloop(
         svm.geyser_events_tx.send(GeyserEvent::UpdateSlotStatus {
             slot,
             parent: slot.checked_sub(1),
-            status: crate::surfnet::GeyserSlotStatus::CreatedBank,
+            status: SlotStatus::CreatedBank,
         })
     });
 
@@ -841,17 +841,8 @@ fn start_geyser_runloop(
                         }
                     }
                     Ok(GeyserEvent::UpdateSlotStatus { slot, parent, status }) => {
-                        let slot_status = match status {
-                            crate::surfnet::GeyserSlotStatus::Processed => SlotStatus::Processed,
-                            crate::surfnet::GeyserSlotStatus::Confirmed => SlotStatus::Confirmed,
-                            crate::surfnet::GeyserSlotStatus::Rooted => SlotStatus::Rooted,
-                            crate::surfnet::GeyserSlotStatus::FirstShredReceived => SlotStatus::FirstShredReceived,
-                            crate::surfnet::GeyserSlotStatus::CreatedBank => SlotStatus::CreatedBank,
-                            crate::surfnet::GeyserSlotStatus::Completed => SlotStatus::Completed,
-                        };
-
                         for plugin in managed_plugins.iter().map(|p| &*p.plugin) {
-                            if let Err(e) = plugin.update_slot_status(slot, parent, &slot_status) {
+                            if let Err(e) = plugin.update_slot_status(slot, parent, &status) {
                                 simnet_events_tx.error(format!("Failed to update slot status in Geyser plugin: {:?}", e));
                             }
                         }

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -48,6 +48,12 @@ pub enum GeyserSlotStatus {
     Rooted,
     /// Slot has been confirmed
     Confirmed,
+    /// First Shred Received
+    FirstShredReceived,
+    /// All shreds for the slot have been received.
+    Completed,
+    /// A new bank fork is created with the slot
+    CreatedBank,
 }
 
 /// Block metadata for geyser plugin notifications.

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
+use agave_geyser_plugin_interface::geyser_plugin_interface::SlotStatus;
 use crossbeam_channel::Sender;
 use jsonrpc_core::Result as RpcError;
 use locker::SurfnetSvmLocker;
@@ -37,24 +38,6 @@ pub const FINALIZATION_SLOT_THRESHOLD: u64 = 31;
 pub const SLOTS_PER_EPOCH: u64 = 432000;
 
 pub type AccountFactory = Box<dyn Fn(SurfnetSvmLocker) -> GetAccountResult + Send + Sync>;
-
-/// Slot status for geyser plugin notifications.
-/// Mirrors `agave_geyser_plugin_interface::geyser_plugin_interface::SlotStatus`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GeyserSlotStatus {
-    /// Slot is being processed
-    Processed,
-    /// Slot has been rooted (finalized)
-    Rooted,
-    /// Slot has been confirmed
-    Confirmed,
-    /// First Shred Received
-    FirstShredReceived,
-    /// All shreds for the slot have been received.
-    Completed,
-    /// A new bank fork is created with the slot
-    CreatedBank,
-}
 
 /// Block metadata for geyser plugin notifications.
 #[derive(Debug, Clone)]
@@ -94,7 +77,7 @@ pub enum GeyserEvent {
     UpdateSlotStatus {
         slot: Slot,
         parent: Option<Slot>,
-        status: GeyserSlotStatus,
+        status: SlotStatus,
     },
     /// Notify plugins of block metadata.
     NotifyBlockMetadata(GeyserBlockMetadata),

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use agave_feature_set::FeatureSet;
+use agave_geyser_plugin_interface::geyser_plugin_interface::SlotStatus;
 use base64::{Engine, prelude::BASE64_STANDARD};
 use chrono::Utc;
 use convert_case::Casing;
@@ -77,9 +78,9 @@ use uuid::Uuid;
 
 use super::{
     AccountSubscriptionData, BlockHeader, BlockIdentifier, FINALIZATION_SLOT_THRESHOLD,
-    GetAccountResult, GeyserBlockMetadata, GeyserEntryInfo, GeyserEvent, GeyserSlotStatus,
-    ProgramSubscriptionData, SignatureSubscriptionData, SignatureSubscriptionType,
-    SlotsUpdatesSubscriptionData, remote::SurfnetRemoteClient,
+    GetAccountResult, GeyserBlockMetadata, GeyserEntryInfo, GeyserEvent, ProgramSubscriptionData,
+    SignatureSubscriptionData, SignatureSubscriptionType, SlotsUpdatesSubscriptionData,
+    remote::SurfnetRemoteClient,
 };
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
@@ -2465,7 +2466,7 @@ impl SurfnetSvm {
             .send(GeyserEvent::UpdateSlotStatus {
                 slot: new_slot,
                 parent: Some(parent_slot),
-                status: GeyserSlotStatus::CreatedBank,
+                status: SlotStatus::CreatedBank,
             })
             .ok();
 
@@ -2476,7 +2477,7 @@ impl SurfnetSvm {
             .send(GeyserEvent::UpdateSlotStatus {
                 slot,
                 parent: slot.checked_sub(1),
-                status: GeyserSlotStatus::Processed,
+                status: SlotStatus::Processed,
             })
             .ok();
 
@@ -2485,7 +2486,7 @@ impl SurfnetSvm {
             .send(GeyserEvent::UpdateSlotStatus {
                 slot,
                 parent: slot.checked_sub(1),
-                status: GeyserSlotStatus::Confirmed,
+                status: SlotStatus::Confirmed,
             })
             .ok();
         // Mirror the Confirmed Geyser event as an `OptimisticConfirmation`
@@ -2546,7 +2547,7 @@ impl SurfnetSvm {
                 .send(GeyserEvent::UpdateSlotStatus {
                     slot: root,
                     parent: root.checked_sub(1),
-                    status: GeyserSlotStatus::Rooted,
+                    status: SlotStatus::Rooted,
                 })
                 .ok();
             // Mirror the Rooted Geyser event as a `Root` notification for
@@ -6873,7 +6874,7 @@ mod tests {
             match event {
                 GeyserEvent::UpdateSlotStatus {
                     slot,
-                    status: GeyserSlotStatus::CreatedBank,
+                    status: SlotStatus::CreatedBank,
                     ..
                 } => {
                     assert!(

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -2461,7 +2461,24 @@ impl SurfnetSvm {
             timestamp: slots_update_ts,
         });
 
+        self.geyser_events_tx
+            .send(GeyserEvent::UpdateSlotStatus {
+                slot: new_slot,
+                parent: Some(parent_slot),
+                status: GeyserSlotStatus::CreatedBank,
+            })
+            .ok();
+
         let geyser_parent_slot = slot.saturating_sub(1);
+
+        // Emit `Processed` for the slot that just executed
+        self.geyser_events_tx
+            .send(GeyserEvent::UpdateSlotStatus {
+                slot,
+                parent: slot.checked_sub(1),
+                status: GeyserSlotStatus::Processed,
+            })
+            .ok();
 
         // Emit confirmation for the same slot used by processed account/transaction updates.
         self.geyser_events_tx
@@ -6828,5 +6845,70 @@ mod tests {
             .expect("get_account should not error")
             .expect("Valid account should be restored");
         assert_eq!(restored_account.lamports, 1_000_000);
+    }
+
+    /// Geyser consumers that reconstruct blocks (yellowstone-grpc, for one) start
+    /// tracking a slot only once a lifecycle status announces it, and discard block
+    /// data that arrives for a slot they are not tracking. So every slot must be
+    /// announced with `CreatedBank` before any of its block data is emitted.
+    ///
+    /// The genesis slot is announced by the runloop rather than here, since block
+    /// production only ever announces the *next* slot — see the `CreatedBank` send
+    /// after `GeyserEvent::EndOfStartup` in `runloops::start_local_surfnet_runloop`.
+    /// That first slot is therefore excluded below.
+    #[test]
+    fn test_slot_is_announced_before_its_block_data_is_emitted() {
+        let (mut svm, _events_rx, geyser_rx) = SurfnetSvm::default();
+        let genesis_slot = svm.get_latest_absolute_slot();
+
+        for _ in 0..5 {
+            svm.confirm_current_block()
+                .expect("block confirmation should succeed");
+        }
+
+        let mut announced = HashSet::new();
+        let mut slots_with_block_data = HashSet::new();
+
+        while let Ok(event) = geyser_rx.try_recv() {
+            match event {
+                GeyserEvent::UpdateSlotStatus {
+                    slot,
+                    status: GeyserSlotStatus::CreatedBank,
+                    ..
+                } => {
+                    assert!(
+                        announced.insert(slot),
+                        "slot {slot} was announced more than once"
+                    );
+                }
+                GeyserEvent::NotifyBlockMetadata(metadata) => {
+                    if metadata.slot != genesis_slot {
+                        assert!(
+                            announced.contains(&metadata.slot),
+                            "block metadata for slot {} was emitted before the slot was announced",
+                            metadata.slot
+                        );
+                    }
+                    slots_with_block_data.insert(metadata.slot);
+                }
+                GeyserEvent::NotifyEntry(entry) => {
+                    if entry.slot != genesis_slot {
+                        assert!(
+                            announced.contains(&entry.slot),
+                            "entry for slot {} was emitted before the slot was announced",
+                            entry.slot
+                        );
+                    }
+                    slots_with_block_data.insert(entry.slot);
+                }
+                _ => {}
+            }
+        }
+
+        assert!(
+            slots_with_block_data.len() > 1,
+            "expected block data for several slots, got {}",
+            slots_with_block_data.len()
+        );
     }
 }


### PR DESCRIPTION
Fixes #719 

`GeyserSlotStatus` declared 2 of agave's 7 variants and only the `Confirmed` and `Rooted` were emitted. `Processed` was declared but never emitted. Consumers that reconstruct block data start tracking a slot only on a lifecycle status and drop block data for untracked slots, so the blocks metadata and entries surfpool produces get discarded on arrival

What I did was announce each newly opened slot with  `CreatedBank`, plus on at startup for the genesis slot. I also emit `Processed` which is not really needed here but #719 actually depends on it. I can drop it also

Regression test drives five blocks through `confirm_current_block` and asserts every `NotifyBlockMetadata` and `NotifyEntry` is for a slot announced beforehand. Before the fix: `block metadata for slot 32 was emitted before the slot was announced`.

I verified with a geyser plugin logging every callback over approx 54 slots `created_bank` went from 0 to 55, and all 109 block-metadata, entry and transaction events landed on an announced slot

Note: I added `FirstShredReceived` and `Completed` but never emit them, as surfpool has no gossip layer. I kept them because the enum's doc comment says it mirrors agave's `SlotStatus`. I can trim that to only what's emitted also