### PR TITLE
fix(types): resolve u16 PDA seeds from a constant option value

### DIFF
--- a/crates/core/src/scenarios/registry.rs
+++ b/crates/core/src/scenarios/registry.rs
@@ -182,7 +182,148 @@ impl TemplateRegistry {
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::HashMap, str::FromStr};
+
+    use solana_pubkey::Pubkey;
+    use surfpool_types::{AccountAddress, PdaSeed};
+
     use super::*;
+
+    #[test]
+    fn raydium_config_index_options_derive_their_documented_address() {
+        let registry = TemplateRegistry::new();
+        let template = registry.get("raydium-clmm-custom").expect("template");
+
+        let AccountAddress::Pda { seeds, .. } = &template.address else {
+            panic!("the pool address is a PDA");
+        };
+        let derived_pda_seed = seeds
+            .iter()
+            .find(|seed| matches!(seed, PdaSeed::DerivedPda { .. }))
+            .expect("the pool PDA derives the amm config PDA");
+
+        let options = &template
+            .constants
+            .get("amm_config_index")
+            .expect("amm_config_index constant")
+            .options;
+        assert!(!options.is_empty(), "the fee tiers are the fixture here");
+
+        for option in options {
+            let expected = option
+                .metadata
+                .get("derived_address")
+                .and_then(|address| address.as_str())
+                .map(|address| Pubkey::from_str(address).expect("a valid address"))
+                .unwrap_or_else(|| panic!("option {} documents no derived_address", option.id));
+
+            let values = HashMap::from([(
+                "config_index".to_string(),
+                serde_json::Value::String(option.value.clone()),
+            )]);
+            let bytes = derived_pda_seed
+                .to_bytes(Some(&values))
+                .unwrap_or_else(|| panic!("option {} did not resolve", option.id));
+
+            assert_eq!(
+                Pubkey::try_from(bytes.as_slice()).expect("32 bytes"),
+                expected,
+                "option {}",
+                option.id
+            );
+        }
+    }
+
+    /// The expected address is not ours: SOL/USDC at fee tier 1 holds a live CLMM
+    /// PoolState on mainnet (owner CAMMCzo5…, discriminator 247 237 227 245 215 195 222 70),
+    /// so this pins the whole chain — catalogue value, config PDA, pool PDA — against
+    /// something outside the fixtures. Mint order is part of the recipe: Raydium expects
+    /// the lower mint first, and the reversed order derives an address that holds nothing.
+    #[test]
+    fn raydium_template_derives_the_live_sol_usdc_pool() {
+        let registry = TemplateRegistry::new();
+        let template = registry.get("raydium-clmm-custom").expect("template");
+        let sol = "So11111111111111111111111111111111111111112";
+        let usdc = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+        let values = |mint_0: &str, mint_1: &str| {
+            HashMap::from([
+                (
+                    "config_index".to_string(),
+                    serde_json::Value::String("1".to_string()),
+                ),
+                (
+                    "token_mint_0".to_string(),
+                    serde_json::Value::String(mint_0.to_string()),
+                ),
+                (
+                    "token_mint_1".to_string(),
+                    serde_json::Value::String(mint_1.to_string()),
+                ),
+            ])
+        };
+
+        assert_eq!(
+            template
+                .address
+                .resolve(Some(&values(sol, usdc)))
+                .expect("resolves"),
+            Pubkey::from_str("3tD34VtprDSkYCnATtQLCiVgTkECU3d12KtjupeR6N2X").expect("address"),
+        );
+
+        assert_ne!(
+            template
+                .address
+                .resolve(Some(&values(usdc, sol)))
+                .expect("resolves"),
+            Pubkey::from_str("3tD34VtprDSkYCnATtQLCiVgTkECU3d12KtjupeR6N2X").expect("address"),
+            "swapping the mints must not land on the same pool"
+        );
+    }
+
+    #[test]
+    fn raydium_pool_address_needs_every_seed_to_resolve() {
+        let registry = TemplateRegistry::new();
+        let template = registry.get("raydium-clmm-custom").expect("template");
+
+        let mints: Vec<String> = template
+            .constants
+            .get("token_mint")
+            .expect("token_mint constant")
+            .options
+            .iter()
+            .take(2)
+            .map(|option| option.value.clone())
+            .collect();
+        assert_eq!(mints.len(), 2, "the pool address needs two mints");
+
+        let mut values = HashMap::from([
+            (
+                "config_index".to_string(),
+                serde_json::Value::String("1".to_string()),
+            ),
+            (
+                "token_mint_0".to_string(),
+                serde_json::Value::String(mints[0].clone()),
+            ),
+            (
+                "token_mint_1".to_string(),
+                serde_json::Value::String(mints[1].clone()),
+            ),
+        ]);
+
+        assert!(
+            template.address.resolve(Some(&values)).is_some(),
+            "every seed resolves, so the pool address does too"
+        );
+
+        values.remove("config_index");
+        assert_eq!(
+            template.address.resolve(Some(&values)),
+            None,
+            "a seed that cannot resolve must not derive a shorter address"
+        );
+    }
 
     #[test]
     fn test_registry_loads_all_protocols() {

--- a/crates/types/src/scenarios.rs
+++ b/crates/types/src/scenarios.rs
@@ -131,16 +131,13 @@ impl PdaSeed {
                 })
             }
             PdaSeed::U16Be(n) => Some(n.to_be_bytes().to_vec()),
-            PdaSeed::U16BeRef(prop) => {
-                values?.get(prop).and_then(|v| {
-                    // Handle numeric values - convert to u16 big-endian
-                    if let Some(n) = v.as_u64() {
-                        let n16 = u16::try_from(n).ok()?;
-                        return Some(n16.to_be_bytes().to_vec());
-                    }
-                    None
-                })
-            }
+            PdaSeed::U16BeRef(prop) => values?.get(prop).and_then(|v| {
+                let index = match v {
+                    serde_json::Value::String(s) => s.parse::<u16>().ok()?,
+                    _ => u16::try_from(v.as_u64()?).ok()?,
+                };
+                Some(index.to_be_bytes().to_vec())
+            }),
             PdaSeed::U16Le(n) => Some(n.to_le_bytes().to_vec()),
             PdaSeed::Bytes32Ref(prop) => {
                 values?.get(prop).and_then(|v| {
@@ -1121,5 +1118,33 @@ mod tests {
         let values = HashMap::from([("index".to_string(), json!(513))]);
 
         assert_eq!(seed.to_bytes(Some(&values)), Some(vec![2, 1]));
+    }
+
+    #[test]
+    fn u16_be_ref_encodes_decimal_strings() {
+        let seed = PdaSeed::U16BeRef("index".to_string());
+        let values = HashMap::from([("index".to_string(), json!("513"))]);
+
+        assert_eq!(seed.to_bytes(Some(&values)), Some(vec![2, 1]));
+    }
+
+    #[test]
+    fn u16_be_ref_rejects_strings_that_are_not_a_u16() {
+        let seed = PdaSeed::U16BeRef("index".to_string());
+
+        for value in [json!("65536"), json!("abc"), json!("-1"), json!("")] {
+            let values = HashMap::from([("index".to_string(), value.clone())]);
+            assert_eq!(seed.to_bytes(Some(&values)), None, "value {value}");
+        }
+    }
+
+    #[test]
+    fn u16_be_ref_rejects_values_that_are_not_an_integer() {
+        let seed = PdaSeed::U16BeRef("index".to_string());
+
+        for value in [json!(1.5), json!(true), json!(null), json!([1]), json!({})] {
+            let values = HashMap::from([("index".to_string(), value.clone())]);
+            assert_eq!(seed.to_bytes(Some(&values)), None, "value {value}");
+        }
     }
 }


### PR DESCRIPTION
`ConstantOption.value` is a `String` for every constant, so Raydium's `amm_config_index` options carry their index as `"0"`, `"1"`, `"2"`, `"3"`, `"8"`. `PdaSeed::U16BeRef` accepted only JSON numbers, so the seed resolved to `None`, `AccountAddress::resolve` returned `None` with it, and the apply loop logged a warning and moved on — while the caller was told the scenario applied. In practice the CLMM custom template could never derive its address from the catalogue.

The seed now accepts a decimal string as well as a number, u16-bounded either way.

Tests cover the bounds and non-integer JSON in `surfpool-types`. In `surfpool-core`, every `amm_config_index` option derives the address its own fixture documents, and the full template derives the live SOL/USDC pool at fee tier 1 (`3tD34VtprDSkYCnATtQLCiVgTkECU3d12KtjupeR6N2X`) — verified against mainnet: owner `CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK`, 1544 bytes, PoolState discriminator. That a missing seed must not shorten the derivation is asserted too.

The other value-taking seeds were audited and are consistent: the Pyth feed id is a hex string `Bytes32Ref` accepts, and the three mint/market references are pubkeys `PropertyRef` accepts. This was the only mismatch.
