### PR TITLE
fix(cli): honest 404s and an idempotent POST for the scenario endpoints

### DIFF
--- a/crates/cli/src/http/mod.rs
+++ b/crates/cli/src/http/mod.rs
@@ -309,6 +309,20 @@ mod tests {
             );
         }
 
+        let request = test::TestRequest::post()
+            .uri("/v1/nonexistent")
+            .to_request();
+        let response = test::call_service(&app, request).await;
+        assert_eq!(
+            response.status(),
+            404,
+            "the guard must catch non-GET methods too"
+        );
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/json",
+        );
+
         let request = test::TestRequest::get().uri("/v1/scenarios").to_request();
         let response = test::call_service(&app, request).await;
         assert_eq!(

--- a/crates/cli/src/http/mod.rs
+++ b/crates/cli/src/http/mod.rs
@@ -317,8 +317,24 @@ mod tests {
 
     use super::*;
 
+    fn scenario_body() -> serde_json::Value {
+        serde_json::json!({
+            "id": "s1",
+            "name": "first",
+            "description": "",
+            "overrides": [],
+            "tags": [],
+        })
+    }
+
+    fn post_scenario(body: serde_json::Value) -> test::TestRequest {
+        test::TestRequest::post()
+            .uri("/v1/scenarios")
+            .set_json(body)
+    }
+
     #[actix_web::test]
-    async fn creating_the_same_scenario_twice_is_a_no_op_and_a_reused_id_conflicts() {
+    async fn creating_the_same_scenario_twice_is_a_no_op() {
         let loaded_scenarios = Data::new(RwLock::new(LoadedScenarios::new()));
         let app = test::init_service(
             App::new()
@@ -327,34 +343,36 @@ mod tests {
         )
         .await;
 
-        let scenario = serde_json::json!({
-            "id": "s1",
-            "name": "first",
-            "description": "",
-            "overrides": [],
-            "tags": [],
-        });
-
-        let post = |body: serde_json::Value| {
-            test::TestRequest::post()
-                .uri("/v1/scenarios")
-                .set_json(body)
-                .to_request()
-        };
-
-        let created = test::call_service(&app, post(scenario.clone())).await;
+        let created = test::call_service(&app, post_scenario(scenario_body()).to_request()).await;
         assert_eq!(created.status(), 200, "first create must succeed");
 
-        let retried = test::call_service(&app, post(scenario.clone())).await;
+        let retried = test::call_service(&app, post_scenario(scenario_body()).to_request()).await;
         assert_eq!(
             retried.status(),
             200,
             "an identical retry must be accepted as a no-op"
         );
 
-        let mut conflicting = scenario.clone();
+        let stored = &loaded_scenarios.read().unwrap().scenarios;
+        assert_eq!(stored.len(), 1, "no duplicate may be stored");
+    }
+
+    #[actix_web::test]
+    async fn reusing_a_scenario_id_for_different_content_conflicts() {
+        let loaded_scenarios = Data::new(RwLock::new(LoadedScenarios::new()));
+        let app = test::init_service(
+            App::new()
+                .app_data(loaded_scenarios.clone())
+                .configure(configure_api),
+        )
+        .await;
+
+        let created = test::call_service(&app, post_scenario(scenario_body()).to_request()).await;
+        assert_eq!(created.status(), 200, "first create must succeed");
+
+        let mut conflicting = scenario_body();
         conflicting["name"] = serde_json::json!("second");
-        let rejected = test::call_service(&app, post(conflicting)).await;
+        let rejected = test::call_service(&app, post_scenario(conflicting).to_request()).await;
         assert_eq!(
             rejected.status(),
             409,
@@ -362,7 +380,11 @@ mod tests {
         );
 
         let stored = &loaded_scenarios.read().unwrap().scenarios;
-        assert_eq!(stored.len(), 1, "no duplicate may be stored");
+        assert_eq!(
+            stored.len(),
+            1,
+            "the conflicting scenario must not be stored"
+        );
         assert_eq!(stored[0].name, "first", "the stored scenario is untouched");
     }
 

--- a/crates/cli/src/http/mod.rs
+++ b/crates/cli/src/http/mod.rs
@@ -183,6 +183,36 @@ async fn post_scenarios(
         .map_err(|_| actix_web::error::ErrorInternalServerError("Failed to acquire write lock"))?;
     let scenario_data = scenario.into_inner();
     let scenario_id = scenario_data.id.clone();
+
+    if let Some(existing) = loaded_scenarios
+        .scenarios
+        .iter()
+        .find(|s| s.id == scenario_id)
+    {
+        let identical = match (
+            serde_json::to_value(existing),
+            serde_json::to_value(&scenario_data),
+        ) {
+            (Ok(stored), Ok(incoming)) => stored == incoming,
+            _ => false,
+        };
+
+        if identical {
+            let response = serde_json::json!({"id": scenario_id});
+            return Ok(HttpResponse::Ok()
+                .content_type("application/json")
+                .body(response.to_string()));
+        }
+
+        let response = serde_json::json!({
+            "error": "a different scenario is already stored under this id",
+            "id": scenario_id,
+        });
+        return Ok(HttpResponse::Conflict()
+            .content_type("application/json")
+            .body(response.to_string()));
+    }
+
     loaded_scenarios.scenarios.push(scenario_data);
     let response = serde_json::json!({"id": scenario_id});
     Ok(HttpResponse::Ok()
@@ -286,6 +316,55 @@ mod tests {
     use actix_web::{App, test};
 
     use super::*;
+
+    #[actix_web::test]
+    async fn creating_the_same_scenario_twice_is_a_no_op_and_a_reused_id_conflicts() {
+        let loaded_scenarios = Data::new(RwLock::new(LoadedScenarios::new()));
+        let app = test::init_service(
+            App::new()
+                .app_data(loaded_scenarios.clone())
+                .configure(configure_api),
+        )
+        .await;
+
+        let scenario = serde_json::json!({
+            "id": "s1",
+            "name": "first",
+            "description": "",
+            "overrides": [],
+            "tags": [],
+        });
+
+        let post = |body: serde_json::Value| {
+            test::TestRequest::post()
+                .uri("/v1/scenarios")
+                .set_json(body)
+                .to_request()
+        };
+
+        let created = test::call_service(&app, post(scenario.clone())).await;
+        assert_eq!(created.status(), 200, "first create must succeed");
+
+        let retried = test::call_service(&app, post(scenario.clone())).await;
+        assert_eq!(
+            retried.status(),
+            200,
+            "an identical retry must be accepted as a no-op"
+        );
+
+        let mut conflicting = scenario.clone();
+        conflicting["name"] = serde_json::json!("second");
+        let rejected = test::call_service(&app, post(conflicting)).await;
+        assert_eq!(
+            rejected.status(),
+            409,
+            "different content under a taken id must conflict"
+        );
+
+        let stored = &loaded_scenarios.read().unwrap().scenarios;
+        assert_eq!(stored.len(), 1, "no duplicate may be stored");
+        assert_eq!(stored[0].name, "first", "the stored scenario is untouched");
+    }
 
     #[actix_web::test]
     async fn unknown_v1_paths_return_json_404_instead_of_spa_fallback() {

--- a/crates/cli/src/http/mod.rs
+++ b/crates/cli/src/http/mod.rs
@@ -41,6 +41,19 @@ use crate::cli::Context;
 #[folder = "../../../explorer/.next/server/app"]
 pub struct Asset;
 
+/// Registers the studio API routes. Shared between the server and its tests
+fn configure_api(cfg: &mut web::ServiceConfig) {
+    cfg.service(get_config)
+        .service(get_scenario_templates)
+        .service(post_scenarios)
+        .service(get_scenarios)
+        .service(delete_scenario)
+        .service(patch_scenario)
+        // Unknown /v1/* paths must fail loudly here: otherwise the studio
+        // SPA fallback answers them with index.html and a misleading 200
+        .service(web::scope("/v1").default_service(web::route().to(api_not_found)));
+}
+
 pub async fn start_studio_and_scenario_server(
     network_binding: String,
     config: SanitizedConfig,
@@ -78,12 +91,7 @@ pub async fn start_studio_and_scenario_server(
             )
             .wrap(middleware::Compress::default())
             .wrap(middleware::Logger::default())
-            .service(get_config)
-            .service(get_scenario_templates)
-            .service(post_scenarios)
-            .service(get_scenarios)
-            .service(delete_scenario)
-            .service(patch_scenario)
+            .configure(configure_api)
             .service(web::scope("/mcp").service(mcp_service.clone().scope()));
 
         if enable_studio {
@@ -265,4 +273,48 @@ async fn dist(path: web::Path<String>) -> impl Responder {
         other => other,
     };
     handle_embedded_file(path_str)
+}
+
+async fn api_not_found() -> HttpResponse {
+    HttpResponse::NotFound()
+        .content_type("application/json")
+        .body(r#"{"error":"not found"}"#)
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::{App, test};
+
+    use super::*;
+
+    #[actix_web::test]
+    async fn unknown_v1_paths_return_json_404_instead_of_spa_fallback() {
+        let loaded_scenarios = Data::new(RwLock::new(LoadedScenarios::new()));
+        let app = test::init_service(
+            App::new()
+                .app_data(loaded_scenarios)
+                .configure(configure_api)
+                .service(surfpool_studio_ui::serve_studio_static_files),
+        )
+        .await;
+
+        for path in ["/v1/scenarios/some-id", "/v1/nonexistent"] {
+            let request = test::TestRequest::get().uri(path).to_request();
+            let response = test::call_service(&app, request).await;
+            assert_eq!(response.status(), 404, "expected 404 for {path}");
+            assert_eq!(
+                response.headers().get("content-type").unwrap(),
+                "application/json",
+                "expected JSON body for {path}"
+            );
+        }
+
+        let request = test::TestRequest::get().uri("/v1/scenarios").to_request();
+        let response = test::call_service(&app, request).await;
+        assert_eq!(
+            response.status(),
+            200,
+            "registered endpoints must keep working"
+        );
+    }
 }


### PR DESCRIPTION
Two defects in the same file.

Unknown `/v1/*` paths fell through to the SPA handler, which answered with `index.html` and HTTP 200, so a client calling a mistyped or nonexistent endpoint parsed HTML as JSON. A scope-level default service now returns a JSON 404, and the endpoint registration moved into a shared `configure_api` so the test exercises the real registration, including a non-GET request.

`POST /v1/scenarios` also stored a second copy when a client retried. An identical retry is now a no-op 200, and a reused id carrying different content returns 409.
