### PR TITLE
feat(sdk-node): auto-airdrop configured addresses in the kit plugin

### DIFF
--- a/crates/sdk-node/README.md
+++ b/crates/sdk-node/README.md
@@ -82,9 +82,9 @@ const client = await createClient()
   .use(surfpool({ rpcUrl: "http://127.0.0.1:8899" }));
 ```
 
-That payer is usually unfunded on the running Surfnet. `airdropAddresses` tops
-up each listed address or signer while the client is composed, so no separate
-cheatcode call is needed before sending a transaction:
+That payer is usually unfunded on the running Surfnet. `airdropAddresses`
+credits each listed address or signer while the client is composed, so no
+separate cheatcode call is needed before sending a transaction:
 
 ```ts
 const client = await createClient()
@@ -98,10 +98,10 @@ const client = await createClient()
   );
 ```
 
-Funding is a top-up: an address already holding at least `airdropAmount` is
-left alone, and only the lamport balance is written, so existing account data
-and owner survive. A failure to fund throws, naming the address. The option
-works in embedded mode too, alongside the pre-funded payer.
+Funding is additive, like a real airdrop: `airdropAmount` is added to whatever
+the address already holds, and only the lamport balance is written, so existing
+account data and owner survive. A failure to fund throws, naming the address.
+The option works in embedded mode too, alongside the pre-funded payer.
 
 For one-off use without a client, `createSurfnetCheatcodesRpc(url)` returns a
 standalone `Rpc<SurfnetCheatcodesApi>`, and `surfnetCheatcodes()` installs

--- a/crates/sdk-node/README.md
+++ b/crates/sdk-node/README.md
@@ -82,6 +82,27 @@ const client = await createClient()
   .use(surfpool({ rpcUrl: "http://127.0.0.1:8899" }));
 ```
 
+That payer is usually unfunded on the running Surfnet. `airdropAddresses` tops
+up each listed address or signer while the client is composed, so no separate
+cheatcode call is needed before sending a transaction:
+
+```ts
+const client = await createClient()
+  .use(payer(myPayer))
+  .use(
+    surfpool({
+      airdropAddresses: [myPayer, someRecipient],
+      airdropAmount: 5_000_000_000n, // lamports, defaults to 10 SOL
+      rpcUrl: "http://127.0.0.1:8899",
+    }),
+  );
+```
+
+Funding is a top-up: an address already holding at least `airdropAmount` is
+left alone, and only the lamport balance is written, so existing account data
+and owner survive. A failure to fund throws, naming the address. The option
+works in embedded mode too, alongside the pre-funded payer.
+
 For one-off use without a client, `createSurfnetCheatcodesRpc(url)` returns a
 standalone `Rpc<SurfnetCheatcodesApi>`, and `surfnetCheatcodes()` installs
 `client.cheatcodes` on any existing client.

--- a/crates/sdk-node/scripts/kit-smoke.js
+++ b/crates/sdk-node/scripts/kit-smoke.js
@@ -61,6 +61,24 @@ test("embedded surfpool() boots a Surfnet and wires the full kit client", async 
   assert.equal(funded.value, 1_000_000_000n);
 });
 
+test("embedded surfpool() airdrops configured addresses at startup", async (t) => {
+  const recipient = Surfnet.newKeypair().publicKey;
+  const signerLike = { address: Surfnet.newKeypair().publicKey };
+  const client = await createClient().use(
+    surfpool({
+      airdropAddresses: [recipient, signerLike],
+      airdropAmount: 3_000_000_000n,
+      surfnet: { offline: true },
+    }),
+  );
+  t.after(() => client.surfnet.stop());
+
+  const funded = await client.rpc.getBalance(recipient).send();
+  assert.equal(funded.value, 3_000_000_000n);
+  const fundedSigner = await client.rpc.getBalance(signerLike.address).send();
+  assert.equal(fundedSigner.value, 3_000_000_000n);
+});
+
 test("disposing the embedded client stops the Surfnet", async () => {
   const client = await createClient().use(surfpool({ surfnet: { offline: true } }));
   await client.rpc.getSlot().send();

--- a/crates/sdk-node/scripts/kit-smoke.js
+++ b/crates/sdk-node/scripts/kit-smoke.js
@@ -64,11 +64,18 @@ test("embedded surfpool() boots a Surfnet and wires the full kit client", async 
 test("embedded surfpool() airdrops configured addresses at startup", async (t) => {
   const recipient = Surfnet.newKeypair().publicKey;
   const signerLike = { address: Surfnet.newKeypair().publicKey };
+  // Funded by the Surfnet itself before the plugin runs, so the plugin's own
+  // airdrop lands on an address that already holds lamports.
+  const preFunded = Surfnet.newKeypair().publicKey;
   const client = await createClient().use(
     surfpool({
-      airdropAddresses: [recipient, signerLike],
+      airdropAddresses: [recipient, signerLike, preFunded],
       airdropAmount: 3_000_000_000n,
-      surfnet: { offline: true },
+      surfnet: {
+        airdropAddresses: [preFunded],
+        airdropSol: 1_000_000_000,
+        offline: true,
+      },
     }),
   );
   t.after(() => client.surfnet.stop());
@@ -77,6 +84,9 @@ test("embedded surfpool() airdrops configured addresses at startup", async (t) =
   assert.equal(funded.value, 3_000_000_000n);
   const fundedSigner = await client.rpc.getBalance(signerLike.address).send();
   assert.equal(fundedSigner.value, 3_000_000_000n);
+  // Additive: the startup balance survives and the airdrop is added to it.
+  const toppedUp = await client.rpc.getBalance(preFunded).send();
+  assert.equal(toppedUp.value, 4_000_000_000n);
 });
 
 test("disposing the embedded client stops the Surfnet", async () => {

--- a/crates/sdk-node/scripts/kit-unit.js
+++ b/crates/sdk-node/scripts/kit-unit.js
@@ -302,6 +302,25 @@ test("attach mode honors airdropAmount and skips addresses already holding enoug
   }
 });
 
+test("attach mode rejects airdropAmount numbers that cannot represent lamports exactly", async () => {
+  const restore = mockFetch(() => {
+    throw new Error("no request should be made for an invalid amount");
+  });
+  try {
+    for (const airdropAmount of [Number.MAX_SAFE_INTEGER + 2, 1.5]) {
+      const payer = fakePayer();
+      await assert.rejects(
+        createClient({ payer }).use(
+          surfpool({ airdropAddresses: [payer], airdropAmount, rpcUrl: ENDPOINT }),
+        ),
+        /airdropAmount must be a safe integer or a bigint/,
+      );
+    }
+  } finally {
+    restore();
+  }
+});
+
 test("attach mode airdrop failures reject with the offending address", async () => {
   const restore = mockFetch((request) =>
     request.method === "getBalance"

--- a/crates/sdk-node/scripts/kit-unit.js
+++ b/crates/sdk-node/scripts/kit-unit.js
@@ -302,7 +302,7 @@ test("attach mode honors airdropAmount and skips addresses already holding enoug
   }
 });
 
-test("attach mode rejects airdropAmount numbers that cannot represent lamports exactly", async () => {
+test("attach mode rejects airdropAmount values that cannot represent a lamport top-up", async () => {
   const restore = mockFetch(() => {
     throw new Error("no request should be made for an invalid amount");
   });
@@ -314,6 +314,16 @@ test("attach mode rejects airdropAmount numbers that cannot represent lamports e
           surfpool({ airdropAddresses: [payer], airdropAmount, rpcUrl: ENDPOINT }),
         ),
         /airdropAmount must be a safe integer or a bigint/,
+      );
+    }
+    // A negative amount is below every balance, so it would silently fund nothing.
+    for (const airdropAmount of [-1, -1n]) {
+      const payer = fakePayer();
+      await assert.rejects(
+        createClient({ payer }).use(
+          surfpool({ airdropAddresses: [payer], airdropAmount, rpcUrl: ENDPOINT }),
+        ),
+        /airdropAmount must not be negative/,
       );
     }
   } finally {

--- a/crates/sdk-node/scripts/kit-unit.js
+++ b/crates/sdk-node/scripts/kit-unit.js
@@ -306,6 +306,46 @@ test("attach mode honors airdropAmount and adds it to an existing balance", asyn
   }
 });
 
+test("attach mode funds an address named twice exactly once", async () => {
+  const funded = [];
+  const restore = mockFetch((request) => {
+    if (request.method === "getBalance") {
+      return { result: { context: { slot: 1 }, value: 5_000_000_000 } };
+    }
+    funded.push([request.params[0], request.params[1].lamports]);
+    return { result: { context: { slot: 1 }, value: null } };
+  });
+  try {
+    const payer = fakePayer();
+    await createClient({ payer }).use(
+      surfpool({
+        // The signer and its own address are the same target spelled two ways.
+        airdropAddresses: [payer, payer.address],
+        airdropAmount: 2_000_000_000n,
+        rpcUrl: ENDPOINT,
+      }),
+    );
+    assert.deepEqual(funded, [[payer.address, 7_000_000_000]]);
+  } finally {
+    restore();
+  }
+});
+
+test("attach mode funds nothing when airdropAmount is zero", async () => {
+  const restore = mockFetch((request) => {
+    throw new Error(`no request should be made for a zero amount, got ${request.method}`);
+  });
+  try {
+    const payer = fakePayer();
+    const client = await createClient({ payer }).use(
+      surfpool({ airdropAddresses: [payer], airdropAmount: 0, rpcUrl: ENDPOINT }),
+    );
+    assert.equal(client.rpcUrl, ENDPOINT);
+  } finally {
+    restore();
+  }
+});
+
 test("attach mode rejects airdropAmount values that cannot represent a lamport amount", async () => {
   const restore = mockFetch(() => {
     throw new Error("no request should be made for an invalid amount");

--- a/crates/sdk-node/scripts/kit-unit.js
+++ b/crates/sdk-node/scripts/kit-unit.js
@@ -29,6 +29,10 @@ function mockFetch(handler) {
   };
 }
 
+function fakePayer() {
+  return { address: "SurfpoolTestPayer11111111111111111111111111" };
+}
+
 test("cheatcodes RPC prefixes method names and unwraps { context, value } envelopes", async () => {
   const seenMethods = [];
   const restore = mockFetch((request) => {
@@ -179,8 +183,8 @@ test("cheatcodes RPC sends configured extra headers", async () => {
 });
 
 test("attach mode installs the full client surface without loading the native module", () => {
-  const fakePayer = { address: "SurfpoolTestPayer11111111111111111111111111" };
-  const client = createClient({ payer: fakePayer }).use(
+  const payer = fakePayer();
+  const client = createClient({ payer }).use(
     surfpool({ rpcUrl: "http://127.0.0.1:8899" }),
   );
 
@@ -196,32 +200,125 @@ test("attach mode installs the full client surface without loading the native mo
   assert.equal(typeof client.sendTransaction, "function");
   assert.equal(typeof client.sendTransactions, "function");
   assert.equal(client.surfnet, undefined);
-  assert.equal(client.payer, fakePayer);
+  assert.equal(client.payer, payer);
 });
 
 test("attach mode defaults the WebSocket URL to surfpool's default WS port", () => {
-  const fakePayer = { address: "SurfpoolTestPayer11111111111111111111111111" };
+  const payer = fakePayer();
 
   // Surfpool's WebSocket port (default 8900) is independent of its HTTP
   // port, so a custom --port keeps subscriptions on 8900.
-  const customPort = createClient({ payer: fakePayer }).use(
+  const customPort = createClient({ payer }).use(
     surfpool({ rpcUrl: "http://127.0.0.1:12345" }),
   );
   assert.equal(customPort.wsUrl, "ws://127.0.0.1:8900");
 
   // Port-less URLs (e.g. behind a proxy) only swap the protocol.
-  const proxied = createClient({ payer: fakePayer }).use(
+  const proxied = createClient({ payer }).use(
     surfpool({ rpcUrl: "https://surfpool.example.com" }),
   );
   assert.equal(proxied.wsUrl, "wss://surfpool.example.com");
 
-  const explicit = createClient({ payer: fakePayer }).use(
+  const explicit = createClient({ payer }).use(
     surfpool({
       rpcUrl: "http://127.0.0.1:12345",
       rpcSubscriptionsUrl: "ws://127.0.0.1:54321",
     }),
   );
   assert.equal(explicit.wsUrl, "ws://127.0.0.1:54321");
+});
+
+test("attach mode without airdropAddresses stays synchronous and funds nothing", () => {
+  const calls = [];
+  const restore = mockFetch((request) => {
+    calls.push(request.method);
+    return { result: { context: { slot: 1 }, value: null } };
+  });
+  try {
+    const client = createClient({ payer: fakePayer() }).use(
+      surfpool({ rpcUrl: ENDPOINT }),
+    );
+    assert.equal(typeof client.then, "undefined");
+    assert.deepEqual(calls, []);
+  } finally {
+    restore();
+  }
+});
+
+test("attach mode airdrops configured addresses, accepting signers and bare addresses", async () => {
+  const funded = new Map();
+  const restore = mockFetch((request) => {
+    if (request.method === "getBalance") {
+      return { result: { context: { slot: 1 }, value: 0 } };
+    }
+    if (request.method === "surfnet_setAccount") {
+      funded.set(request.params[0], request.params[1].lamports);
+      return { result: { context: { slot: 1 }, value: null } };
+    }
+    throw new Error(`unexpected method ${request.method}`);
+  });
+  try {
+    const payer = fakePayer();
+    const other = "SurfpoolTestOther111111111111111111111111111";
+    const client = await createClient({ payer }).use(
+      surfpool({ airdropAddresses: [payer, other], rpcUrl: ENDPOINT }),
+    );
+
+    assert.equal(client.rpcUrl, ENDPOINT);
+    assert.equal(typeof client.cheatcodes.setAccount, "function");
+    // 10 SOL by default, matching Surfnet's own startup airdrop.
+    assert.equal(funded.get(payer.address), 10_000_000_000);
+    assert.equal(funded.get(other), 10_000_000_000);
+  } finally {
+    restore();
+  }
+});
+
+test("attach mode honors airdropAmount and skips addresses already holding enough", async () => {
+  const balances = {
+    SurfpoolTestOther111111111111111111111111111: 5_000_000_000,
+    SurfpoolTestPayer11111111111111111111111111: 0,
+  };
+  const funded = [];
+  const restore = mockFetch((request) => {
+    if (request.method === "getBalance") {
+      return { result: { context: { slot: 1 }, value: balances[request.params[0]] } };
+    }
+    funded.push(request.params[0]);
+    return { result: { context: { slot: 1 }, value: null } };
+  });
+  try {
+    const payer = fakePayer();
+    await createClient({ payer }).use(
+      surfpool({
+        airdropAddresses: [payer, "SurfpoolTestOther111111111111111111111111111"],
+        airdropAmount: 2_000_000_000n,
+        rpcUrl: ENDPOINT,
+      }),
+    );
+    assert.deepEqual(funded, [payer.address]);
+  } finally {
+    restore();
+  }
+});
+
+test("attach mode airdrop failures reject with the offending address", async () => {
+  const restore = mockFetch((request) =>
+    request.method === "getBalance"
+      ? { result: { context: { slot: 1 }, value: 0 } }
+      : { error: { code: -32601, message: "cheatcode disabled" } },
+  );
+  try {
+    const payer = fakePayer();
+    await assert.rejects(
+      createClient({ payer }).use(
+        surfpool({ airdropAddresses: [payer], rpcUrl: ENDPOINT }),
+      ),
+      /Failed to airdrop 10000000000 lamports to SurfpoolTestPayer11111111111111111111111111/,
+    );
+  } finally {
+    restore();
+  }
 });
 
 test("ESM and CJS builds expose the same named exports", async () => {

--- a/crates/sdk-node/scripts/kit-unit.js
+++ b/crates/sdk-node/scripts/kit-unit.js
@@ -370,6 +370,43 @@ test("attach mode rejects airdropAmount values that cannot represent a lamport a
         /airdropAmount must not be negative/,
       );
     }
+    // A lamport balance is a u64 on the wire, so anything beyond that range is
+    // rejected here rather than by the RPC deserializer.
+    for (const airdropAmount of [2n ** 64n, 2n ** 70n]) {
+      const payer = fakePayer();
+      await assert.rejects(
+        createClient({ payer }).use(
+          surfpool({ airdropAddresses: [payer], airdropAmount, rpcUrl: ENDPOINT }),
+        ),
+        /airdropAmount must not exceed 18446744073709551615 lamports/,
+      );
+    }
+  } finally {
+    restore();
+  }
+});
+
+test("attach mode rejects an airdrop whose sum with the existing balance exceeds u64", async () => {
+  const restore = mockFetch((request) => {
+    if (request.method === "getBalance") {
+      return { result: { context: { slot: 1 }, value: 5_000_000_000 } };
+    }
+    throw new Error("no account should be written for an unrepresentable balance");
+  });
+  try {
+    const payer = fakePayer();
+    await assert.rejects(
+      createClient({ payer }).use(
+        surfpool({
+          airdropAddresses: [payer],
+          airdropAmount: 2n ** 64n - 1n,
+          rpcUrl: ENDPOINT,
+        }),
+      ),
+      (error) =>
+        /Failed to airdrop/.test(error.message) &&
+        /exceeds the maximum lamport balance 18446744073709551615/.test(error.cause.message),
+    );
   } finally {
     restore();
   }

--- a/crates/sdk-node/scripts/kit-unit.js
+++ b/crates/sdk-node/scripts/kit-unit.js
@@ -274,17 +274,17 @@ test("attach mode airdrops configured addresses, accepting signers and bare addr
   }
 });
 
-test("attach mode honors airdropAmount and skips addresses already holding enough", async () => {
+test("attach mode honors airdropAmount and adds it to an existing balance", async () => {
   const balances = {
     SurfpoolTestOther111111111111111111111111111: 5_000_000_000,
     SurfpoolTestPayer11111111111111111111111111: 0,
   };
-  const funded = [];
+  const funded = new Map();
   const restore = mockFetch((request) => {
     if (request.method === "getBalance") {
       return { result: { context: { slot: 1 }, value: balances[request.params[0]] } };
     }
-    funded.push(request.params[0]);
+    funded.set(request.params[0], request.params[1].lamports);
     return { result: { context: { slot: 1 }, value: null } };
   });
   try {
@@ -296,13 +296,17 @@ test("attach mode honors airdropAmount and skips addresses already holding enoug
         rpcUrl: ENDPOINT,
       }),
     );
-    assert.deepEqual(funded, [payer.address]);
+    assert.equal(funded.get(payer.address), 2_000_000_000);
+    assert.equal(
+      funded.get("SurfpoolTestOther111111111111111111111111111"),
+      7_000_000_000,
+    );
   } finally {
     restore();
   }
 });
 
-test("attach mode rejects airdropAmount values that cannot represent a lamport top-up", async () => {
+test("attach mode rejects airdropAmount values that cannot represent a lamport amount", async () => {
   const restore = mockFetch(() => {
     throw new Error("no request should be made for an invalid amount");
   });
@@ -316,7 +320,7 @@ test("attach mode rejects airdropAmount values that cannot represent a lamport t
         /airdropAmount must be a safe integer or a bigint/,
       );
     }
-    // A negative amount is below every balance, so it would silently fund nothing.
+    // A negative amount would debit the address rather than fund it.
     for (const airdropAmount of [-1, -1n]) {
       const payer = fakePayer();
       await assert.rejects(

--- a/crates/sdk-node/surfpool-sdk/kit/__typetests__/typetests.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/__typetests__/typetests.ts
@@ -3,7 +3,7 @@
  * the emitting builds; checked by `npm run typecheck:kit`. Each
  * `@ts-expect-error` documents a misuse the types must keep rejecting.
  */
-import { createClient, type KeyPairSigner } from '@solana/kit';
+import { type Address, createClient, type KeyPairSigner } from '@solana/kit';
 
 import { surfpool } from '../surfpool.js';
 
@@ -34,6 +34,41 @@ void (async () => {
     // @ts-expect-error attach mode has no native Surfnet handle.
     void attached.surfnet;
 });
+// Attach mode without funding stays synchronous.
+void (() => {
+    const attached = createClient({ payer: payerSigner }).use(surfpool({ rpcUrl: 'http://127.0.0.1:8899' }));
+    void attached.rpc.getSlot();
+});
+
+// Attach mode with `airdropAddresses` becomes asynchronous.
+void (async () => {
+    const attached = await createClient({ payer: payerSigner }).use(
+        surfpool({
+            airdropAddresses: [payerSigner, '11111111111111111111111111111111' as Address],
+            airdropAmount: 1_000_000_000n,
+            rpcUrl: 'http://127.0.0.1:8899',
+        }),
+    );
+    void attached.rpc.getSlot();
+});
+// @ts-expect-error airdrop targets must be addresses or carry one.
+void surfpool({ airdropAddresses: [42], rpcUrl: 'http://127.0.0.1:8899' });
+
+declare const shouldFund: boolean;
+// A possibly-present `airdropAddresses` is rejected rather than typed as the
+// synchronous plugin it would not be at runtime.
+// @ts-expect-error the funding decision must be made at the type level.
+void surfpool({
+    airdropAddresses: shouldFund ? [payerSigner] : undefined,
+    rpcUrl: 'http://127.0.0.1:8899',
+});
+const conditionalConfig = {
+    rpcUrl: 'http://127.0.0.1:8899',
+    ...(shouldFund ? { airdropAddresses: [payerSigner] } : {}),
+};
+// @ts-expect-error same, spread into the config rather than written inline.
+void surfpool(conditionalConfig);
+
 // @ts-expect-error attach mode requires the client to already have a payer.
 void createClient().use(surfpool({ rpcUrl: 'http://127.0.0.1:8899' }));
 // @ts-expect-error embedded startup options cannot be combined with attach mode.

--- a/crates/sdk-node/surfpool-sdk/kit/index.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/index.ts
@@ -1,7 +1,9 @@
 export { createSurfnetCheatcodesRpc, DEFAULT_SURFNET_ENDPOINT, surfnetCheatcodes } from './cheatcodes.js';
 export { surfpool } from './surfpool.js';
 export type {
+    AirdropTarget,
     SurfpoolAttachConfig,
+    SurfpoolAttachConfigWithAirdrop,
     SurfpoolConfig,
     SurfpoolEmbeddedConfig,
     SurfpoolRpcOptions,

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -30,11 +30,13 @@ type SurfpoolAirdropOptions = {
      * Addresses (or signers) credited with {@link SurfpoolAirdropOptions.airdropAmount}
      * lamports while the client is being composed. The amount is added to
      * whatever the address already holds, the way a real airdrop behaves.
+     * Entries naming the same address are funded once.
      */
     airdropAddresses?: readonly AirdropTarget[];
     /**
      * Lamports to fund each entry of `airdropAddresses` with. Defaults to 10 SOL.
      * A `number` must be a safe integer; pass a `bigint` for amounts above 2^53.
+     * Zero funds nothing.
      */
     airdropAmount?: bigint | number;
 };
@@ -105,9 +107,13 @@ async function fundAirdropAddresses(
     targets: readonly AirdropTarget[],
     amount: bigint,
 ): Promise<void> {
+    if (amount === 0n) {
+        return;
+    }
+    // Collapsing aliases to a set of addresses funds each exactly once.
+    const addresses = new Set(targets.map(target => (typeof target === 'string' ? target : target.address)));
     await Promise.all(
-        targets.map(async target => {
-            const address = typeof target === 'string' ? target : target.address;
+        [...addresses].map(async address => {
             try {
                 const { value: balance } = await client.rpc.getBalance(address).send();
                 await client.cheatcodes.setAccount(address, { lamports: balance + amount }).send();

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -32,7 +32,10 @@ type SurfpoolAirdropOptions = {
      * least that much are left alone.
      */
     airdropAddresses?: readonly AirdropTarget[];
-    /** Lamports to fund each entry of `airdropAddresses` with. Defaults to 10 SOL. */
+    /**
+     * Lamports to fund each entry of `airdropAddresses` with. Defaults to 10 SOL.
+     * A `number` must be a safe integer; pass a `bigint` for amounts above 2^53.
+     */
     airdropAmount?: bigint | number;
 };
 
@@ -68,6 +71,18 @@ export type SurfpoolAttachConfigWithAirdrop = SurfpoolAttachConfig & {
 };
 
 export type SurfpoolConfig = SurfpoolAttachConfig | SurfpoolEmbeddedConfig;
+
+/**
+ * A `number` above `Number.MAX_SAFE_INTEGER` has already lost precision by the
+ * time it is read, and a fractional one is not a lamport amount at all; both
+ * are rejected rather than silently funding a different balance.
+ */
+function toLamports(amount: bigint | number = DEFAULT_AIRDROP_LAMPORTS): bigint {
+    if (typeof amount === 'number' && !Number.isSafeInteger(amount)) {
+        throw new Error(`airdropAmount must be a safe integer or a bigint; received ${amount}`);
+    }
+    return BigInt(amount);
+}
 
 /**
  * Tops each target up to `amount` lamports through the `setAccount` cheatcode,
@@ -136,11 +151,7 @@ function surfpoolEmbedded(config: SurfpoolEmbeddedConfig = {}) {
             );
 
             if (airdropAddresses?.length) {
-                await fundAirdropAddresses(
-                    configuredClient,
-                    airdropAddresses,
-                    BigInt(airdropAmount ?? DEFAULT_AIRDROP_LAMPORTS),
-                );
+                await fundAirdropAddresses(configuredClient, airdropAddresses, toLamports(airdropAmount));
             }
 
             // Disposing the client stops the in-process Surfnet so its servers
@@ -209,11 +220,7 @@ function surfpoolAttachFunded(config: SurfpoolAttachConfigWithAirdrop) {
     const attach = surfpoolAttach(config);
     return async <T extends ClientWithPayer>(client: T) => {
         const configuredClient = attach(client);
-        await fundAirdropAddresses(
-            configuredClient,
-            config.airdropAddresses,
-            BigInt(config.airdropAmount ?? DEFAULT_AIRDROP_LAMPORTS),
-        );
+        await fundAirdropAddresses(configuredClient, config.airdropAddresses, toLamports(config.airdropAmount));
         return configuredClient;
     };
 }

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -11,7 +11,7 @@ import type { SurfnetConfig } from '@solana/surfpool';
 
 import { createSurfnetCheatcodesRpc } from './cheatcodes.js';
 
-/** Lamports each `airdropAddresses` entry is topped up to when no amount is given. */
+/** Lamports each `airdropAddresses` entry is credited with when no amount is given. */
 const DEFAULT_AIRDROP_LAMPORTS = 10_000_000_000n;
 
 /** An address to fund, or anything carrying one (a signer, a PDA, an account). */
@@ -27,9 +27,9 @@ export type SurfpoolRpcOptions = Omit<SolanaRpcConfig<string>, 'rpcSubscriptions
 /** Startup funding applied to both modes. */
 type SurfpoolAirdropOptions = {
     /**
-     * Addresses (or signers) topped up to {@link SurfpoolAirdropOptions.airdropAmount}
-     * lamports while the client is being composed. Addresses already holding at
-     * least that much are left alone.
+     * Addresses (or signers) credited with {@link SurfpoolAirdropOptions.airdropAmount}
+     * lamports while the client is being composed. The amount is added to
+     * whatever the address already holds, the way a real airdrop behaves.
      */
     airdropAddresses?: readonly AirdropTarget[];
     /**
@@ -75,9 +75,9 @@ export type SurfpoolConfig = SurfpoolAttachConfig | SurfpoolEmbeddedConfig;
 /**
  * A `number` above `Number.MAX_SAFE_INTEGER` has already lost precision by the
  * time it is read, and a fractional one is not a lamport amount at all. A
- * negative amount is below every balance, so it would skip funding entirely
- * rather than do what it says. All three are rejected instead of silently
- * funding something other than what was asked for.
+ * negative amount would debit the address instead of funding it, which is not
+ * what an airdrop means. All three are rejected instead of silently funding
+ * something other than what was asked for.
  */
 function toLamports(amount: bigint | number = DEFAULT_AIRDROP_LAMPORTS): bigint {
     if (typeof amount === 'number' && !Number.isSafeInteger(amount)) {
@@ -91,10 +91,11 @@ function toLamports(amount: bigint | number = DEFAULT_AIRDROP_LAMPORTS): bigint 
 }
 
 /**
- * Tops each target up to `amount` lamports through the `setAccount` cheatcode,
- * leaving any account that already holds at least that much untouched. Only
- * the lamport balance is written, so an existing account keeps its data and
- * owner.
+ * Credits each target with `amount` lamports through the `setAccount`
+ * cheatcode. The cheatcode writes an absolute balance, so the current balance
+ * is read first and the amount added to it, matching what a real airdrop does
+ * to an address that already holds lamports. Only the lamport balance is
+ * written, so an existing account keeps its data and owner.
  */
 async function fundAirdropAddresses(
     client: {
@@ -109,10 +110,7 @@ async function fundAirdropAddresses(
             const address = typeof target === 'string' ? target : target.address;
             try {
                 const { value: balance } = await client.rpc.getBalance(address).send();
-                if (balance >= amount) {
-                    return;
-                }
-                await client.cheatcodes.setAccount(address, { lamports: amount }).send();
+                await client.cheatcodes.setAccount(address, { lamports: balance + amount }).send();
             } catch (error) {
                 throw new Error(`Failed to airdrop ${amount} lamports to ${address}`, { cause: error });
             }
@@ -249,8 +247,8 @@ function surfpoolAttachFunded(config: SurfpoolAttachConfigWithAirdrop) {
  * Surfpool instance (e.g. `surfpool start`) instead of booting one. No native
  * module is loaded, no `payer` is installed (the client must already have
  * one), and there is no `client.surfnet` handle. Because that payer is usually
- * unfunded on the running Surfnet, `airdropAddresses` tops it (and anything
- * else listed) up to `airdropAmount` lamports as the client is composed; the
+ * unfunded on the running Surfnet, `airdropAddresses` credits it (and anything
+ * else listed) with `airdropAmount` lamports as the client is composed; the
  * plugin then returns a promise, so `.use()` must be awaited.
  *
  * @example Embedded

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -74,14 +74,20 @@ export type SurfpoolConfig = SurfpoolAttachConfig | SurfpoolEmbeddedConfig;
 
 /**
  * A `number` above `Number.MAX_SAFE_INTEGER` has already lost precision by the
- * time it is read, and a fractional one is not a lamport amount at all; both
- * are rejected rather than silently funding a different balance.
+ * time it is read, and a fractional one is not a lamport amount at all. A
+ * negative amount is below every balance, so it would skip funding entirely
+ * rather than do what it says. All three are rejected instead of silently
+ * funding something other than what was asked for.
  */
 function toLamports(amount: bigint | number = DEFAULT_AIRDROP_LAMPORTS): bigint {
     if (typeof amount === 'number' && !Number.isSafeInteger(amount)) {
         throw new Error(`airdropAmount must be a safe integer or a bigint; received ${amount}`);
     }
-    return BigInt(amount);
+    const lamports = BigInt(amount);
+    if (lamports < 0n) {
+        throw new Error(`airdropAmount must not be negative; received ${amount}`);
+    }
+    return lamports;
 }
 
 /**

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -1,8 +1,21 @@
-import { type ClientWithPayer, createKeyPairSignerFromBytes, extendClient, pipe, withCleanup } from '@solana/kit';
+import {
+    type Address,
+    type ClientWithPayer,
+    createKeyPairSignerFromBytes,
+    extendClient,
+    pipe,
+    withCleanup,
+} from '@solana/kit';
 import { solanaLocalRpc, type SolanaRpcConfig } from '@solana/kit-plugin-rpc';
 import type { SurfnetConfig } from '@solana/surfpool';
 
 import { createSurfnetCheatcodesRpc } from './cheatcodes.js';
+
+/** Lamports each `airdropAddresses` entry is topped up to when no amount is given. */
+const DEFAULT_AIRDROP_LAMPORTS = 10_000_000_000n;
+
+/** An address to fund, or anything carrying one (a signer, a PDA, an account). */
+export type AirdropTarget = Address | { readonly address: Address };
 
 /**
  * Transaction planner/executor and RPC options forwarded to the standard
@@ -11,35 +24,91 @@ import { createSurfnetCheatcodesRpc } from './cheatcodes.js';
  */
 export type SurfpoolRpcOptions = Omit<SolanaRpcConfig<string>, 'rpcSubscriptionsUrl' | 'rpcUrl'>;
 
-/** Configuration for {@link surfpool} in embedded mode (boots an in-process Surfnet). */
-export type SurfpoolEmbeddedConfig = SurfpoolRpcOptions & {
-    rpcSubscriptionsUrl?: never;
-    rpcUrl?: never;
-    /** Startup options forwarded verbatim to `Surfnet.startWithConfig()`. */
-    surfnet?: SurfnetConfig;
+/** Startup funding applied to both modes. */
+type SurfpoolAirdropOptions = {
+    /**
+     * Addresses (or signers) topped up to {@link SurfpoolAirdropOptions.airdropAmount}
+     * lamports while the client is being composed. Addresses already holding at
+     * least that much are left alone.
+     */
+    airdropAddresses?: readonly AirdropTarget[];
+    /** Lamports to fund each entry of `airdropAddresses` with. Defaults to 10 SOL. */
+    airdropAmount?: bigint | number;
 };
 
+/** Configuration for {@link surfpool} in embedded mode (boots an in-process Surfnet). */
+export type SurfpoolEmbeddedConfig = SurfpoolAirdropOptions &
+    SurfpoolRpcOptions & {
+        rpcSubscriptionsUrl?: never;
+        rpcUrl?: never;
+        /** Startup options forwarded verbatim to `Surfnet.startWithConfig()`. */
+        surfnet?: SurfnetConfig;
+    };
+
 /** Configuration for {@link surfpool} in attach mode (connects to a running Surfpool). */
-export type SurfpoolAttachConfig = SurfpoolRpcOptions & {
-    /**
-     * The WebSocket URL of the running Surfpool instance. When omitted and
-     * the `rpcUrl` has an explicit port, defaults to Surfpool's default
-     * WebSocket port (8900, `--ws-port`) on the same host — Surfpool's
-     * WebSocket port is independent of its HTTP port. For a `rpcUrl` without
-     * a port (e.g. behind a proxy), only the protocol is swapped to
-     * `ws`/`wss`. Set this explicitly when your setup differs.
-     */
-    rpcSubscriptionsUrl?: string;
-    /** The HTTP RPC URL of a running Surfpool instance to attach to. */
-    rpcUrl: string;
-    surfnet?: never;
+export type SurfpoolAttachConfig = SurfpoolAirdropOptions &
+    SurfpoolRpcOptions & {
+        /**
+         * The WebSocket URL of the running Surfpool instance. When omitted and
+         * the `rpcUrl` has an explicit port, defaults to Surfpool's default
+         * WebSocket port (8900, `--ws-port`) on the same host — Surfpool's
+         * WebSocket port is independent of its HTTP port. For a `rpcUrl` without
+         * a port (e.g. behind a proxy), only the protocol is swapped to
+         * `ws`/`wss`. Set this explicitly when your setup differs.
+         */
+        rpcSubscriptionsUrl?: string;
+        /** The HTTP RPC URL of a running Surfpool instance to attach to. */
+        rpcUrl: string;
+        surfnet?: never;
+    };
+
+/** Attach-mode configuration that funds addresses, making the plugin asynchronous. */
+export type SurfpoolAttachConfigWithAirdrop = SurfpoolAttachConfig & {
+    airdropAddresses: readonly AirdropTarget[];
 };
 
 export type SurfpoolConfig = SurfpoolAttachConfig | SurfpoolEmbeddedConfig;
 
+/**
+ * Tops each target up to `amount` lamports through the `setAccount` cheatcode,
+ * leaving any account that already holds at least that much untouched. Only
+ * the lamport balance is written, so an existing account keeps its data and
+ * owner.
+ */
+async function fundAirdropAddresses(
+    client: {
+        cheatcodes: ReturnType<typeof createSurfnetCheatcodesRpc>;
+        rpc: { getBalance: (address: Address) => { send: () => Promise<{ value: bigint }> } };
+    },
+    targets: readonly AirdropTarget[],
+    amount: bigint,
+): Promise<void> {
+    await Promise.all(
+        targets.map(async target => {
+            const address = typeof target === 'string' ? target : target.address;
+            try {
+                const { value: balance } = await client.rpc.getBalance(address).send();
+                if (balance >= amount) {
+                    return;
+                }
+                await client.cheatcodes.setAccount(address, { lamports: amount }).send();
+            } catch (error) {
+                throw new Error(`Failed to airdrop ${amount} lamports to ${address}`, { cause: error });
+            }
+        }),
+    );
+}
+
 function surfpoolEmbedded(config: SurfpoolEmbeddedConfig = {}) {
     return async <T extends object>(client: T) => {
-        const { rpcSubscriptionsUrl: _unusedWs, rpcUrl: _unusedRpc, surfnet: surfnetConfig, ...rpcOptions } = config;
+        const {
+            airdropAddresses,
+            airdropAmount,
+            rpcSubscriptionsUrl: _unusedWs,
+            rpcUrl: _unusedRpc,
+            surfnet: surfnetConfig,
+            ...rpcOptions
+        } = config;
         // Lazy imports keep the optional peers optional: the native module is
         // only needed in embedded mode, and the signer package is only needed
         // for the payer this mode installs.
@@ -65,6 +134,14 @@ function surfpoolEmbedded(config: SurfpoolEmbeddedConfig = {}) {
                     rpcUrl: surfnet.rpcUrl,
                 }),
             );
+
+            if (airdropAddresses?.length) {
+                await fundAirdropAddresses(
+                    configuredClient,
+                    airdropAddresses,
+                    BigInt(airdropAmount ?? DEFAULT_AIRDROP_LAMPORTS),
+                );
+            }
 
             // Disposing the client stops the in-process Surfnet so its servers
             // and ports are freed; recreating the client boots a fresh one.
@@ -103,7 +180,14 @@ function surfpoolEmbedded(config: SurfpoolEmbeddedConfig = {}) {
 
 function surfpoolAttach(config: SurfpoolAttachConfig) {
     return <T extends ClientWithPayer>(client: T) => {
-        const { rpcSubscriptionsUrl, rpcUrl, surfnet: _unusedSurfnet, ...rpcOptions } = config;
+        const {
+            airdropAddresses: _unusedAirdropAddresses,
+            airdropAmount: _unusedAirdropAmount,
+            rpcSubscriptionsUrl,
+            rpcUrl,
+            surfnet: _unusedSurfnet,
+            ...rpcOptions
+        } = config;
         const wsUrl = rpcSubscriptionsUrl ?? deriveSubscriptionsUrl(rpcUrl);
 
         return pipe(
@@ -118,6 +202,19 @@ function surfpoolAttach(config: SurfpoolAttachConfig) {
                 rpcUrl,
             }),
         );
+    };
+}
+
+function surfpoolAttachFunded(config: SurfpoolAttachConfigWithAirdrop) {
+    const attach = surfpoolAttach(config);
+    return async <T extends ClientWithPayer>(client: T) => {
+        const configuredClient = attach(client);
+        await fundAirdropAddresses(
+            configuredClient,
+            config.airdropAddresses,
+            BigInt(config.airdropAmount ?? DEFAULT_AIRDROP_LAMPORTS),
+        );
+        return configuredClient;
     };
 }
 
@@ -138,7 +235,10 @@ function surfpoolAttach(config: SurfpoolAttachConfig) {
  * **Attach mode** (when `rpcUrl` is set): connects to an already-running
  * Surfpool instance (e.g. `surfpool start`) instead of booting one. No native
  * module is loaded, no `payer` is installed (the client must already have
- * one), and there is no `client.surfnet` handle.
+ * one), and there is no `client.surfnet` handle. Because that payer is usually
+ * unfunded on the running Surfnet, `airdropAddresses` tops it (and anything
+ * else listed) up to `airdropAmount` lamports as the client is composed; the
+ * plugin then returns a promise, so `.use()` must be awaited.
  *
  * @example Embedded
  * ```ts
@@ -154,17 +254,27 @@ function surfpoolAttach(config: SurfpoolAttachConfig) {
  * ```ts
  * const client = await createClient()
  *     .use(payer(myPayer))
- *     .use(surfpool({ rpcUrl: 'http://127.0.0.1:8899' }));
+ *     .use(surfpool({ airdropAddresses: [myPayer], rpcUrl: 'http://127.0.0.1:8899' }));
  * ```
  */
 export function surfpool(config?: SurfpoolEmbeddedConfig): ReturnType<typeof surfpoolEmbedded>;
-export function surfpool(config: SurfpoolAttachConfig): ReturnType<typeof surfpoolAttach>;
+export function surfpool(config: SurfpoolAttachConfigWithAirdrop): ReturnType<typeof surfpoolAttachFunded>;
+export function surfpool(
+    config: SurfpoolAttachConfig & { airdropAddresses?: never },
+): ReturnType<typeof surfpoolAttach>;
 export function surfpool(config: SurfpoolConfig = {}) {
-    return isAttachConfig(config) ? surfpoolAttach(config) : surfpoolEmbedded(config);
+    if (!isAttachConfig(config)) {
+        return surfpoolEmbedded(config);
+    }
+    return hasAirdropAddresses(config) ? surfpoolAttachFunded(config) : surfpoolAttach(config);
 }
 
 function isAttachConfig(config: SurfpoolConfig): config is SurfpoolAttachConfig {
     return typeof config.rpcUrl === 'string';
+}
+
+function hasAirdropAddresses(config: SurfpoolAttachConfig): config is SurfpoolAttachConfigWithAirdrop {
+    return config.airdropAddresses !== undefined;
 }
 
 function deriveSubscriptionsUrl(rpcUrl: string): string {

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -13,6 +13,7 @@ import { createSurfnetCheatcodesRpc } from './cheatcodes.js';
 
 /** Lamports each `airdropAddresses` entry is credited with when no amount is given. */
 const DEFAULT_AIRDROP_LAMPORTS = 10_000_000_000n;
+const MAX_LAMPORTS = 2n ** 64n - 1n;
 
 /** An address to fund, or anything carrying one (a signer, a PDA, an account). */
 export type AirdropTarget = Address | { readonly address: Address };
@@ -78,7 +79,8 @@ export type SurfpoolConfig = SurfpoolAttachConfig | SurfpoolEmbeddedConfig;
  * A `number` above `Number.MAX_SAFE_INTEGER` has already lost precision by the
  * time it is read, and a fractional one is not a lamport amount at all. A
  * negative amount would debit the address instead of funding it, which is not
- * what an airdrop means. All three are rejected instead of silently funding
+ * what an airdrop means. An amount beyond `u64::MAX` cannot be represented as a
+ * lamport balance at all. All four are rejected instead of silently funding
  * something other than what was asked for.
  */
 function toLamports(amount: bigint | number = DEFAULT_AIRDROP_LAMPORTS): bigint {
@@ -89,6 +91,9 @@ function toLamports(amount: bigint | number = DEFAULT_AIRDROP_LAMPORTS): bigint 
     if (lamports < 0n) {
         throw new Error(`airdropAmount must not be negative; received ${amount}`);
     }
+    if (lamports > MAX_LAMPORTS) {
+        throw new Error(`airdropAmount must not exceed ${MAX_LAMPORTS} lamports; received ${amount}`);
+    }
     return lamports;
 }
 
@@ -97,7 +102,9 @@ function toLamports(amount: bigint | number = DEFAULT_AIRDROP_LAMPORTS): bigint 
  * cheatcode. The cheatcode writes an absolute balance, so the current balance
  * is read first and the amount added to it, matching what a real airdrop does
  * to an address that already holds lamports. Only the lamport balance is
- * written, so an existing account keeps its data and owner.
+ * written, so an existing account keeps its data and owner. A sum past
+ * `u64::MAX` is not a representable balance and is rejected before it reaches
+ * the cheatcode.
  */
 async function fundAirdropAddresses(
     client: {
@@ -116,7 +123,13 @@ async function fundAirdropAddresses(
         [...addresses].map(async address => {
             try {
                 const { value: balance } = await client.rpc.getBalance(address).send();
-                await client.cheatcodes.setAccount(address, { lamports: balance + amount }).send();
+                const lamports = balance + amount;
+                if (lamports > MAX_LAMPORTS) {
+                    throw new Error(
+                        `balance ${balance} plus airdropAmount ${amount} exceeds the maximum lamport balance ${MAX_LAMPORTS}`,
+                    );
+                }
+                await client.cheatcodes.setAccount(address, { lamports }).send();
             } catch (error) {
                 throw new Error(`Failed to airdrop ${amount} lamports to ${address}`, { cause: error });
             }


### PR DESCRIPTION
In attach mode the kit client must already carry a `payer`, and that signer is typically unfunded on the running Surfnet — so every caller had to make a separate cheatcode call before they could send anything.

`surfpool()` now takes `airdropAddresses` (bare addresses or anything carrying one, e.g. signers) plus an optional `airdropAmount`, funding each entry while the client is composed:

```ts
const client = await createClient()
  .use(payer(myPayer))
  .use(surfpool({ airdropAddresses: [myPayer], rpcUrl: "http://127.0.0.1:8899" }));
```

Decisions worth flagging:

- **Funds via the `setAccount` cheatcode, not `client.airdrop`.** The faucet path confirms over WebSocket, and the attach-mode WS URL is a derived guess (the port-8900 heuristic). Tying client construction to that heuristic being right is the wrong trade; the cheatcode needs HTTP only.
- **Top-up semantics.** An address already holding at least `airdropAmount` is skipped, and only the lamport balance is written, so existing data and owner survive. Idempotent, and never lowers a balance that a runbook already set.
- **Default 10 SOL**, matching Surfnet's own `airdrop_lamports` default.
- **Failures throw**, naming the address, with the RPC error as `cause` — silent under-funding would resurface later as a confusing transaction failure.
- **Attach mode stays synchronous unless the option is present**, so existing sync `.use()` callers keep working. The sync overload rejects a *possibly*-present `airdropAddresses` (`{ airdropAddresses?: never }`); without that, a conditional value would type as sync while dispatching async, handing back a Promise typed as a client.

Works in embedded mode too, alongside the pre-funded payer.

-- 

One thing that I have mixed feelings about @MicaiahReid ...
- an alternative approach might be to just prefund the client's payer `client.payer.address`. I think this would make sense but maybe could be annoying for folks that don't want it funded for some reason? idk.
- another thought is should this be more than just airdrop in the future...like mints/tokens/etc (almost like a mini runbook config?). if that's the case, may want to step back from this pr and do some thought on longer term design before shipping this.  WDYT?

--

Closes TOO-650