### PR TITLE
fix(rpc): scale uiAmountString in getTokenSupply

### DIFF
--- a/crates/core/src/rpc/accounts_data.rs
+++ b/crates/core/src/rpc/accounts_data.rs
@@ -3,7 +3,7 @@ use jsonrpc_derive::rpc;
 use solana_account_decoder::{
     UiAccount,
     parse_account_data::SplTokenAdditionalDataV2,
-    parse_token::{TokenAccountType, UiTokenAmount, parse_token_v3},
+    parse_token::{TokenAccountType, UiTokenAmount, parse_token_v3, real_number_string_trimmed},
 };
 use solana_client::{
     rpc_config::RpcAccountInfoConfig,
@@ -675,7 +675,10 @@ impl AccountsData for SurfpoolAccountsDataRpc {
                                 amount: mint.supply.clone(),
                                 decimals: mint.decimals,
                                 ui_amount,
-                                ui_amount_string: mint.supply,
+                                ui_amount_string: real_number_string_trimmed(
+                                    supply_u64,
+                                    mint.decimals,
+                                ),
                             })
                         }
                         _ => None,
@@ -936,7 +939,7 @@ mod tests {
 
         assert_eq!(res.value.amount, "1000000000000");
         assert_eq!(res.value.decimals, 6);
-        assert_eq!(res.value.ui_amount_string, "1000000000000");
+        assert_eq!(res.value.ui_amount_string, "1000000");
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

The `getTokenSupply` RPC handler builds `UiTokenAmount` for a mint by hand and sets `ui_amount_string` to the raw supply, while `ui_amount` is decimal-scaled:

```rust
Some(UiTokenAmount {
    amount: mint.supply.clone(),
    decimals: mint.decimals,
    ui_amount,                      // scaled: supply / 10^decimals
    ui_amount_string: mint.supply,  // raw base units, not scaled
})
```

Per the Solana `UiTokenAmount` contract, `ui_amount` and `ui_amount_string` are the human-readable amount (`amount / 10^decimals`), so the two must agree. For a 6-decimal mint with supply `1000000000000`, the response reports `uiAmount: 1000000.0` next to `uiAmountString: "1000000000000"`, a 10^6 discrepancy on the same field pair. Any client that renders `uiAmountString` (wallets, explorers) shows the supply inflated by `10^decimals`.

The sibling `getTokenAccountBalance` builds the struct via `parse_token_v3` and formats `uiAmountString` correctly, so this handler is the odd one out.

## Fix

Set `ui_amount_string` with `real_number_string_trimmed(supply, decimals)` (the same helper the standard token amount formatting uses), so it matches `ui_amount` and real Solana output.

## Test

`test_get_token_supply_with_real_mint` asserted the unscaled `"1000000000000"`, enshrining the bug; corrected to `"1000000"` (supply `1000000000000`, 6 decimals). `cargo test` for that test and `cargo fmt --check` pass.
