### PR TITLE
docs(rpc): make the documented surface match the wire

### DIFF
--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -735,12 +735,15 @@ pub trait SurfnetCheatcodes {
         limit: Option<u64>,
     ) -> BoxFuture<Result<RpcResponse<Vec<RpcLogsResponse>>>>;
 
-    /// A cheat code to jump forward or backward in time on the local network.
+    /// A cheat code to jump forward in time on the local network. The clock only moves
+    /// forward: a target in the past is rejected.
     /// Useful for testing epoch-based or time-sensitive logic.
     ///
     /// ## Parameters
     /// - `config` (optional): A `TimeTravelConfig` specifying how to modify the clock:
-    ///   - `absoluteTimestamp(u64)`: Moves time to the specified UNIX timestamp.
+    ///   - `absoluteTimestamp(u64)`: Moves time to the specified UNIX timestamp in
+    ///     **milliseconds** (like JavaScript `Date.now()`). Note that the `Clock` sysvar
+    ///     programs read is in seconds, so a value taken from it must be multiplied by 1000.
     ///   - `absoluteSlot(u64)`: Moves to the specified absolute slot.
     ///   - `absoluteEpoch(u64)`: Advances time to the specified epoch (each epoch = 432,000 slots).
     ///

--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -766,11 +766,11 @@ pub trait SurfnetCheatcodes {
     ///   "jsonrpc": "2.0",
     ///   "result": {
     ///     "epoch": 512,
-    ///     "slot_index": 0,
-    ///     "slots_in_epoch": 432000,
-    ///     "absolute_slot": 221184000,
-    ///     "block_height": 650000000,
-    ///     "transaction_count": 923472834
+    ///     "slotIndex": 0,
+    ///     "slotsInEpoch": 432000,
+    ///     "absoluteSlot": 221184000,
+    ///     "blockHeight": 650000000,
+    ///     "transactionCount": 923472834
     ///   },
     ///   "id": 1
     /// }
@@ -803,11 +803,11 @@ pub trait SurfnetCheatcodes {
     ///   "jsonrpc": "2.0",
     ///   "result": {
     ///     "epoch": 512,
-    ///     "slot_index": 0,
-    ///     "slots_in_epoch": 432000,
-    ///     "absolute_slot": 221184000,
-    ///     "block_height": 650000000,
-    ///     "transaction_count": 923472834
+    ///     "slotIndex": 0,
+    ///     "slotsInEpoch": 432000,
+    ///     "absoluteSlot": 221184000,
+    ///     "blockHeight": 650000000,
+    ///     "transactionCount": 923472834
     ///   },
     ///   "id": 1
     /// }
@@ -839,11 +839,11 @@ pub trait SurfnetCheatcodes {
     ///   "jsonrpc": "2.0",
     ///   "result": {
     ///     "epoch": 512,
-    ///     "slot_index": 0,
-    ///     "slots_in_epoch": 432000,
-    ///     "absolute_slot": 221184000,
-    ///     "block_height": 650000000,
-    ///     "transaction_count": 923472834
+    ///     "slotIndex": 0,
+    ///     "slotsInEpoch": 432000,
+    ///     "absoluteSlot": 221184000,
+    ///     "blockHeight": 650000000,
+    ///     "transactionCount": 923472834
     ///   },
     ///   "id": 1
     /// }

--- a/crates/types/src/rpc_endpoints.json
+++ b/crates/types/src/rpc_endpoints.json
@@ -811,6 +811,30 @@
           "returns": "A `RpcResponse<()>` indicating whether the write was successful."
         },
         {
+          "method": "surfnet_timeTravel",
+          "description": "A cheat code to move the Surfnet clock forward. The clock only moves forward: a target in the past is rejected. Returns the epoch state after the jump.",
+          "params": [
+            {
+              "name": "config",
+              "type": "Option<TimeTravelConfig>",
+              "description": "One of {\"absoluteTimestamp\": <unix milliseconds>}, {\"absoluteSlot\": <slot>} or {\"absoluteEpoch\": <epoch>}. Note that absoluteTimestamp is in MILLISECONDS, while the Clock sysvar reports seconds. If omitted, jumps one hour ahead."
+            }
+          ],
+          "returns": "An `EpochInfo` object describing the clock after the jump."
+        },
+        {
+          "method": "surfnet_pauseClock",
+          "description": "A cheat code to freeze the Surfnet clock. Slot production and time progression halt until resumed. The paused state is not reported by any other method.",
+          "params": [],
+          "returns": "An `EpochInfo` object describing the clock at the moment of the pause. It carries no timestamp: read the Clock sysvar with getAccountInfo on SysvarC1ock11111111111111111111111111111111 (jsonParsed) for the simulated unix time."
+        },
+        {
+          "method": "surfnet_resumeClock",
+          "description": "A cheat code to resume Surfnet clock progression after a pause.",
+          "params": [],
+          "returns": "An `EpochInfo` object describing the clock after resuming."
+        },
+        {
           "method": "surfnet_registerScenario",
           "description": "A cheat code to register a scenario with account overrides.",
           "params": [
@@ -822,6 +846,7 @@
                 "id": "String (A unique identifier for the scenario)",
                 "name": "String (A Human-readable name for the scenario)",
                 "description": "String (A description of the scenario)",
+                "tags": "Vec<String> (Required. Tags for categorization; pass an empty array when unused)",
                 "overrides": {
                   "type": "array",
                   "description": "Array of OverrideInstance objects, each containing account overrides.",
@@ -836,7 +861,7 @@
                       "label": "Option<String> (An optional label for this override instance)",
                       "enabled": "bool (Indicates whether this override instance is enabled)",
                       "fetchBeforeUse": "bool (Indicates whether to fetch the latest on-chain account data before applying overrides)",
-                      "account": "String (The account this override instance is applied to)"
+                      "account": "AccountAddress (The account this override targets, as {\"pubkey\": \"<base-58 address>\"} or {\"pda\": {\"programId\": \"<base-58 program>\", \"seeds\": [ ... ]}})"
                     }
                   }
                 }

--- a/crates/types/src/rpc_endpoints.json
+++ b/crates/types/src/rpc_endpoints.json
@@ -651,7 +651,7 @@
                 "lamports": "Option<u64>",
                 "owner": "Option<string> (base-58 encoded pubkey)",
                 "executable": "Option<bool>",
-                "rent_epoch": "Option<u64>",
+                "rentEpoch": "Option<u64>",
                 "data": "Option<string> (hex encoded)"
               }
             }
@@ -693,8 +693,8 @@
                 "amount": "Option<u64>",
                 "delegate": "Option<SetSomeAccount>",
                 "state": "Option<string> ('uninitialized', 'frozen', 'initialized')",
-                "delegated_amount": "Option<u64>",
-                "close_authority": "Option<SetSomeAccount>",
+                "delegatedAmount": "Option<u64>",
+                "closeAuthority": "Option<SetSomeAccount>",
                 "confidential": "Option<ConfidentialTransferAccountUpdate> (Token-2022 only; configures the confidential-transfer extension. Fields: elgamalPubkey (string, 32 bytes base58/base64, required), aesKey (string, 16 bytes base58/base64, required — produces the owner-decryptable balance, encrypt(0) for a zero balance), amount (Option<u64>, default 0), approved (Option<bool>, default true), allowConfidentialCredits (Option<bool>, default true), allowNonConfidentialCredits (Option<bool>, default true), maximumPendingBalanceCreditCounter (Option<u64>, default 65536))"
               }
             },
@@ -830,12 +830,12 @@
                     "description": "An OverrideInstance object.",
                     "schema": {
                       "id": "String (A unique identifier for this override instance)",
-                      "template_id": "String (The identifier of the template this instance is based on)",
+                      "templateId": "String (The identifier of the template this instance is based on)",
                       "values": "HashMap<String, serde_json::Value> (A hash map of field paths to override values. The field paths are a flat map to the account key being updated, from the IDL, using dot-notation to provide the path to the key. For example, to override a field 'amount' in an account 'myAccount', the path would be 'myAccount.amount'.)",
-                      "scenario_relative_slot": "u64 (Relative slot when this override should be applied (relative to scenario registration slot))",
+                      "scenarioRelativeSlot": "u64 (Relative slot when this override should be applied (relative to scenario registration slot))",
                       "label": "Option<String> (An optional label for this override instance)",
                       "enabled": "bool (Indicates whether this override instance is enabled)",
-                      "fetch_before_use": "bool (Indicates whether to fetch the latest on-chain account data before applying overrides)",
+                      "fetchBeforeUse": "bool (Indicates whether to fetch the latest on-chain account data before applying overrides)",
                       "account": "String (The account this override instance is applied to)"
                     }
                   }


### PR DESCRIPTION
Four corrections to documentation a client can follow into failure, each checked against a running surfnet.

`surfnet_timeTravel` documented neither its units nor its direction: `absoluteTimestamp` is milliseconds while the Clock sysvar reports seconds, and the clock only moves forward, so a value read from the clock and passed back is rejected as a past target.

Six field names were documented in snake_case while the wire is camelCase. `fetch_before_use` is the harmful one — it is `#[serde(default)]`, so posting an override the way the docs spelled it returns HTTP 200 and stores `fetchBeforeUse: false`, which means no fresh fetch and a skipped override when the account is not already in the SVM.

The `surfnet_registerScenario` schema omitted the required `tags` (a request following it fails with `missing field tags`) and typed `account` as a string, though `AccountAddress` needs `{"pubkey": "…"}` or `{"pda": {…}}`. The clock cheatcodes were missing from the catalog entirely, although the MCP tool description points models at that resource as the list of available methods, and their `EpochInfo` examples showed snake_case.
