### PR TITLE
refactor: route simnet events through a sender that owns delivery policy

### DIFF
--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -80,15 +80,15 @@ pub async fn handle_start_local_surfnet_command(
                 &cmd.observability.metrics_addr,
             ) {
                 Err(e) => {
-                    let _ = surfnet_svm
+                    surfnet_svm
                         .simnet_events_tx
-                        .send(SimnetEvent::warn(format!("Metrics init failed: {}", e)));
+                        .warn(format!("Metrics init failed: {}", e));
                 }
                 Ok(_) => {
-                    let _ = surfnet_svm.simnet_events_tx.send(SimnetEvent::info(format!(
+                    surfnet_svm.simnet_events_tx.info(format!(
                         "Metrics available at http://{}/metrics",
                         cmd.observability.metrics_addr
-                    )));
+                    ));
                 }
             }
         }
@@ -129,11 +129,11 @@ pub async fn handle_start_local_surfnet_command(
                 Option<surfpool_types::AccountSnapshot>,
             > = serde_json::from_str(&content)
                 .map_err(|e| format!("Failed to parse snapshot JSON '{}': {}", snapshot_path, e))?;
-            let _ = simnet_events_tx.send(SimnetEvent::info(format!(
+            simnet_events_tx.info(format!(
                 "Loaded {} accounts from snapshot file: {}",
                 snapshot_data.len(),
                 snapshot_path
-            )));
+            ));
 
             // Merge into the combined snapshot (later files override earlier ones)
             merged_snapshot.extend(snapshot_data);
@@ -197,11 +197,11 @@ pub async fn handle_start_local_surfnet_command(
         Ok(explorer_handle) => Some(explorer_handle),
         Err(e) => {
             error!("Failed to start subgraph and explorer server: {}", e);
-            let _ = simnet_events_tx.send(SimnetEvent::warn(format!(
+            simnet_events_tx.warn(format!(
                 "Failed to start subgraph and explorer server: {}",
                 e
-            )));
-            let _ = simnet_events_tx.send(SimnetEvent::info("Continuing with simnet startup..."));
+            ));
+            simnet_events_tx.info("Continuing with simnet startup...");
             None
         }
     };
@@ -221,7 +221,7 @@ pub async fn handle_start_local_surfnet_command(
             );
             if let Err(e) = hiro_system_kit::nestable_block_on(future) {
                 // Send the error through the event channel so the main thread can handle it
-                let _ = simnet_events_tx_for_thread.send(SimnetEvent::Aborted(e.to_string()));
+                simnet_events_tx_for_thread.emit(SimnetEvent::Aborted(e.to_string()));
             }
             Ok::<(), String>(())
         })
@@ -244,11 +244,11 @@ pub async fn handle_start_local_surfnet_command(
 
     // Re-send early events (like snapshot loading messages) so the TUI receives them
     for event in early_events {
-        let _ = simnet_events_tx.send(event);
+        simnet_events_tx.emit(event);
     }
 
     for event in airdrop_events {
-        let _ = simnet_events_tx.send(event);
+        simnet_events_tx.emit(event);
     }
 
     let simnet_commands_tx_copy = simnet_commands_tx.clone();
@@ -262,8 +262,7 @@ pub async fn handle_start_local_surfnet_command(
             // the watchdog's decision.
             Err(StartupPlanFailure::Planning(e)) => {
                 let _ = simnet_commands_tx_copy.send(SimnetCommand::FailStartupPlanning(e.clone()));
-                let _ = simnet_events_tx
-                    .send(SimnetEvent::warn(format!("Startup planning failed: {e}")));
+                simnet_events_tx.warn(format!("Startup planning failed: {e}"));
             }
             // The command loop is dead or wedged, so the startup state machine
             // is unreachable and no session can ever become ready.
@@ -309,8 +308,7 @@ pub async fn handle_start_local_surfnet_command(
         if let Ok(response) = response {
             if let Ok(body) = response.json::<CheckVersionResponse>().await {
                 if let Some(deprecation_notice) = body.deprecation_notice {
-                    let _ =
-                        simnet_events_tx.send(SimnetEvent::warn(deprecation_notice.to_string()));
+                    let _ = simnet_events_tx.warn(deprecation_notice.to_string());
                 }
             }
         }

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -629,9 +629,19 @@ pub(crate) fn replay_early_events(
     early_events: Vec<SimnetEvent>,
     airdrop_events: Vec<SimnetEvent>,
 ) {
-    for event in early_events.into_iter().chain(airdrop_events) {
-        simnet_events_tx.emit(event);
-    }
+    // On a separate thread: the caller owns the only receiver and does not
+    // drain again until the frontend consumer starts, so a blocking emit on
+    // the caller's thread wedges startup once the buffer fills (a warm
+    // start can buffer a full channel of replayed transactions before
+    // CoreStarted). The replay thread blocks until the consumer drains,
+    // intentionally.
+    let tx = simnet_events_tx.clone();
+    let _ = hiro_system_kit::thread_named("early-event-replay").spawn(move || {
+        for event in early_events.into_iter().chain(airdrop_events) {
+            tx.emit(event);
+        }
+        Ok::<(), String>(())
+    });
 }
 
 #[cfg(test)]

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -221,7 +221,7 @@ pub async fn handle_start_local_surfnet_command(
             );
             if let Err(e) = hiro_system_kit::nestable_block_on(future) {
                 // Send the error through the event channel so the main thread can handle it
-                simnet_events_tx_for_thread.emit(SimnetEvent::Aborted(e.to_string()));
+                simnet_events_tx_for_thread.aborted(e.to_string());
             }
             Ok::<(), String>(())
         })
@@ -638,7 +638,7 @@ pub(crate) fn replay_early_events(
     let tx = simnet_events_tx.clone();
     let _ = hiro_system_kit::thread_named("early-event-replay").spawn(move || {
         for event in early_events.into_iter().chain(airdrop_events) {
-            tx.emit(event);
+            tx.forward(event);
         }
         Ok::<(), String>(())
     });
@@ -654,9 +654,10 @@ mod replay_tests {
 
     /// Startup calls the replay on the thread that owns the only receiver,
     /// and concurrent producers may already have refilled the buffer, so
-    /// the call must return without waiting on a drain; the events follow
-    /// once the consumer starts. Small capacity for speed; the mechanism is
-    /// capacity-independent.
+    /// the call must return without waiting on a drain. Buffered events
+    /// route by class: lifecycle events arrive once the consumer drains;
+    /// telemetry may drop, telemetry's standing contract. Small capacity
+    /// for speed; the mechanism is capacity-independent.
     #[test]
     fn replay_returns_before_the_consumer_drains() {
         let (tx, rx) = SimnetEventsTx::channel(4);
@@ -666,7 +667,14 @@ mod replay_tests {
 
         let replay_tx = tx.clone();
         let replayer = thread::spawn(move || {
-            replay_early_events(&replay_tx, vec![SimnetEvent::info("replayed")], vec![]);
+            replay_early_events(
+                &replay_tx,
+                vec![
+                    SimnetEvent::info("telemetry, droppable"),
+                    SimnetEvent::RunbookStarted("lifecycle, must arrive".to_string()),
+                ],
+                vec![],
+            );
         });
 
         thread::sleep(Duration::from_millis(300));
@@ -675,14 +683,18 @@ mod replay_tests {
             "replay must not block the receiver-owning thread on a full buffer"
         );
 
-        // The consumer drains, as log_events/start_app do; every event
-        // arrives, the replayed one behind the producers.
+        // The consumer drains, as log_events/start_app do. The four producer
+        // events and the lifecycle event arrive; the telemetry line found
+        // the buffer full and dropped.
         let received: Vec<SimnetEvent> = (0..5)
             .map(|_| {
                 rx.recv_timeout(Duration::from_secs(5))
-                    .expect("every event arrives once the consumer drains")
+                    .expect("every surviving event arrives once the consumer drains")
             })
             .collect();
-        assert!(matches!(&received[4], SimnetEvent::InfoLog(_, msg) if msg == "replayed"));
+        assert!(
+            matches!(&received[4], SimnetEvent::RunbookStarted(msg) if msg == "lifecycle, must arrive")
+        );
+        assert!(rx.try_recv().is_err(), "nothing else was queued");
     }
 }

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -16,7 +16,7 @@ use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use surfpool_core::{start_local_surfnet, surfnet::svm::SurfnetSvm};
-use surfpool_types::{SanitizedConfig, SimnetCommand, SimnetEvent, SubgraphEvent};
+use surfpool_types::{SanitizedConfig, SimnetCommand, SimnetEvent, SimnetEventsTx, SubgraphEvent};
 use txtx_core::kit::{channel::Receiver, helpers::fs::FileLocation, types::frontend::BlockEvent};
 use txtx_gql::kit::{indexmap::IndexMap, types::frontend::LogLevel, uuid::Uuid};
 
@@ -243,13 +243,7 @@ pub async fn handle_start_local_surfnet_command(
     };
 
     // Re-send early events (like snapshot loading messages) so the TUI receives them
-    for event in early_events {
-        simnet_events_tx.emit(event);
-    }
-
-    for event in airdrop_events {
-        simnet_events_tx.emit(event);
-    }
+    replay_early_events(&simnet_events_tx, early_events, airdrop_events);
 
     let simnet_commands_tx_copy = simnet_commands_tx.clone();
     let mut runbook_progress_rx = vec![];
@@ -625,5 +619,60 @@ mod tests {
             public_service_url(None, None, "http", "0.0.0.0", 8899),
             "http://127.0.0.1:8899"
         );
+    }
+}
+
+/// Re-send events buffered before `CoreStarted` (and the airdrop
+/// announcements) so the frontend consumer receives them.
+pub(crate) fn replay_early_events(
+    simnet_events_tx: &SimnetEventsTx,
+    early_events: Vec<SimnetEvent>,
+    airdrop_events: Vec<SimnetEvent>,
+) {
+    for event in early_events.into_iter().chain(airdrop_events) {
+        simnet_events_tx.emit(event);
+    }
+}
+
+#[cfg(test)]
+mod replay_tests {
+    use std::{thread, time::Duration};
+
+    use surfpool_types::SimnetEventsTx;
+
+    use super::*;
+
+    /// Startup calls the replay on the thread that owns the only receiver,
+    /// and concurrent producers may already have refilled the buffer, so
+    /// the call must return without waiting on a drain; the events follow
+    /// once the consumer starts. Small capacity for speed; the mechanism is
+    /// capacity-independent.
+    #[test]
+    fn replay_returns_before_the_consumer_drains() {
+        let (tx, rx) = SimnetEventsTx::channel(4);
+        for i in 0..4 {
+            tx.info(format!("producer {i}"));
+        }
+
+        let replay_tx = tx.clone();
+        let replayer = thread::spawn(move || {
+            replay_early_events(&replay_tx, vec![SimnetEvent::info("replayed")], vec![]);
+        });
+
+        thread::sleep(Duration::from_millis(300));
+        assert!(
+            replayer.is_finished(),
+            "replay must not block the receiver-owning thread on a full buffer"
+        );
+
+        // The consumer drains, as log_events/start_app do; every event
+        // arrives, the replayed one behind the producers.
+        let received: Vec<SimnetEvent> = (0..5)
+            .map(|_| {
+                rx.recv_timeout(Duration::from_secs(5))
+                    .expect("every event arrives once the consumer drains")
+            })
+            .collect();
+        assert!(matches!(&received[4], SimnetEvent::InfoLog(_, msg) if msg == "replayed"));
     }
 }

--- a/crates/cli/src/cli/simnet/startup.rs
+++ b/crates/cli/src/cli/simnet/startup.rs
@@ -10,7 +10,8 @@ use notify::{
 };
 use solana_pubkey::Pubkey;
 use surfpool_types::{
-    SimnetCommand, SimnetEvent, StartupError, SurfnetStartupPhase, SurfnetStartupTask,
+    SimnetCommand, SimnetEvent, SimnetEventsTx, StartupError, SurfnetStartupPhase,
+    SurfnetStartupTask,
 };
 use txtx_core::{
     kit::{
@@ -91,7 +92,7 @@ impl RunbookExecutionMode {
 pub(super) fn spawn_startup_watchdog(
     headless: bool,
     startup_status_rx: tokio::sync::watch::Receiver<surfpool_types::SurfnetStartupStatus>,
-    events_tx: Sender<SimnetEvent>,
+    events_tx: SimnetEventsTx,
     commands_tx: Sender<SimnetCommand>,
 ) -> Result<(), String> {
     if !headless {
@@ -113,7 +114,7 @@ pub(super) fn spawn_startup_watchdog(
 /// the surfnet is already shutting down, requires nothing.
 pub(super) fn watch_startup_until_completion(
     mut startup_status_rx: tokio::sync::watch::Receiver<surfpool_types::SurfnetStartupStatus>,
-    events_tx: Sender<SimnetEvent>,
+    events_tx: SimnetEventsTx,
     commands_tx: Sender<SimnetCommand>,
 ) {
     let terminal = hiro_system_kit::nestable_block_on(startup_status_rx.wait_for(|status| {
@@ -129,7 +130,7 @@ pub(super) fn watch_startup_until_completion(
         _ => None,
     };
     if let Some(error) = failure {
-        let _ = events_tx.send(SimnetEvent::Aborted(format!(
+        events_tx.emit(SimnetEvent::Aborted(format!(
             "Surfpool startup failed: {error}"
         )));
         let _ = commands_tx.send(SimnetCommand::Terminate(None));
@@ -211,7 +212,7 @@ struct StartupPlan {
 /// failure leaves it in Planning-unsealed for the caller to fail explicitly.
 async fn plan_startup(
     cmd: &StartSimnet,
-    simnet_events_tx: &Sender<SimnetEvent>,
+    simnet_events_tx: &SimnetEventsTx,
 ) -> Result<StartupPlan, String> {
     let (progress_tx, progress_rx) = crossbeam::channel::unbounded();
 
@@ -252,10 +253,10 @@ async fn plan_startup(
             return Err(format!("Failed to detect project framework: {e}"));
         }
         Err(e) => {
-            let _ = simnet_events_tx.send(SimnetEvent::warn(format!(
+            simnet_events_tx.warn(format!(
                 "Could not detect the project framework, continuing with the runbook on disk. \
                  Declared clones, if any, were not loaded: {e}"
-            )));
+            ));
             None
         }
     };
@@ -272,12 +273,12 @@ async fn plan_startup(
         let (parsed, rejected) = parse_clone_addresses(&clones.unwrap_or_default());
         clone_pubkeys = parsed;
         if !rejected.is_empty() {
-            let _ = simnet_events_tx.send(SimnetEvent::warn(format!(
+            simnet_events_tx.warn(format!(
                 "Ignoring {} declared clone address(es) that could not be parsed; \
                  the rest were loaded. {}",
                 rejected.len(),
                 rejected.join("; ")
-            )));
+            ));
         }
 
         match mode {
@@ -340,7 +341,7 @@ async fn plan_startup(
 /// choreography around them.
 pub(super) async fn plan_and_dispatch_startup(
     cmd: &StartSimnet,
-    simnet_events_tx: &Sender<SimnetEvent>,
+    simnet_events_tx: &SimnetEventsTx,
     simnet_commands_tx: &Sender<SimnetCommand>,
 ) -> Result<Receiver<BlockEvent>, StartupPlanFailure> {
     let StartupPlan {
@@ -424,7 +425,7 @@ pub(super) async fn plan_and_dispatch_startup(
             // fatality. The error event covers the TUI, which has no other
             // channel announcing the failed phase.
             let error = format!("Thread to execute runbooks exited: {error}");
-            let _ = simnet_events_tx.send(SimnetEvent::error(error.clone()));
+            simnet_events_tx.error(error.clone());
             let _ = simnet_commands_tx.send(SimnetCommand::CompleteStartupTask(
                 SurfnetStartupTask::RunbookExecutions,
                 Err(error),
@@ -445,9 +446,9 @@ pub(super) async fn plan_and_dispatch_startup(
             in_memory_runbook_data,
             runbook_input,
         ) {
-            let _ = simnet_events_tx.send(SimnetEvent::warn(format!(
+            simnet_events_tx.warn(format!(
                 "Failed to watch deploy artifacts for changes: {error}"
-            )));
+            ));
         }
     }
 
@@ -460,7 +461,7 @@ fn spawn_artifact_watcher(
     base_location: FileLocation,
     artifacts_path: Option<String>,
     progress_tx: Sender<BlockEvent>,
-    simnet_events_tx: Sender<SimnetEvent>,
+    simnet_events_tx: SimnetEventsTx,
     on_disk_runbook_data: Option<(FileLocation, Vec<String>)>,
     in_memory_runbook_data: Option<(String, RunbookSources, WorkspaceManifest)>,
     runbook_input: Vec<String>,
@@ -548,7 +549,7 @@ type RunbookExecutionFutures =
 
 fn assemble_runbook_execution_futures(
     progress_tx: &Sender<BlockEvent>,
-    simnet_events_tx: &Sender<SimnetEvent>,
+    simnet_events_tx: &SimnetEventsTx,
     on_disk_runbook_data: &Option<(FileLocation, Vec<String>)>,
     in_memory_runbook_data: &Option<(String, RunbookSources, WorkspaceManifest)>,
     runbook_input: &[String],
@@ -651,7 +652,7 @@ mod tests {
 
         use crossbeam::channel::{Receiver, unbounded};
         use surfpool_types::{
-            SimnetCommand, SimnetEvent, SurfnetStartupStatus, SurfnetStartupTask,
+            SimnetCommand, SimnetEvent, SimnetEventsTx, SurfnetStartupStatus, SurfnetStartupTask,
         };
         use tokio::sync::watch;
 
@@ -690,7 +691,7 @@ mod tests {
         #[test]
         fn headless_watchdog_aborts_and_terminates_on_failed_startup() {
             let (status_tx, status_rx) = watch::channel(SurfnetStartupStatus::default());
-            let (events_tx, events_rx) = unbounded();
+            let (events_tx, events_rx) = SimnetEventsTx::unbounded();
             let (commands_tx, commands_rx) = unbounded();
 
             let watchdog = std::thread::spawn(move || {
@@ -717,7 +718,7 @@ mod tests {
         #[test]
         fn headless_watchdog_stays_quiet_when_startup_reaches_ready() {
             let (status_tx, status_rx) = watch::channel(SurfnetStartupStatus::default());
-            let (events_tx, events_rx) = unbounded();
+            let (events_tx, events_rx) = SimnetEventsTx::unbounded();
             let (commands_tx, commands_rx) = unbounded();
 
             let watchdog = std::thread::spawn(move || {
@@ -734,7 +735,7 @@ mod tests {
         #[test]
         fn headless_watchdog_stays_quiet_when_the_surfnet_shuts_down_first() {
             let (status_tx, status_rx) = watch::channel(SurfnetStartupStatus::default());
-            let (events_tx, events_rx) = unbounded();
+            let (events_tx, events_rx) = SimnetEventsTx::unbounded();
             let (commands_tx, commands_rx) = unbounded();
 
             let watchdog = std::thread::spawn(move || {
@@ -751,7 +752,7 @@ mod tests {
         #[test]
         fn tui_mode_spawns_no_watchdog() {
             let (status_tx, status_rx) = watch::channel(SurfnetStartupStatus::default());
-            let (events_tx, events_rx) = unbounded();
+            let (events_tx, events_rx) = SimnetEventsTx::unbounded();
             let (commands_tx, commands_rx) = unbounded();
 
             spawn_startup_watchdog(false, status_rx, events_tx, commands_tx).unwrap();
@@ -767,7 +768,7 @@ mod tests {
         #[test]
         fn headless_mode_spawns_a_watchdog_that_exits_after_ready() {
             let (status_tx, status_rx) = watch::channel(SurfnetStartupStatus::default());
-            let (events_tx, events_rx) = unbounded();
+            let (events_tx, events_rx) = SimnetEventsTx::unbounded();
             let (commands_tx, commands_rx) = unbounded();
 
             spawn_startup_watchdog(true, status_rx, events_tx, commands_tx).unwrap();

--- a/crates/cli/src/cli/simnet/startup.rs
+++ b/crates/cli/src/cli/simnet/startup.rs
@@ -10,8 +10,7 @@ use notify::{
 };
 use solana_pubkey::Pubkey;
 use surfpool_types::{
-    SimnetCommand, SimnetEvent, SimnetEventsTx, StartupError, SurfnetStartupPhase,
-    SurfnetStartupTask,
+    SimnetCommand, SimnetEventsTx, StartupError, SurfnetStartupPhase, SurfnetStartupTask,
 };
 use txtx_core::{
     kit::{
@@ -130,9 +129,7 @@ pub(super) fn watch_startup_until_completion(
         _ => None,
     };
     if let Some(error) = failure {
-        events_tx.emit(SimnetEvent::Aborted(format!(
-            "Surfpool startup failed: {error}"
-        )));
+        events_tx.aborted(format!("Surfpool startup failed: {error}"));
         let _ = commands_tx.send(SimnetCommand::Terminate(None));
     }
 }

--- a/crates/cli/src/runbook/mod.rs
+++ b/crates/cli/src/runbook/mod.rs
@@ -319,7 +319,7 @@ pub async fn execute_runbook(
     }
 
     if cmd.unsupervised {
-        simnet_events_tx.emit(SimnetEvent::RunbookStarted(runbook_id.clone()));
+        simnet_events_tx.runbook_started(runbook_id.clone());
         let res = start_unsupervised_runbook_runloop(&mut runbook, &progress_tx).await;
         let diags = res
             .as_ref()
@@ -332,7 +332,7 @@ pub async fn execute_runbook(
             &simnet_events_tx,
             cmd.output_json,
         );
-        simnet_events_tx.emit(SimnetEvent::RunbookCompleted(runbook_id, diags));
+        simnet_events_tx.runbook_completed(runbook_id, diags);
         if !success {
             return Err("Runbook execution failed".to_string());
         }

--- a/crates/cli/src/runbook/mod.rs
+++ b/crates/cli/src/runbook/mod.rs
@@ -4,7 +4,7 @@ use crossbeam::channel;
 use dialoguer::{Confirm, console::Style, theme::ColorfulTheme};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use log::{debug, error, info, trace, warn};
-use surfpool_types::SimnetEvent;
+use surfpool_types::{SimnetEvent, SimnetEventsTx};
 use tokio::{sync::RwLock, task::JoinHandle};
 use txtx_addon_network_svm::SvmNetworkAddon;
 use txtx_core::{
@@ -72,7 +72,7 @@ pub fn load_workspace_manifest_from_manifest_path(
 }
 
 pub async fn handle_execute_runbook_command(cmd: ExecuteRunbook) -> Result<(), String> {
-    let (simnet_events_tx, simnet_events_rx) = channel::unbounded();
+    let (simnet_events_tx, simnet_events_rx) = SimnetEventsTx::unbounded();
     let (progress_tx, progress_rx) = channel::unbounded();
 
     let _ = hiro_system_kit::thread_named("Runbook Execution Event Loop").spawn(move || {
@@ -131,7 +131,7 @@ pub async fn load_runbook_from_file_path(
 
 pub async fn execute_in_memory_runbook(
     progress_tx: Sender<BlockEvent>,
-    simnet_events_tx: crossbeam::channel::Sender<SimnetEvent>,
+    simnet_events_tx: SimnetEventsTx,
     cmd: ExecuteRunbook,
     do_setup_logger: bool,
     runbook_id: String,
@@ -155,7 +155,7 @@ pub async fn execute_in_memory_runbook(
 
 pub async fn execute_on_disk_runbook(
     progress_tx: Sender<BlockEvent>,
-    simnet_events_tx: crossbeam::channel::Sender<SimnetEvent>,
+    simnet_events_tx: SimnetEventsTx,
     cmd: ExecuteRunbook,
     do_setup_logger: bool,
 ) -> Result<(), String> {
@@ -190,7 +190,7 @@ pub async fn execute_on_disk_runbook(
 #[allow(clippy::too_many_arguments)]
 pub async fn execute_runbook(
     progress_tx: Sender<BlockEvent>,
-    simnet_events_tx: crossbeam::channel::Sender<SimnetEvent>,
+    simnet_events_tx: SimnetEventsTx,
     cmd: ExecuteRunbook,
     do_setup_logger: bool,
     runbook_id: String,
@@ -243,7 +243,7 @@ pub async fn execute_runbook(
         ) {
             Ok(snapshot) => Some(snapshot),
             Err(e) => {
-                let _ = simnet_events_tx.send(SimnetEvent::warn(format!("{:?}", e)));
+                simnet_events_tx.warn(format!("{:?}", e));
                 None
             }
         }
@@ -259,19 +259,18 @@ pub async fn execute_runbook(
 
         for flow_context in runbook.flow_contexts.iter() {
             if old.flows.get(&flow_context.name).is_none() {
-                let _ = simnet_events_tx.send(SimnetEvent::info(format!(
+                simnet_events_tx.info(format!(
                     "Previous snapshot not found for flow {}",
                     flow_context.name
-                )));
+                ));
             };
         }
 
         let consolidated_changes = match ctx.diff(old, new) {
             Ok(changes) => changes,
             Err(e) => {
-                let _ =
-                    simnet_events_tx.send(SimnetEvent::warn("Failed to process runbook snapshot"));
-                let _ = simnet_events_tx.send(SimnetEvent::warn(e));
+                let _ = simnet_events_tx.warn("Failed to process runbook snapshot");
+                simnet_events_tx.warn(e);
                 return Ok(());
             }
         };
@@ -320,7 +319,7 @@ pub async fn execute_runbook(
     }
 
     if cmd.unsupervised {
-        let _ = simnet_events_tx.send(SimnetEvent::RunbookStarted(runbook_id.clone()));
+        simnet_events_tx.emit(SimnetEvent::RunbookStarted(runbook_id.clone()));
         let res = start_unsupervised_runbook_runloop(&mut runbook, &progress_tx).await;
         let diags = res
             .as_ref()
@@ -333,7 +332,7 @@ pub async fn execute_runbook(
             &simnet_events_tx,
             cmd.output_json,
         );
-        let _ = simnet_events_tx.send(SimnetEvent::RunbookCompleted(runbook_id, diags));
+        simnet_events_tx.emit(SimnetEvent::RunbookCompleted(runbook_id, diags));
         if !success {
             return Err("Runbook execution failed".to_string());
         }
@@ -357,7 +356,7 @@ pub async fn configure_supervised_execution(
     mut runbook: Runbook,
     runbook_state_location: Option<RunbookStateLocation>,
     cmd: &ExecuteRunbook,
-    simnet_events_tx: crossbeam::channel::Sender<SimnetEvent>,
+    simnet_events_tx: SimnetEventsTx,
 ) -> Result<(Sender<bool>, JoinHandle<()>), String> {
     #[cfg(feature = "supervisor_ui")]
     let runbook_name = runbook.runbook_id.name.clone();
@@ -452,11 +451,9 @@ pub async fn configure_supervised_execution(
             while let Ok(msg) = supervisor_events_rx.recv() {
                 match msg {
                     txtx_supervisor_ui::SupervisorEvents::Started(network_binding) => {
-                        let _ = moved_simnet_events_tx.send(SimnetEvent::info(
-                            "Starting the supervisor web console".to_string(),
-                        ));
                         let _ = moved_simnet_events_tx
-                            .send(SimnetEvent::info(format!("http://{}", network_binding)));
+                            .info("Starting the supervisor web console".to_string());
+                        let _ = moved_simnet_events_tx.info(format!("http://{}", network_binding));
                     }
                 }
             }
@@ -506,7 +503,7 @@ pub async fn configure_supervised_execution(
                         block_store.insert(len, new_block.clone());
                     }
                     BlockEvent::RunbookCompleted(_) => {
-                        let _ = simnet_events_tx.send(SimnetEvent::info("Runbook completed"));
+                        simnet_events_tx.info("Runbook completed");
                     }
                     BlockEvent::Error(new_block) => {
                         let len = block_store.len();
@@ -646,11 +643,11 @@ pub fn display_snapshot_diffing(
     Some(consolidated_changes)
 }
 
-fn log_diagnostic_lines(diags: Vec<Diagnostic>, simnet_events_tx: &Sender<SimnetEvent>) {
+fn log_diagnostic_lines(diags: Vec<Diagnostic>, simnet_events_tx: &SimnetEventsTx) {
     for diag in diags.iter() {
         let diag_str = diag.to_string();
         for line in diag_str.lines() {
-            let _ = simnet_events_tx.send(SimnetEvent::warn(line));
+            simnet_events_tx.warn(line);
         }
     }
 }
@@ -658,23 +655,23 @@ fn log_diagnostic_lines(diags: Vec<Diagnostic>, simnet_events_tx: &Sender<Simnet
 fn log_actions_to_execute(
     actions_to_execute: &IndexMap<String, Vec<(String, Option<String>)>>,
     is_first_time: bool,
-    simnet_events_tx: &Sender<SimnetEvent>,
+    simnet_events_tx: &SimnetEventsTx,
 ) {
     let msg = if is_first_time {
         "The following actions have been added and will be executed for the first time:"
     } else {
         "The following actions will be re-executed:"
     };
-    let _ = simnet_events_tx.send(SimnetEvent::info(msg));
+    simnet_events_tx.info(msg);
     let documentation_missing = black!("<description field empty>");
     for (context, actions) in actions_to_execute.iter() {
-        let _ = simnet_events_tx.send(SimnetEvent::info(context.to_string()));
+        simnet_events_tx.info(context.to_string());
         for (action_name, documentation) in actions.iter() {
-            let _ = simnet_events_tx.send(SimnetEvent::info(format!(
+            simnet_events_tx.info(format!(
                 "- {}: {}",
                 action_name,
                 documentation.as_ref().unwrap_or(&documentation_missing)
-            )));
+            ));
         }
     }
 }
@@ -682,21 +679,15 @@ fn log_actions_to_execute(
 fn write_runbook_transient_state(
     runbook: &mut Runbook,
     runbook_state_location: Option<RunbookStateLocation>,
-    simnet_events_tx: &Sender<SimnetEvent>,
+    simnet_events_tx: &SimnetEventsTx,
 ) {
     match runbook.mark_failed_and_write_transient_state(runbook_state_location) {
         Ok(Some(location)) => {
-            let _ = simnet_events_tx.send(SimnetEvent::warn(format!(
-                "! Saving transient state to {}",
-                location
-            )));
+            simnet_events_tx.warn(format!("! Saving transient state to {}", location));
         }
         Ok(None) => {}
         Err(e) => {
-            let _ = simnet_events_tx.send(SimnetEvent::warn(format!(
-                "x Failed to write transient runbook state: {}",
-                e
-            )));
+            simnet_events_tx.warn(format!("x Failed to write transient runbook state: {}", e));
         }
     };
 }
@@ -704,21 +695,15 @@ fn write_runbook_transient_state(
 fn write_runbook_state(
     runbook: &mut Runbook,
     runbook_state_location: Option<RunbookStateLocation>,
-    simnet_events_tx: &Sender<SimnetEvent>,
+    simnet_events_tx: &SimnetEventsTx,
 ) {
     match runbook.write_runbook_state(runbook_state_location) {
         Ok(Some(location)) => {
-            let _ = simnet_events_tx.send(SimnetEvent::info(format!(
-                "Saved execution state to {}",
-                location
-            )));
+            simnet_events_tx.info(format!("Saved execution state to {}", location));
         }
         Ok(None) => {}
         Err(e) => {
-            let _ = simnet_events_tx.send(SimnetEvent::warn(format!(
-                "Failed to write runbook state: {}",
-                e
-            )));
+            simnet_events_tx.warn(format!("Failed to write runbook state: {}", e));
         }
     };
 }
@@ -727,11 +712,11 @@ fn process_runbook_execution_output(
     execution_result: Result<(), Vec<Diagnostic>>,
     runbook: &mut Runbook,
     runbook_state_location: Option<RunbookStateLocation>,
-    simnet_events_tx: &Sender<SimnetEvent>,
+    simnet_events_tx: &SimnetEventsTx,
     output_json: Option<Option<String>>,
 ) -> bool {
     if let Err(diags) = execution_result {
-        let _ = simnet_events_tx.send(SimnetEvent::warn("Runbook execution aborted"));
+        simnet_events_tx.warn("Runbook execution aborted");
         log_diagnostic_lines(diags, simnet_events_tx);
         write_runbook_transient_state(runbook, runbook_state_location, simnet_events_tx);
         return false;
@@ -752,31 +737,27 @@ fn process_runbook_execution_output(
                         &get_json_converters(),
                     ) {
                         Ok(output_location) => {
-                            let _ = simnet_events_tx.send(SimnetEvent::info(format!(
-                                "Outputs written to {}",
-                                output_location
-                            )));
+                            simnet_events_tx
+                                .info(format!("Outputs written to {}", output_location));
                         }
                         Err(e) => {
-                            let _ = simnet_events_tx.send(SimnetEvent::warn(format!(
-                                "Failed to write runbook outputs: {}",
-                                e
-                            )));
+                            simnet_events_tx
+                                .warn(format!("Failed to write runbook outputs: {}", e));
                         }
                     }
                 } else {
-                    let _ = simnet_events_tx.send(SimnetEvent::info(
+                    simnet_events_tx.info(
                         serde_json::to_string_pretty(
                             &runbook_outputs.to_json(&get_json_converters()),
                         )
                         .unwrap(),
-                    ));
+                    );
                 }
             } else {
-                let _ = simnet_events_tx.send(SimnetEvent::debug(
+                simnet_events_tx.debug(
                     serde_json::to_string_pretty(&runbook_outputs.to_json(&get_json_converters()))
                         .unwrap(),
-                ));
+                );
             }
         }
         write_runbook_state(runbook, runbook_state_location, simnet_events_tx);

--- a/crates/core/src/rpc/mod.rs
+++ b/crates/core/src/rpc/mod.rs
@@ -291,19 +291,14 @@ impl SurfpoolWebsocketMeta {
     }
 
     pub fn log_debug(&self, msg: &str) {
-        let _ = self
-            .runloop_context
+        self.runloop_context
             .svm_locker
             .simnet_events_tx()
-            .send(SimnetEvent::debug(msg));
+            .debug(msg);
     }
 
     pub fn log_warn(&self, msg: &str) {
-        let _ = self
-            .runloop_context
-            .svm_locker
-            .simnet_events_tx()
-            .send(SimnetEvent::warn(msg));
+        self.runloop_context.svm_locker.simnet_events_tx().warn(msg);
     }
 }
 

--- a/crates/core/src/rpc/mod.rs
+++ b/crates/core/src/rpc/mod.rs
@@ -12,7 +12,7 @@ use jsonrpc_core::{
 };
 use jsonrpc_pubsub::{PubSubMetadata, Session};
 use solana_clock::Slot;
-use surfpool_types::{CheatcodeConfig, SimnetCommand, SimnetEvent, types::RpcConfig};
+use surfpool_types::{CheatcodeConfig, SimnetCommand, types::RpcConfig};
 
 use crate::{
     error::{SurfpoolError, SurfpoolResult},

--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -18,8 +18,8 @@ use spl_associated_token_account_interface::address::get_associated_token_addres
 use surfpool_types::{
     AccountSnapshot, CheatcodeControlConfig, CheatcodeFilter, ClockCommand, ExportSnapshotConfig,
     GetStreamedAccountsResponse, GetSurfnetInfoResponse, Idl, OfflineAccountConfig,
-    ResetAccountConfig, RpcProfileResultConfig, Scenario, SimnetCommand, SimnetEvent,
-    StreamAccountConfig, StreamAccountsEntry, UiKeyedProfileResult,
+    ResetAccountConfig, RpcProfileResultConfig, Scenario, SimnetCommand, StreamAccountConfig,
+    StreamAccountsEntry, UiKeyedProfileResult,
     types::{AccountUpdate, SetSomeAccount, SupplyUpdate, TokenAccountUpdate, UuidOrSignature},
 };
 

--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -1433,7 +1433,7 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
                 } = svm_locker.get_account(&remote_ctx, &pubkey, Some(Box::new(move |svm_locker| {
 
                             // if the account does not exist locally or in the remote, create a new account with default values
-                            let _ = svm_locker.simnet_events_tx().send(SimnetEvent::info(format!(
+                            svm_locker.simnet_events_tx().info(format!(
                                 "Account {pubkey} not found, creating a new account from default values"
                             )));
                             GetAccountResult::FoundAccount(

--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -1435,7 +1435,7 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
                             // if the account does not exist locally or in the remote, create a new account with default values
                             svm_locker.simnet_events_tx().info(format!(
                                 "Account {pubkey} not found, creating a new account from default values"
-                            )));
+                            ));
                             GetAccountResult::FoundAccount(
                                 pubkey,
                                 solana_account::Account {

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -199,11 +199,11 @@ pub async fn start_local_surfnet_runloop(
     if let Some(remote_client) = &remote_rpc_client {
         svm_locker
             .simnet_events_tx()
-            .emit(SimnetEvent::Connected(remote_client.client.url()));
+            .connected(remote_client.client.url());
     }
     svm_locker
         .simnet_events_tx()
-        .emit(SimnetEvent::EpochInfoUpdate(svm_locker.get_epoch_info()));
+        .epoch_info_update(svm_locker.get_epoch_info());
 
     svm_locker.airdrop_pubkeys(simnet.airdrop_token_amount, &simnet.airdrop_addresses);
 
@@ -329,7 +329,7 @@ pub async fn start_local_surfnet_runloop(
             simnet_events_tx_cc.error(format!("Failed to seal startup plan: {error}"));
         }
     }
-    simnet_events_tx_cc.emit(SimnetEvent::CoreStarted(initial_transaction_count));
+    simnet_events_tx_cc.core_started(initial_transaction_count);
 
     // Notify geyser plugins that startup is complete
     let _ = svm_locker.with_svm_reader(|svm| svm.geyser_events_tx.send(GeyserEvent::EndOfStartup));
@@ -473,7 +473,7 @@ pub async fn start_block_production_runloop(
                             svm_writer.latest_epoch_info.slot_index = clock.slot;
                             svm_writer.latest_epoch_info.epoch = clock.epoch;
                             svm_writer.latest_epoch_info.absolute_slot = clock.slot + clock.epoch * svm_writer.latest_epoch_info.slots_in_epoch;
-                            svm_writer.simnet_events_tx.log(SimnetEvent::SystemClockUpdated(clock));
+                            svm_writer.simnet_events_tx.system_clock_updated(clock);
                         });
                     }
                     SimnetCommand::UpdateInternalClockWithConfirmation(_, clock, response_tx) => {
@@ -492,7 +492,7 @@ pub async fn start_block_production_runloop(
                             svm_writer.latest_epoch_info.slot_index = clock.slot;
                             svm_writer.latest_epoch_info.epoch = clock.epoch;
                             svm_writer.latest_epoch_info.absolute_slot = clock.slot + clock.epoch * svm_writer.latest_epoch_info.slots_in_epoch;
-                            svm_writer.simnet_events_tx.log(SimnetEvent::SystemClockUpdated(clock));
+                            svm_writer.simnet_events_tx.system_clock_updated(clock);
                             svm_writer.latest_epoch_info.clone()
                         });
 
@@ -652,22 +652,19 @@ pub fn start_clock_runloop(
                 Ok(ClockCommand::Pause) => {
                     enabled = false;
                     if let Some(ref simnet_events_tx) = simnet_events_tx {
-                        let _ =
-                            simnet_events_tx.emit(SimnetEvent::ClockUpdate(ClockCommand::Pause));
+                        let _ = simnet_events_tx.clock_update(ClockCommand::Pause);
                     }
                 }
                 Ok(ClockCommand::Resume) => {
                     enabled = true;
                     if let Some(ref simnet_events_tx) = simnet_events_tx {
-                        let _ =
-                            simnet_events_tx.emit(SimnetEvent::ClockUpdate(ClockCommand::Resume));
+                        let _ = simnet_events_tx.clock_update(ClockCommand::Resume);
                     }
                 }
                 Ok(ClockCommand::Toggle) => {
                     enabled = !enabled;
                     if let Some(ref simnet_events_tx) = simnet_events_tx {
-                        let _ =
-                            simnet_events_tx.emit(SimnetEvent::ClockUpdate(ClockCommand::Toggle));
+                        let _ = simnet_events_tx.clock_update(ClockCommand::Toggle);
                     }
                 }
                 Ok(ClockCommand::UpdateSlotInterval(updated_slot_time)) => {
@@ -678,8 +675,7 @@ pub fn start_clock_runloop(
                     // If it reaches here, just treat it as a regular Pause
                     enabled = false;
                     if let Some(ref simnet_events_tx) = simnet_events_tx {
-                        let _ =
-                            simnet_events_tx.emit(SimnetEvent::ClockUpdate(ClockCommand::Pause));
+                        let _ = simnet_events_tx.clock_update(ClockCommand::Pause);
                     }
                 }
                 Err(_e) => {}
@@ -1040,14 +1036,14 @@ async fn start_http_rpc_server_runloop(
                 Err(e) => {
                     let error = format!("Failed to start RPC server: {:?}", e);
                     let _ = close_handle_tx.send(Err(error.clone()));
-                    simnet_events_tx.emit(SimnetEvent::Aborted(error));
+                    simnet_events_tx.aborted(error);
                     return;
                 }
             };
 
             let _ = close_handle_tx.send(Ok(server.close_handle()));
             server.wait();
-            simnet_events_tx.emit(SimnetEvent::Shutdown);
+            simnet_events_tx.shutdown();
         })
         .map_err(|e| format!("Failed to spawn RPC Handler thread: {:?}", e))?;
 
@@ -1123,7 +1119,7 @@ async fn start_ws_rpc_server_runloop(
                     Err(e) => {
                         let error = format!("Failed to start WebSocket RPC server: {:?}", e);
                         let _ = close_handle_tx.send(Err(error.clone()));
-                        simnet_events_tx.emit(SimnetEvent::Aborted(error));
+                        simnet_events_tx.aborted(error);
                         return;
                     }
                 };
@@ -1135,7 +1131,7 @@ async fn start_ws_rpc_server_runloop(
                 .await
                 .ok();
 
-                simnet_events_tx.emit(SimnetEvent::Shutdown);
+                simnet_events_tx.shutdown();
             });
         })
         .map_err(|e| format!("Failed to spawn WebSocket RPC Handler thread: {:?}", e))?;

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -30,7 +30,8 @@ use solana_transaction::sanitized::{MessageHash, SanitizedTransaction};
 use solana_transaction_status::RewardsAndNumPartitions;
 use surfpool_types::{
     BlockProductionMode, ClockCommand, ClockEvent, DEFAULT_MAINNET_RPC_URL, DataIndexingCommand,
-    SimnetCommand, SimnetConfig, SimnetEvent, StartupPlanner, SurfnetStartupTask, SurfpoolConfig,
+    SimnetCommand, SimnetConfig, SimnetEvent, SimnetEventsTx, StartupPlanner, SurfnetStartupTask,
+    SurfpoolConfig,
 };
 type PluginConstructor = unsafe fn() -> *mut dyn GeyserPlugin;
 use txtx_addon_kit::helpers::fs::FileLocation;
@@ -196,13 +197,13 @@ pub async fn start_local_surfnet_runloop(
     svm_locker.initialize(&remote_rpc_client).await?;
 
     if let Some(remote_client) = &remote_rpc_client {
-        let _ = svm_locker
+        svm_locker
             .simnet_events_tx()
-            .send(SimnetEvent::Connected(remote_client.client.url()));
+            .emit(SimnetEvent::Connected(remote_client.client.url()));
     }
-    let _ = svm_locker
+    svm_locker
         .simnet_events_tx()
-        .send(SimnetEvent::EpochInfoUpdate(svm_locker.get_epoch_info()));
+        .emit(SimnetEvent::EpochInfoUpdate(svm_locker.get_epoch_info()));
 
     svm_locker.airdrop_pubkeys(simnet.airdrop_token_amount, &simnet.airdrop_addresses);
 
@@ -218,7 +219,7 @@ pub async fn start_local_surfnet_runloop(
         {
             Ok(loaded_count) => {
                 let _ = svm_locker.with_svm_reader(|svm| {
-                    svm.simnet_events_tx.send(SimnetEvent::info(format!(
+                    svm.simnet_events_tx.info(format!(
                         "Preloaded {} accounts from snapshot(s) into SVM",
                         loaded_count
                     )))
@@ -226,10 +227,8 @@ pub async fn start_local_surfnet_runloop(
             }
             Err(e) => {
                 let _ = svm_locker.with_svm_reader(|svm| {
-                    svm.simnet_events_tx.send(SimnetEvent::warn(format!(
-                        "Error loading snapshot accounts: {}",
-                        e
-                    )))
+                    svm.simnet_events_tx
+                        .warn(format!("Error loading snapshot accounts: {}", e))
                 });
             }
         }
@@ -258,8 +257,7 @@ pub async fn start_local_surfnet_runloop(
     ) {
         Ok(_) => {}
         Err(e) => {
-            let _ =
-                simnet_events_tx_cc.send(SimnetEvent::error(format!("Geyser plugin failed: {e}")));
+            let _ = simnet_events_tx_cc.error(format!("Geyser plugin failed: {e}"));
         }
     };
 
@@ -316,7 +314,7 @@ pub async fn start_local_surfnet_runloop(
                 .into_iter()
                 .sorted_by(|(a_slot, _), (b_slot, _)| a_slot.cmp(b_slot))
             {
-                let _ = svm.simnet_events_tx.send(event);
+                svm.simnet_events_tx.log(event);
             }
         }
 
@@ -328,12 +326,10 @@ pub async fn start_local_surfnet_runloop(
     // inspects the project after this point and seals its own plan.
     if startup_planner == StartupPlanner::Runloop {
         if let Err(error) = svm_locker.seal_startup_plan(vec![]) {
-            let _ = simnet_events_tx_cc.try_send(SimnetEvent::error(format!(
-                "Failed to seal startup plan: {error}"
-            )));
+            simnet_events_tx_cc.error(format!("Failed to seal startup plan: {error}"));
         }
     }
-    let _ = simnet_events_tx_cc.send(SimnetEvent::CoreStarted(initial_transaction_count));
+    simnet_events_tx_cc.emit(SimnetEvent::CoreStarted(initial_transaction_count));
 
     // Notify geyser plugins that startup is complete
     let _ = svm_locker.with_svm_reader(|svm| svm.geyser_events_tx.send(GeyserEvent::EndOfStartup));
@@ -464,7 +460,7 @@ pub async fn start_block_production_runloop(
                     SimnetCommand::UpdateInternalClock(_, clock) => {
                         // Confirm the current block to materialize any scheduled overrides for this slot
                         if let Err(e) = svm_locker.confirm_current_block(&remote_client_with_commitment).await {
-                            let _ = svm_locker.simnet_events_tx().send(SimnetEvent::error(format!(
+                            svm_locker.simnet_events_tx().error(format!(
                                 "Failed to confirm block after time travel: {}", e
                             )));
                         }
@@ -477,13 +473,13 @@ pub async fn start_block_production_runloop(
                             svm_writer.latest_epoch_info.slot_index = clock.slot;
                             svm_writer.latest_epoch_info.epoch = clock.epoch;
                             svm_writer.latest_epoch_info.absolute_slot = clock.slot + clock.epoch * svm_writer.latest_epoch_info.slots_in_epoch;
-                            let _ = svm_writer.simnet_events_tx.send(SimnetEvent::SystemClockUpdated(clock));
+                            svm_writer.simnet_events_tx.log(SimnetEvent::SystemClockUpdated(clock));
                         });
                     }
                     SimnetCommand::UpdateInternalClockWithConfirmation(_, clock, response_tx) => {
                         // Confirm the current block to materialize any scheduled overrides for this slot
                         if let Err(e) = svm_locker.confirm_current_block(&remote_client_with_commitment).await {
-                            let _ = svm_locker.simnet_events_tx().send(SimnetEvent::error(format!(
+                            svm_locker.simnet_events_tx().error(format!(
                                 "Failed to confirm block after time travel: {}", e
                             )));
                         }
@@ -496,7 +492,7 @@ pub async fn start_block_production_runloop(
                             svm_writer.latest_epoch_info.slot_index = clock.slot;
                             svm_writer.latest_epoch_info.epoch = clock.epoch;
                             svm_writer.latest_epoch_info.absolute_slot = clock.slot + clock.epoch * svm_writer.latest_epoch_info.slots_in_epoch;
-                            let _ = svm_writer.simnet_events_tx.send(SimnetEvent::SystemClockUpdated(clock));
+                            svm_writer.simnet_events_tx.log(SimnetEvent::SystemClockUpdated(clock));
                             svm_writer.latest_epoch_info.clone()
                         });
 
@@ -511,7 +507,7 @@ pub async fn start_block_production_runloop(
                        let skip_sig_verify = skip_sig_verify_override.unwrap_or(global_skip_sig_verify);
                        let sigverify = !skip_sig_verify;
                        if let Err(e) = svm_locker.process_transaction(&remote_client_with_commitment, transaction, status_tx, skip_preflight, sigverify).await {
-                            let _ = svm_locker.simnet_events_tx().send(SimnetEvent::error(format!("Failed to process transaction: {}", e)));
+                            svm_locker.simnet_events_tx().error(format!("Failed to process transaction: {}", e));
                        }
                        if block_production_mode.eq(&BlockProductionMode::Transaction) {
                            do_produce_block = true;
@@ -530,7 +526,7 @@ pub async fn start_block_production_runloop(
                     SimnetCommand::SealStartupPlan(tasks, response_tx) => {
                         let result = svm_locker.seal_startup_plan(tasks);
                         if let Err(error) = &result {
-                            let _ = svm_locker.simnet_events_tx().try_send(SimnetEvent::error(
+                            svm_locker.simnet_events_tx().error(
                                 format!("Failed to seal startup plan: {error}"),
                             ));
                         }
@@ -540,24 +536,23 @@ pub async fn start_block_production_runloop(
                         if let Err(transition_error) =
                             svm_locker.fail_startup_planning(error.clone())
                         {
-                            let _ = svm_locker.simnet_events_tx().try_send(SimnetEvent::error(
+                            svm_locker.simnet_events_tx().error(
                                 format!("Failed to transition startup to Failed: {transition_error}"),
                             ));
                         }
-                        let _ = svm_locker
-                            .simnet_events_tx()
-                            .try_send(SimnetEvent::error(format!("Surfpool startup failed: {error}")));
+                        svm_locker
+                            .simnet_events_tx().error(format!("Surfpool startup failed: {error}"));
                     }
                     SimnetCommand::StartStartupTask(task) => {
                         if let Err(error) = svm_locker.start_startup_task(task) {
-                            let _ = svm_locker.simnet_events_tx().try_send(SimnetEvent::error(
+                            svm_locker.simnet_events_tx().error(
                                 format!("Failed to start startup task {task:?}: {error}"),
                             ));
                         }
                     }
                     SimnetCommand::CompleteStartupTask(task, result) => {
                         if let Err(error) = svm_locker.complete_startup_task(task, result) {
-                            let _ = svm_locker.simnet_events_tx().try_send(SimnetEvent::error(
+                            svm_locker.simnet_events_tx().error(
                                 format!("Failed to complete startup task {task:?}: {error}"),
                             ));
                         }
@@ -594,13 +589,11 @@ pub async fn start_block_production_runloop(
                                     let absent =
                                         absent_after_hydration(&svm_locker, &account_updates.inner);
                                     if !absent.is_empty() {
-                                        let _ = svm_locker.simnet_events_tx().try_send(
-                                            SimnetEvent::warn(format!(
-                                                "Cloned accounts not found on the datasource, and \
-                                                 absent locally: {}",
-                                                absent.iter().map(|key| key.to_string()).join(", ")
-                                            )),
-                                        );
+                                        svm_locker.simnet_events_tx().warn(format!(
+                                            "Cloned accounts not found on the datasource, and \
+                                             absent locally: {}",
+                                            absent.iter().map(|key| key.to_string()).join(", ")
+                                        ));
                                     }
                                     Ok(())
                                 }
@@ -612,15 +605,14 @@ pub async fn start_block_production_runloop(
                         };
 
                         if let Err(error) = &fetch_result {
-                            let _ = svm_locker
-                                .simnet_events_tx()
-                                .try_send(SimnetEvent::error(error.clone()));
+                            svm_locker
+                                .simnet_events_tx().error(error.clone());
                         }
                         if let Err(error) = svm_locker.complete_startup_task(
                             SurfnetStartupTask::RemoteAccounts,
                             fetch_result,
                         ) {
-                            let _ = svm_locker.simnet_events_tx().try_send(SimnetEvent::error(
+                            svm_locker.simnet_events_tx().error(
                                 format!("Failed to finish remote account hydration: {error}"),
                             ));
                         }
@@ -647,7 +639,7 @@ pub async fn start_block_production_runloop(
 
 pub fn start_clock_runloop(
     mut slot_time: u64,
-    simnet_events_tx: Option<Sender<SimnetEvent>>,
+    simnet_events_tx: Option<SimnetEventsTx>,
 ) -> (Receiver<ClockEvent>, Sender<ClockCommand>) {
     let (clock_event_tx, clock_event_rx) = unbounded::<ClockEvent>();
     let (clock_command_tx, clock_command_rx) = unbounded::<ClockCommand>();
@@ -661,21 +653,21 @@ pub fn start_clock_runloop(
                     enabled = false;
                     if let Some(ref simnet_events_tx) = simnet_events_tx {
                         let _ =
-                            simnet_events_tx.send(SimnetEvent::ClockUpdate(ClockCommand::Pause));
+                            simnet_events_tx.emit(SimnetEvent::ClockUpdate(ClockCommand::Pause));
                     }
                 }
                 Ok(ClockCommand::Resume) => {
                     enabled = true;
                     if let Some(ref simnet_events_tx) = simnet_events_tx {
                         let _ =
-                            simnet_events_tx.send(SimnetEvent::ClockUpdate(ClockCommand::Resume));
+                            simnet_events_tx.emit(SimnetEvent::ClockUpdate(ClockCommand::Resume));
                     }
                 }
                 Ok(ClockCommand::Toggle) => {
                     enabled = !enabled;
                     if let Some(ref simnet_events_tx) = simnet_events_tx {
                         let _ =
-                            simnet_events_tx.send(SimnetEvent::ClockUpdate(ClockCommand::Toggle));
+                            simnet_events_tx.emit(SimnetEvent::ClockUpdate(ClockCommand::Toggle));
                     }
                 }
                 Ok(ClockCommand::UpdateSlotInterval(updated_slot_time)) => {
@@ -687,7 +679,7 @@ pub fn start_clock_runloop(
                     enabled = false;
                     if let Some(ref simnet_events_tx) = simnet_events_tx {
                         let _ =
-                            simnet_events_tx.send(SimnetEvent::ClockUpdate(ClockCommand::Pause));
+                            simnet_events_tx.emit(SimnetEvent::ClockUpdate(ClockCommand::Pause));
                     }
                 }
                 Err(_e) => {}
@@ -704,7 +696,7 @@ pub fn start_clock_runloop(
 
 fn start_geyser_runloop(
     plugin_config_paths: Vec<PathBuf>,
-    simnet_events_tx: Sender<SimnetEvent>,
+    simnet_events_tx: SimnetEventsTx,
     geyser_events_rx: Receiver<GeyserEvent>,
     plugin_commands_rx: Receiver<PluginCommand>,
 ) -> Result<JoinHandle<Result<(), String>>, String> {
@@ -715,15 +707,15 @@ fn start_geyser_runloop(
 
         // helper to log errors that can't be propagated
         let log_error = |msg:String|{
-            let _ = simnet_events_tx.send(SimnetEvent::error(msg));
+            simnet_events_tx.error(msg);
         };
 
         let log_warn = |msg:String|{
-            let _ = simnet_events_tx.send(SimnetEvent::warn(msg));
+            simnet_events_tx.warn(msg);
         };
 
         let log_info = |msg:String|{
-            let _ = simnet_events_tx.send(SimnetEvent::info(msg));
+            simnet_events_tx.info(msg);
         };
 
         // Load plugins from config paths at startup
@@ -836,7 +828,7 @@ fn start_geyser_runloop(
                     Ok(GeyserEvent::EndOfStartup) => {
                         for plugin in managed_plugins.iter().map(|p| &*p.plugin) {
                             if let Err(e) = plugin.notify_end_of_startup() {
-                                let _ = simnet_events_tx.send(SimnetEvent::error(format!("Failed to notify end of startup to Geyser plugin: {:?}", e)));
+                                simnet_events_tx.error(format!("Failed to notify end of startup to Geyser plugin: {:?}", e));
                             }
                         }
                     }
@@ -849,7 +841,7 @@ fn start_geyser_runloop(
 
                         for plugin in managed_plugins.iter().map(|p| &*p.plugin) {
                             if let Err(e) = plugin.update_slot_status(slot, parent, &slot_status) {
-                                let _ = simnet_events_tx.send(SimnetEvent::error(format!("Failed to update slot status in Geyser plugin: {:?}", e)));
+                                simnet_events_tx.error(format!("Failed to update slot status in Geyser plugin: {:?}", e));
                             }
                         }
                     }
@@ -873,7 +865,7 @@ fn start_geyser_runloop(
 
                         for plugin in managed_plugins.iter().map(|p| &*p.plugin) {
                             if let Err(e) = plugin.notify_block_metadata(ReplicaBlockInfoVersions::V0_0_4(&block_info)) {
-                                let _ = simnet_events_tx.send(SimnetEvent::error(format!("Failed to notify block metadata to Geyser plugin: {:?}", e)));
+                                simnet_events_tx.error(format!("Failed to notify block metadata to Geyser plugin: {:?}", e));
                             }
                         }
                     }
@@ -889,7 +881,7 @@ fn start_geyser_runloop(
 
                         for plugin in managed_plugins.iter().map(|p| &*p.plugin) {
                             if let Err(e) = plugin.notify_entry(ReplicaEntryInfoVersions::V0_0_2(&entry_replica)) {
-                                let _ = simnet_events_tx.send(SimnetEvent::error(format!("Failed to notify entry to Geyser plugin: {:?}", e)));
+                                simnet_events_tx.error(format!("Failed to notify entry to Geyser plugin: {:?}", e));
                             }
                         }
                     }
@@ -999,7 +991,7 @@ async fn start_rpc_servers_runloop(
 async fn start_http_rpc_server_runloop(
     config: &SurfpoolConfig,
     middleware: SurfpoolMiddleware,
-    simnet_events_tx: Sender<SimnetEvent>,
+    simnet_events_tx: SimnetEventsTx,
 ) -> Result<(JoinHandle<()>, jsonrpc_http_server::CloseHandle), String> {
     let server_bind: SocketAddr = config
         .rpc
@@ -1048,14 +1040,14 @@ async fn start_http_rpc_server_runloop(
                 Err(e) => {
                     let error = format!("Failed to start RPC server: {:?}", e);
                     let _ = close_handle_tx.send(Err(error.clone()));
-                    let _ = simnet_events_tx.send(SimnetEvent::Aborted(error));
+                    simnet_events_tx.emit(SimnetEvent::Aborted(error));
                     return;
                 }
             };
 
             let _ = close_handle_tx.send(Ok(server.close_handle()));
             server.wait();
-            let _ = simnet_events_tx.send(SimnetEvent::Shutdown);
+            simnet_events_tx.emit(SimnetEvent::Shutdown);
         })
         .map_err(|e| format!("Failed to spawn RPC Handler thread: {:?}", e))?;
 
@@ -1068,7 +1060,7 @@ async fn start_http_rpc_server_runloop(
 async fn start_ws_rpc_server_runloop(
     config: &SurfpoolConfig,
     middleware: SurfpoolMiddleware,
-    simnet_events_tx: Sender<SimnetEvent>,
+    simnet_events_tx: SimnetEventsTx,
 ) -> Result<(JoinHandle<()>, jsonrpc_ws_server::CloseHandle), String> {
     let ws_server_bind: SocketAddr = config
         .rpc
@@ -1131,7 +1123,7 @@ async fn start_ws_rpc_server_runloop(
                     Err(e) => {
                         let error = format!("Failed to start WebSocket RPC server: {:?}", e);
                         let _ = close_handle_tx.send(Err(error.clone()));
-                        let _ = simnet_events_tx.send(SimnetEvent::Aborted(error));
+                        simnet_events_tx.emit(SimnetEvent::Aborted(error));
                         return;
                     }
                 };
@@ -1143,7 +1135,7 @@ async fn start_ws_rpc_server_runloop(
                 .await
                 .ok();
 
-                let _ = simnet_events_tx.send(SimnetEvent::Shutdown);
+                simnet_events_tx.emit(SimnetEvent::Shutdown);
             });
         })
         .map_err(|e| format!("Failed to spawn WebSocket RPC Handler thread: {:?}", e))?;

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -222,7 +222,7 @@ pub async fn start_local_surfnet_runloop(
                     svm.simnet_events_tx.info(format!(
                         "Preloaded {} accounts from snapshot(s) into SVM",
                         loaded_count
-                    )))
+                    ))
                 });
             }
             Err(e) => {
@@ -462,7 +462,7 @@ pub async fn start_block_production_runloop(
                         if let Err(e) = svm_locker.confirm_current_block(&remote_client_with_commitment).await {
                             svm_locker.simnet_events_tx().error(format!(
                                 "Failed to confirm block after time travel: {}", e
-                            )));
+                            ));
                         }
 
                         svm_locker.with_svm_writer(|svm_writer| {
@@ -481,7 +481,7 @@ pub async fn start_block_production_runloop(
                         if let Err(e) = svm_locker.confirm_current_block(&remote_client_with_commitment).await {
                             svm_locker.simnet_events_tx().error(format!(
                                 "Failed to confirm block after time travel: {}", e
-                            )));
+                            ));
                         }
 
                         let epoch_info = svm_locker.with_svm_writer(|svm_writer| {
@@ -528,7 +528,7 @@ pub async fn start_block_production_runloop(
                         if let Err(error) = &result {
                             svm_locker.simnet_events_tx().error(
                                 format!("Failed to seal startup plan: {error}"),
-                            ));
+                            );
                         }
                         let _ = response_tx.send(result);
                     }
@@ -538,7 +538,7 @@ pub async fn start_block_production_runloop(
                         {
                             svm_locker.simnet_events_tx().error(
                                 format!("Failed to transition startup to Failed: {transition_error}"),
-                            ));
+                            );
                         }
                         svm_locker
                             .simnet_events_tx().error(format!("Surfpool startup failed: {error}"));
@@ -547,14 +547,14 @@ pub async fn start_block_production_runloop(
                         if let Err(error) = svm_locker.start_startup_task(task) {
                             svm_locker.simnet_events_tx().error(
                                 format!("Failed to start startup task {task:?}: {error}"),
-                            ));
+                            );
                         }
                     }
                     SimnetCommand::CompleteStartupTask(task, result) => {
                         if let Err(error) = svm_locker.complete_startup_task(task, result) {
                             svm_locker.simnet_events_tx().error(
                                 format!("Failed to complete startup task {task:?}: {error}"),
-                            ));
+                            );
                         }
                     }
                     SimnetCommand::StartRunbookExecution(runbook_id) => {
@@ -614,7 +614,7 @@ pub async fn start_block_production_runloop(
                         ) {
                             svm_locker.simnet_events_tx().error(
                                 format!("Failed to finish remote account hydration: {error}"),
-                            ));
+                            );
                         }
                     }
                     SimnetCommand::AirdropProcessed => {

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -55,9 +55,9 @@ use solana_transaction_status::{
 use surfpool_types::{
     AccountSnapshot, ComputeUnitsEstimationResult, ExecutionCapture, ExportSnapshotConfig, Idl,
     KeyedProfileResult, ProfileResult, RpcProfileResultConfig, RunbookExecutionStatusReport,
-    SimnetCommand, SimnetEvent, SimnetEventsTx, StartupError, SurfnetStartupStatus,
-    SurfnetStartupTask, TransactionConfirmationStatus, TransactionStatusEvent,
-    UiKeyedProfileResult, UuidOrSignature, VersionedIdl,
+    SimnetCommand, SimnetEventsTx, StartupError, SurfnetStartupStatus, SurfnetStartupTask,
+    TransactionConfirmationStatus, TransactionStatusEvent, UiKeyedProfileResult, UuidOrSignature,
+    VersionedIdl,
 };
 use tokio::sync::RwLock;
 use txtx_addon_kit::indexmap::IndexSet;
@@ -2121,10 +2121,7 @@ impl SurfnetSvmLocker {
                 );
                 svm_writer
                     .simnet_events_tx
-                    .log(SimnetEvent::transaction_processed(
-                        meta_canonical,
-                        Some(err),
-                    ));
+                    .transaction_processed(meta_canonical, Some(err));
                 Ok::<(), SurfpoolError>(())
             })?;
         }
@@ -2289,7 +2286,7 @@ impl SurfnetSvmLocker {
 
                 svm_writer
                     .simnet_events_tx
-                    .log(SimnetEvent::transaction_processed(transaction_meta, None));
+                    .transaction_processed(transaction_meta, None);
 
                 let _ = svm_writer
                     .geyser_events_tx

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -533,7 +533,7 @@ impl SurfnetSvmLocker {
                         svm.simnet_events_tx.warn(format!(
                             "Skipping invalid pubkey '{}' in snapshot: {}",
                             pubkey_str, e
-                        )));
+                        ));
                     });
                     continue;
                 }
@@ -549,7 +549,7 @@ impl SurfnetSvmLocker {
                                 svm.simnet_events_tx.warn(format!(
                                     "Skipping account '{}': failed to decode base64 data: {}",
                                     pubkey_str, e
-                                )));
+                                ));
                             });
                             continue;
                         }
@@ -563,7 +563,7 @@ impl SurfnetSvmLocker {
                                 svm.simnet_events_tx.warn(format!(
                                     "Skipping account '{}': invalid owner pubkey: {}",
                                     pubkey_str, e
-                                )));
+                                ));
                             });
                             continue;
                         }
@@ -596,7 +596,7 @@ impl SurfnetSvmLocker {
                     svm.simnet_events_tx.info(format!(
                         "Fetching {} accounts from remote RPC for snapshot",
                         pubkeys_to_fetch.len()
-                    )));
+                    ));
                 });
 
                 match client
@@ -2519,7 +2519,7 @@ impl SurfnetSvmLocker {
         simnet_events_tx.info(format!(
             "Account {} will be marked offline (excluded from remote downloads)",
             pubkey
-        )));
+        ));
 
         self.with_svm_writer(move |svm_writer| {
             if let Err(e) = svm_writer.offline_accounts.store(
@@ -3756,7 +3756,7 @@ impl SurfnetSvmLocker {
         self.simnet_events_tx().info(format!(
             "Time travel to {} successful (epoch {} / slot {})",
             formated_time, updated_epoch_info.epoch, updated_epoch_info.absolute_slot
-        )));
+        ));
 
         Ok(updated_epoch_info)
     }
@@ -4063,7 +4063,7 @@ impl SurfnetSvmLocker {
             self.simnet_events_tx().info(format!(
                 "Program cache update deferred for {}: {}",
                 program_id, e
-            )));
+            ));
         }
 
         Ok(())
@@ -4249,7 +4249,7 @@ impl SurfnetSvmLocker {
                 "Updating program authority of program {} to {}",
                 program_id,
                 authority.unwrap_or(solana_system_interface::program::id())
-            )));
+            ));
             solana_loader_v3_interface::state::UpgradeableLoaderState::ProgramData {
                 slot,
                 upgrade_authority_address: authority
@@ -4296,7 +4296,7 @@ impl SurfnetSvmLocker {
             self.simnet_events_tx().info(format!(
                 "Expanding program data account to {} bytes",
                 new_size
-            )));
+            ));
         }
 
         // Write the metadata
@@ -4315,7 +4315,7 @@ impl SurfnetSvmLocker {
             data.len(),
             program_id,
             offset
-        )));
+        ));
 
         Ok(program_data_account)
     }

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -55,9 +55,9 @@ use solana_transaction_status::{
 use surfpool_types::{
     AccountSnapshot, ComputeUnitsEstimationResult, ExecutionCapture, ExportSnapshotConfig, Idl,
     KeyedProfileResult, ProfileResult, RpcProfileResultConfig, RunbookExecutionStatusReport,
-    SimnetCommand, SimnetEvent, StartupError, SurfnetStartupStatus, SurfnetStartupTask,
-    TransactionConfirmationStatus, TransactionStatusEvent, UiKeyedProfileResult, UuidOrSignature,
-    VersionedIdl,
+    SimnetCommand, SimnetEvent, SimnetEventsTx, StartupError, SurfnetStartupStatus,
+    SurfnetStartupTask, TransactionConfirmationStatus, TransactionStatusEvent,
+    UiKeyedProfileResult, UuidOrSignature, VersionedIdl,
 };
 use tokio::sync::RwLock;
 use txtx_addon_kit::indexmap::IndexSet;
@@ -530,7 +530,7 @@ impl SurfnetSvmLocker {
                 Ok(pk) => pk,
                 Err(e) => {
                     self.with_svm_reader(|svm| {
-                        let _ = svm.simnet_events_tx.send(SimnetEvent::warn(format!(
+                        svm.simnet_events_tx.warn(format!(
                             "Skipping invalid pubkey '{}' in snapshot: {}",
                             pubkey_str, e
                         )));
@@ -546,7 +546,7 @@ impl SurfnetSvmLocker {
                         Ok(d) => d,
                         Err(e) => {
                             self.with_svm_reader(|svm| {
-                                let _ = svm.simnet_events_tx.send(SimnetEvent::warn(format!(
+                                svm.simnet_events_tx.warn(format!(
                                     "Skipping account '{}': failed to decode base64 data: {}",
                                     pubkey_str, e
                                 )));
@@ -560,7 +560,7 @@ impl SurfnetSvmLocker {
                         Ok(pk) => pk,
                         Err(e) => {
                             self.with_svm_reader(|svm| {
-                                let _ = svm.simnet_events_tx.send(SimnetEvent::warn(format!(
+                                svm.simnet_events_tx.warn(format!(
                                     "Skipping account '{}': invalid owner pubkey: {}",
                                     pubkey_str, e
                                 )));
@@ -593,7 +593,7 @@ impl SurfnetSvmLocker {
         if let Some(client) = remote_client {
             if !pubkeys_to_fetch.is_empty() {
                 self.with_svm_reader(|svm| {
-                    let _ = svm.simnet_events_tx.send(SimnetEvent::info(format!(
+                    svm.simnet_events_tx.info(format!(
                         "Fetching {} accounts from remote RPC for snapshot",
                         pubkeys_to_fetch.len()
                     )));
@@ -635,10 +635,8 @@ impl SurfnetSvmLocker {
                     }
                     Err(e) => {
                         self.with_svm_reader(|svm| {
-                            let _ = svm.simnet_events_tx.send(SimnetEvent::warn(format!(
-                                "Failed to fetch some accounts from remote: {}",
-                                e
-                            )));
+                            svm.simnet_events_tx
+                                .warn(format!("Failed to fetch some accounts from remote: {}", e));
                         });
                     }
                 }
@@ -653,10 +651,8 @@ impl SurfnetSvmLocker {
 
             for (pubkey, account) in accounts_to_load {
                 if let Err(e) = svm.set_account(&pubkey, account.clone()) {
-                    let _ = svm.simnet_events_tx.send(SimnetEvent::warn(format!(
-                        "Failed to set account '{}': {}",
-                        pubkey, e
-                    )));
+                    svm.simnet_events_tx
+                        .warn(format!("Failed to set account '{}': {}", pubkey, e));
                     continue;
                 }
 
@@ -761,7 +757,7 @@ impl SurfnetSvmLocker {
                     }
                     RemoteRpcResult::MethodNotSupported => {
                         let tx = self.simnet_events_tx();
-                        let _ = tx.send(SimnetEvent::warn("The `getLargestAccounts` method was sent to the remote RPC, but this method isn't supported by your RPC provider. Only local accounts will be returned."));
+                        tx.warn("The `getLargestAccounts` method was sent to the remote RPC, but this method isn't supported by your RPC provider. Only local accounts will be returned.");
                         (vec![], vec![])
                     }
                 };
@@ -1815,10 +1811,8 @@ impl SurfnetSvmLocker {
             {
                 Ok(profiles) => profiles,
                 Err(e) => {
-                    let _ = self.simnet_events_tx().try_send(SimnetEvent::error(format!(
-                        "Failed to generate instruction profiles: {}",
-                        e
-                    )));
+                    self.simnet_events_tx()
+                        .error(format!("Failed to generate instruction profiles: {}", e));
                     None
                 }
             }
@@ -1918,7 +1912,7 @@ impl SurfnetSvmLocker {
             }
             let mut svm_clone = self.with_svm_reader(|svm_reader| svm_reader.clone_for_profiling());
 
-            let (dummy_simnet_tx, _) = crossbeam_channel::bounded(1);
+            let (dummy_simnet_tx, _) = SimnetEventsTx::channel(1);
             let (dummy_geyser_tx, _) = crossbeam_channel::bounded(1);
             svm_clone.simnet_events_tx = dummy_simnet_tx;
             svm_clone.geyser_events_tx = dummy_geyser_tx;
@@ -1980,10 +1974,7 @@ impl SurfnetSvmLocker {
         if do_propagate {
             let meta = convert_transaction_metadata_from_canonical(&meta);
             let simnet_events_tx = self.simnet_events_tx();
-            let _ = simnet_events_tx.try_send(SimnetEvent::error(format!(
-                "Transaction simulation failed: {}",
-                err
-            )));
+            simnet_events_tx.error(format!("Transaction simulation failed: {}", err));
 
             self.with_svm_writer(|svm_writer| {
                 svm_writer.notify_signature_subscribers(
@@ -2074,10 +2065,7 @@ impl SurfnetSvmLocker {
         if do_propagate {
             let meta_canonical = convert_transaction_metadata_from_canonical(&meta);
             let simnet_events_tx = self.simnet_events_tx();
-            let _ = simnet_events_tx.try_send(SimnetEvent::error(format!(
-                "Transaction execution failed: {}",
-                err
-            )));
+            simnet_events_tx.error(format!("Transaction execution failed: {}", err));
             let _ = status_tx.try_send(TransactionStatusEvent::ExecutionFailure((
                 err.clone(),
                 meta_canonical.clone(),
@@ -2131,9 +2119,9 @@ impl SurfnetSvmLocker {
                     log_messages.clone(),
                     CommitmentLevel::Processed,
                 );
-                let _ = svm_writer
+                svm_writer
                     .simnet_events_tx
-                    .try_send(SimnetEvent::transaction_processed(
+                    .log(SimnetEvent::transaction_processed(
                         meta_canonical,
                         Some(err),
                     ));
@@ -2299,9 +2287,9 @@ impl SurfnetSvmLocker {
                     ),
                 )?;
 
-                let _ = svm_writer
+                svm_writer
                     .simnet_events_tx
-                    .try_send(SimnetEvent::transaction_processed(transaction_meta, None));
+                    .log(SimnetEvent::transaction_processed(transaction_meta, None));
 
                 let _ = svm_writer
                     .geyser_events_tx
@@ -2477,10 +2465,7 @@ impl SurfnetSvmLocker {
         include_owned_accounts: bool,
     ) -> SurfpoolResult<()> {
         let simnet_events_tx = self.simnet_events_tx();
-        let _ = simnet_events_tx.send(SimnetEvent::info(format!(
-            "Account {} will be reset",
-            pubkey
-        )));
+        simnet_events_tx.info(format!("Account {} will be reset", pubkey));
         // Set the account online so it can be fetched from mainnet again.
         self.remove_offline_account(pubkey, include_owned_accounts)?;
 
@@ -2498,7 +2483,7 @@ impl SurfnetSvmLocker {
         remote_ctx: &Option<SurfnetRemoteClient>,
     ) -> SurfpoolResult<()> {
         let simnet_events_tx = self.simnet_events_tx();
-        let _ = simnet_events_tx.send(SimnetEvent::info("Resetting network..."));
+        simnet_events_tx.info("Resetting network...");
 
         // Fetch epoch info from remote if available (similar to initialize)
         let (mut epoch_info, epoch_schedule) = if let Some(remote_client) = remote_ctx {
@@ -2531,7 +2516,7 @@ impl SurfnetSvmLocker {
         include_owned_accounts: bool,
     ) -> SurfpoolResult<()> {
         let simnet_events_tx = self.simnet_events_tx();
-        let _ = simnet_events_tx.send(SimnetEvent::info(format!(
+        simnet_events_tx.info(format!(
             "Account {} will be marked offline (excluded from remote downloads)",
             pubkey
         )));
@@ -2557,10 +2542,7 @@ impl SurfnetSvmLocker {
         include_owned_accounts: bool,
     ) -> SurfpoolResult<()> {
         let simnet_events_tx = self.simnet_events_tx();
-        let _ = simnet_events_tx.send(SimnetEvent::info(format!(
-            "Account {} changes will be streamed",
-            pubkey
-        )));
+        simnet_events_tx.info(format!("Account {} changes will be streamed", pubkey));
         self.with_svm_writer(|svm_writer| {
             svm_writer
                 .streamed_accounts
@@ -3492,42 +3474,26 @@ impl SurfnetSvmLocker {
         match (original_authority, new_authority) {
             (Some(original), Some(new)) => {
                 if original != new {
-                    let _ = simnet_events_tx.send(SimnetEvent::info(format!(
-                        "Setting new authority for program {}",
-                        program_id
-                    )));
-                    let _ = simnet_events_tx
-                        .send(SimnetEvent::info(format!("Old Authority: {}", original)));
-                    let _ =
-                        simnet_events_tx.send(SimnetEvent::info(format!("New Authority: {}", new)));
+                    simnet_events_tx
+                        .info(format!("Setting new authority for program {}", program_id));
+                    simnet_events_tx.info(format!("Old Authority: {}", original));
+                    let _ = simnet_events_tx.info(format!("New Authority: {}", new));
                 } else {
-                    let _ = simnet_events_tx.send(SimnetEvent::info(format!(
-                        "No authority change for program {}",
-                        program_id
-                    )));
+                    simnet_events_tx
+                        .info(format!("No authority change for program {}", program_id));
                 }
             }
             (Some(original), None) => {
-                let _ = simnet_events_tx.send(SimnetEvent::info(format!(
-                    "Removing authority for program {}",
-                    program_id
-                )));
-                let _ = simnet_events_tx
-                    .send(SimnetEvent::info(format!("Old Authority: {}", original)));
+                simnet_events_tx.info(format!("Removing authority for program {}", program_id));
+                simnet_events_tx.info(format!("Old Authority: {}", original));
             }
             (None, Some(new)) => {
-                let _ = simnet_events_tx.send(SimnetEvent::info(format!(
-                    "Setting new authority for program {}",
-                    program_id
-                )));
-                let _ = simnet_events_tx.send(SimnetEvent::info("Old Authority: None".to_string()));
-                let _ = simnet_events_tx.send(SimnetEvent::info(format!("New Authority: {}", new)));
+                simnet_events_tx.info(format!("Setting new authority for program {}", program_id));
+                simnet_events_tx.info("Old Authority: None".to_string());
+                simnet_events_tx.info(format!("New Authority: {}", new));
             }
             (None, None) => {
-                let _ = simnet_events_tx.send(SimnetEvent::info(format!(
-                    "No authority change for program {}",
-                    program_id
-                )));
+                simnet_events_tx.info(format!("No authority change for program {}", program_id));
             }
         };
 
@@ -3628,7 +3594,7 @@ impl SurfnetSvmLocker {
 
         let remote_accounts = remote_accounts_result.handle_method_not_supported(|| {
             let tx = self.simnet_events_tx();
-            let _ = tx.send(SimnetEvent::warn("The `getProgramAccounts` method was sent to the remote RPC, but this method isn't supported by your RPC provider. If you need this method, please use a different RPC provider."));
+            tx.warn("The `getProgramAccounts` method was sent to the remote RPC, but this method isn't supported by your RPC provider. If you need this method, please use a different RPC provider.");
             vec![]
         });
 
@@ -3738,7 +3704,7 @@ impl SurfnetSvmLocker {
 /// Pass through functions for accessing the underlying SurfnetSvm instance
 impl SurfnetSvmLocker {
     /// Returns a sender for simulation events from the underlying SVM.
-    pub fn simnet_events_tx(&self) -> Sender<SimnetEvent> {
+    pub fn simnet_events_tx(&self) -> SimnetEventsTx {
         self.with_svm_reader(|svm_reader| svm_reader.simnet_events_tx.clone())
     }
 
@@ -3787,7 +3753,7 @@ impl SurfnetSvmLocker {
                 SurfpoolError::internal(format!("Failed to confirm clock update: {}", e))
             })?;
 
-        let _ = self.simnet_events_tx().send(SimnetEvent::info(format!(
+        self.simnet_events_tx().info(format!(
             "Time travel to {} successful (epoch {} / slot {})",
             formated_time, updated_epoch_info.epoch, updated_epoch_info.absolute_slot
         )));
@@ -4094,7 +4060,7 @@ impl SurfnetSvmLocker {
             svm_writer.set_account(&program_id, program_account.clone())
         });
         if let Err(e) = set_result {
-            let _ = self.simnet_events_tx().send(SimnetEvent::info(format!(
+            self.simnet_events_tx().info(format!(
                 "Program cache update deferred for {}: {}",
                 program_id, e
             )));
@@ -4131,12 +4097,10 @@ impl SurfnetSvmLocker {
                             .minimum_balance_for_rent_exemption(program_data.len())
                     });
 
-                    let _ = svm_locker
-                        .simnet_events_tx()
-                        .send(SimnetEvent::info(format!(
-                            "Creating program account {} with program data address {}",
-                            program_id, program_data_address
-                        )));
+                    svm_locker.simnet_events_tx().info(format!(
+                        "Creating program account {} with program data address {}",
+                        program_id, program_data_address
+                    ));
 
                     GetAccountResult::FoundAccount(
                         program_id,
@@ -4229,12 +4193,10 @@ impl SurfnetSvmLocker {
                             .minimum_balance_for_rent_exemption(programdata_data.len())
                     });
 
-                    let _ = svm_locker
-                        .simnet_events_tx()
-                        .send(SimnetEvent::info(format!(
-                            "Creating program data account {} for program {}",
-                            program_data_address, program_id
-                        )));
+                    svm_locker.simnet_events_tx().info(format!(
+                        "Creating program data account {} for program {}",
+                        program_data_address, program_id
+                    ));
 
                     GetAccountResult::FoundAccount(
                         program_data_address,
@@ -4283,7 +4245,7 @@ impl SurfnetSvmLocker {
         };
 
         let new_metadata = if upgrade_authority_address.ne(&authority) {
-            let _ = self.simnet_events_tx().send(SimnetEvent::info(format!(
+            self.simnet_events_tx().info(format!(
                 "Updating program authority of program {} to {}",
                 program_id,
                 authority.unwrap_or(solana_system_interface::program::id())
@@ -4331,7 +4293,7 @@ impl SurfnetSvmLocker {
             });
             program_data_account.lamports = new_lamports;
 
-            let _ = self.simnet_events_tx().send(SimnetEvent::info(format!(
+            self.simnet_events_tx().info(format!(
                 "Expanding program data account to {} bytes",
                 new_size
             )));
@@ -4348,7 +4310,7 @@ impl SurfnetSvmLocker {
             Ok::<(), SurfpoolError>(())
         })?;
 
-        let _ = self.simnet_events_tx().send(SimnetEvent::info(format!(
+        self.simnet_events_tx().info(format!(
             "Wrote {} bytes to program {} at offset {}",
             data.len(),
             program_id,

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -1243,7 +1243,7 @@ impl SurfnetSvm {
                     self.simnet_events_tx.info(format!(
                         "Genesis airdrop successful {}: {}",
                         recipient, lamports
-                    )));
+                    ));
                 }
                 Err(AirdropError::ZeroAmount) => {
                     let _ = self.simnet_events_tx.info("Skipping 0 lamport airdrop");
@@ -1252,7 +1252,7 @@ impl SurfnetSvm {
                 Err(AirdropError::BelowRentExemption { lamports, min_rent }) => {
                     self.simnet_events_tx.error(format!(
                         "Skipping invalid airdrop: amount {lamports} is below the rent-exempt minimum of {min_rent} lamports"
-                    )));
+                    ));
                     return;
                 }
                 Err(AirdropError::Other(e)) => {
@@ -2000,13 +2000,13 @@ impl SurfnetSvm {
                 "Snapshot restore completed with {} errors: {}",
                 errors.len(),
                 errors.join("; ")
-            )));
+            ));
         }
 
         self.simnet_events_tx.info(format!(
             "Restored {} accounts from snapshot",
             restored_count
-        )));
+        ));
 
         Ok(restored_count)
     }
@@ -2046,7 +2046,7 @@ impl SurfnetSvm {
                 estimation_result.success,
                 estimation_result.log_messages,
                 estimation_result.error_message
-            )));
+            ));
         }
         self.transactions_processed += 1;
 

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -1619,9 +1619,7 @@ impl SurfnetSvm {
         // Notify program subscribers
         self.notify_program_subscribers(pubkey, &account);
 
-        let _ = self
-            .simnet_events_tx
-            .log(SimnetEvent::account_update(*pubkey));
+        let _ = self.simnet_events_tx.account_update(*pubkey);
         Ok(())
     }
 
@@ -2057,10 +2055,7 @@ impl SurfnetSvm {
             let transaction_meta = convert_transaction_metadata_from_canonical(&meta);
 
             self.simnet_events_tx
-                .log(SimnetEvent::transaction_processed(
-                    transaction_meta,
-                    Some(err.clone()),
-                ));
+                .transaction_processed(transaction_meta, Some(err.clone()));
             return Err(FailedTransactionMetadata { err, meta });
         }
 
@@ -2071,10 +2066,7 @@ impl SurfnetSvm {
                     convert_transaction_metadata_from_canonical(&tx_failure.meta);
 
                 self.simnet_events_tx
-                    .log(SimnetEvent::transaction_processed(
-                        transaction_meta,
-                        Some(tx_failure.err.clone()),
-                    ));
+                    .transaction_processed(transaction_meta, Some(tx_failure.err.clone()));
                 Err(tx_failure)
             }
         }
@@ -2525,9 +2517,7 @@ impl SurfnetSvm {
             leader_schedule_epoch: 0, // todo
         };
 
-        let _ = self
-            .simnet_events_tx
-            .log(SimnetEvent::SystemClockUpdated(clock.clone()));
+        let _ = self.simnet_events_tx.system_clock_updated(clock.clone());
         self.inner.set_sysvar(&clock);
 
         self.finalize_transactions()?;
@@ -3887,13 +3877,8 @@ impl SurfnetSvm {
         // subscriber exists yet, so a late subscriber's first borrow() is current.
         self.startup_status_watch_tx
             .send_replace(self.startup_status.clone());
-        // log, not emit: callers hold the SVM write guard, and the bounded
-        // events channel may belong to an embedder that never drains it. The
-        // watch channel above is the reliable path; the event stream is a
-        // best effort sequence, and dropping an entry must not wedge the SVM.
-        self.simnet_events_tx.log(SimnetEvent::StartupStatusChanged(
-            self.startup_status.clone(),
-        ));
+        self.simnet_events_tx
+            .startup_status_changed(self.startup_status.clone());
     }
 
     pub fn complete_runbook_execution(&mut self, runbook_id: &str, error: Option<Vec<String>>) {

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -57,7 +57,7 @@ use surfpool_types::{
     AccountChange, AccountProfileState, AccountSnapshot, DEFAULT_PROFILING_MAP_CAPACITY,
     DEFAULT_SLOT_TIME_MS, ExportSnapshotConfig, ExportSnapshotScope, FifoMap, Idl,
     OverrideInstance, ProfileResult, RpcProfileDepth, RpcProfileResultConfig,
-    RunbookExecutionStatusReport, SimnetEvent, StartupError, SurfnetStartupStatus,
+    RunbookExecutionStatusReport, SimnetEvent, SimnetEventsTx, StartupError, SurfnetStartupStatus,
     SurfnetStartupTask, SvmFeatureConfig, TransactionConfirmationStatus, TransactionStatusEvent,
     UiAccountChange, UiAccountProfileState, UiProfileResult, VersionedIdl,
     types::{
@@ -271,7 +271,7 @@ pub struct SurfnetSvm {
     pub perf_samples: VecDeque<RpcPerfSample>,
     pub transactions_processed: u64,
     pub latest_epoch_info: EpochInfo,
-    pub simnet_events_tx: Sender<SimnetEvent>,
+    pub simnet_events_tx: SimnetEventsTx,
     pub geyser_events_tx: Sender<GeyserEvent>,
     pub signature_subscriptions: HashMap<Signature, Vec<SignatureSubscriptionData>>,
     pub account_subscriptions: AccountSubscriptionData,
@@ -520,7 +520,7 @@ impl SurfnetSvm {
     /// and `sandbox_geyser_events_rx`. Bundle commit code can drain these to replay the events
     /// on the original VM's channels.
     pub fn clone_for_profiling(&self) -> Self {
-        let (dummy_simnet_tx, _) = crossbeam_channel::bounded(1);
+        let (dummy_simnet_tx, _) = SimnetEventsTx::channel(1);
         let (dummy_geyser_tx, _) = crossbeam_channel::bounded(1);
 
         Self {
@@ -643,7 +643,7 @@ impl SurfnetSvm {
     pub fn clone_for_bundle_sandbox(&self) -> BundleSandbox {
         let mut svm = self.clone_for_profiling();
         let (geyser_tx, geyser_rx) = crossbeam_channel::unbounded();
-        let (simnet_tx, simnet_rx) = crossbeam_channel::unbounded();
+        let (simnet_tx, simnet_rx) = SimnetEventsTx::unbounded();
         svm.geyser_events_tx = geyser_tx;
         svm.simnet_events_tx = simnet_tx;
         BundleSandbox {
@@ -797,7 +797,7 @@ impl SurfnetSvm {
 
         // 6. Drain buffered simnet events; replay onto self's real channel.
         while let Ok(event) = simnet_rx.try_recv() {
-            let _ = self.simnet_events_tx.try_send(event);
+            self.simnet_events_tx.log(event);
         }
 
         // 7. Fire signature/logs subscribers and Success acks for each committed tx.
@@ -835,7 +835,7 @@ impl SurfnetSvm {
         database_url: Option<&str>,
         config: SurfnetSvmConfig,
     ) -> SurfpoolResult<(Self, Receiver<SimnetEvent>, Receiver<GeyserEvent>)> {
-        let (simnet_events_tx, simnet_events_rx) = crossbeam_channel::bounded(1024);
+        let (simnet_events_tx, simnet_events_rx) = SimnetEventsTx::channel(1024);
         let (geyser_events_tx, geyser_events_rx) = crossbeam_channel::bounded(1024);
         let surfnet_id = config.surfnet_id;
 
@@ -1240,28 +1240,24 @@ impl SurfnetSvm {
         for recipient in addresses {
             match self.airdrop(recipient, lamports) {
                 Ok(_) => {
-                    let _ = self.simnet_events_tx.send(SimnetEvent::info(format!(
+                    self.simnet_events_tx.info(format!(
                         "Genesis airdrop successful {}: {}",
                         recipient, lamports
                     )));
                 }
                 Err(AirdropError::ZeroAmount) => {
-                    let _ = self
-                        .simnet_events_tx
-                        .send(SimnetEvent::info("Skipping 0 lamport airdrop"));
+                    let _ = self.simnet_events_tx.info("Skipping 0 lamport airdrop");
                     return;
                 }
                 Err(AirdropError::BelowRentExemption { lamports, min_rent }) => {
-                    let _ = self.simnet_events_tx.send(SimnetEvent::error(format!(
+                    self.simnet_events_tx.error(format!(
                         "Skipping invalid airdrop: amount {lamports} is below the rent-exempt minimum of {min_rent} lamports"
                     )));
                     return;
                 }
                 Err(AirdropError::Other(e)) => {
-                    let _ = self.simnet_events_tx.send(SimnetEvent::error(format!(
-                        "Genesis airdrop failed {}: {}",
-                        recipient, e
-                    )));
+                    self.simnet_events_tx
+                        .error(format!("Genesis airdrop failed {}: {}", recipient, e));
                 }
             };
         }
@@ -1625,7 +1621,7 @@ impl SurfnetSvm {
 
         let _ = self
             .simnet_events_tx
-            .send(SimnetEvent::account_update(*pubkey));
+            .log(SimnetEvent::account_update(*pubkey));
         Ok(())
     }
 
@@ -2000,14 +1996,14 @@ impl SurfnetSvm {
 
         // Log any errors that occurred
         if !errors.is_empty() {
-            let _ = self.simnet_events_tx.send(SimnetEvent::warn(format!(
+            self.simnet_events_tx.warn(format!(
                 "Snapshot restore completed with {} errors: {}",
                 errors.len(),
                 errors.join("; ")
             )));
         }
 
-        let _ = self.simnet_events_tx.send(SimnetEvent::info(format!(
+        self.simnet_events_tx.info(format!(
             "Restored {} accounts from snapshot",
             restored_count
         )));
@@ -2041,7 +2037,7 @@ impl SurfnetSvm {
 
         if cu_analysis_enabled {
             let estimation_result = self.estimate_compute_units(&tx);
-            let _ = self.simnet_events_tx.try_send(SimnetEvent::info(format!(
+            self.simnet_events_tx.info(format!(
                 "CU Estimation for tx: {} | Consumed: {} | Success: {} | Logs: {:?} | Error: {:?}",
                 tx.signatures
                     .first()
@@ -2060,9 +2056,8 @@ impl SurfnetSvm {
 
             let transaction_meta = convert_transaction_metadata_from_canonical(&meta);
 
-            let _ = self
-                .simnet_events_tx
-                .try_send(SimnetEvent::transaction_processed(
+            self.simnet_events_tx
+                .log(SimnetEvent::transaction_processed(
                     transaction_meta,
                     Some(err.clone()),
                 ));
@@ -2075,9 +2070,8 @@ impl SurfnetSvm {
                 let transaction_meta =
                     convert_transaction_metadata_from_canonical(&tx_failure.meta);
 
-                let _ = self
-                    .simnet_events_tx
-                    .try_send(SimnetEvent::transaction_processed(
+                self.simnet_events_tx
+                    .log(SimnetEvent::transaction_processed(
                         transaction_meta,
                         Some(tx_failure.err.clone()),
                     ));
@@ -2314,23 +2308,17 @@ impl SurfnetSvm {
                                 if let Err(e) =
                                     self.set_account(&programdata_address, programdata_account)
                                 {
-                                    let _ = self
-                                        .simnet_events_tx
-                                        .send(SimnetEvent::error(e.to_string()));
+                                    let _ = self.simnet_events_tx.error(e.to_string());
                                 }
                             }
                             Ok(Some(_)) => {}
                             Err(e) => {
-                                let _ = self
-                                    .simnet_events_tx
-                                    .send(SimnetEvent::error(e.to_string()));
+                                let _ = self.simnet_events_tx.error(e.to_string());
                             }
                         }
                     }
                     if let Err(e) = self.set_account(&pubkey, account.clone()) {
-                        let _ = self
-                            .simnet_events_tx
-                            .send(SimnetEvent::error(e.to_string()));
+                        let _ = self.simnet_events_tx.error(e.to_string());
                     }
                 }
             }
@@ -2343,30 +2331,22 @@ impl SurfnetSvm {
                             if let Err(e) =
                                 self.set_account(&programdata_address, programdata_account)
                             {
-                                let _ = self
-                                    .simnet_events_tx
-                                    .send(SimnetEvent::error(e.to_string()));
+                                let _ = self.simnet_events_tx.error(e.to_string());
                             }
                         }
                         Ok(Some(_)) => {}
                         Err(e) => {
-                            let _ = self
-                                .simnet_events_tx
-                                .send(SimnetEvent::error(e.to_string()));
+                            let _ = self.simnet_events_tx.error(e.to_string());
                         }
                     }
                 }
                 if let Err(e) = self.set_account(&pubkey, account.clone()) {
-                    let _ = self
-                        .simnet_events_tx
-                        .send(SimnetEvent::error(e.to_string()));
+                    let _ = self.simnet_events_tx.error(e.to_string());
                 }
             }
             GetAccountResult::FoundTokenAccount((pubkey, account), (_, None)) => {
                 if let Err(e) = self.set_account(&pubkey, account.clone()) {
-                    let _ = self
-                        .simnet_events_tx
-                        .send(SimnetEvent::error(e.to_string()));
+                    let _ = self.simnet_events_tx.error(e.to_string());
                 }
             }
             GetAccountResult::FoundProgramAccount(
@@ -2379,14 +2359,10 @@ impl SurfnetSvm {
             ) => {
                 // The data account _must_ be set first, as the program account depends on it.
                 if let Err(e) = self.set_account(&coupled_pubkey, coupled_account.clone()) {
-                    let _ = self
-                        .simnet_events_tx
-                        .send(SimnetEvent::error(e.to_string()));
+                    let _ = self.simnet_events_tx.error(e.to_string());
                 }
                 if let Err(e) = self.set_account(&pubkey, account.clone()) {
-                    let _ = self
-                        .simnet_events_tx
-                        .send(SimnetEvent::error(e.to_string()));
+                    let _ = self.simnet_events_tx.error(e.to_string());
                 }
             }
             GetAccountResult::None(_) => {}
@@ -2551,7 +2527,7 @@ impl SurfnetSvm {
 
         let _ = self
             .simnet_events_tx
-            .send(SimnetEvent::SystemClockUpdated(clock.clone()));
+            .log(SimnetEvent::SystemClockUpdated(clock.clone()));
         self.inner.set_sysvar(&clock);
 
         self.finalize_transactions()?;
@@ -3911,15 +3887,13 @@ impl SurfnetSvm {
         // subscriber exists yet, so a late subscriber's first borrow() is current.
         self.startup_status_watch_tx
             .send_replace(self.startup_status.clone());
-        // try_send: callers hold the SVM write guard, and the bounded events
-        // channel may belong to an embedder that never drains it. The watch
-        // channel above is the reliable path; the event stream is a best
-        // effort sequence, and dropping an entry must not wedge the SVM.
-        let _ = self
-            .simnet_events_tx
-            .try_send(SimnetEvent::StartupStatusChanged(
-                self.startup_status.clone(),
-            ));
+        // log, not emit: callers hold the SVM write guard, and the bounded
+        // events channel may belong to an embedder that never drains it. The
+        // watch channel above is the reliable path; the event stream is a
+        // best effort sequence, and dropping an entry must not wedge the SVM.
+        self.simnet_events_tx.log(SimnetEvent::StartupStatusChanged(
+            self.startup_status.clone(),
+        ));
     }
 
     pub fn complete_runbook_execution(&mut self, runbook_id: &str, error: Option<Vec<String>>) {

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod helpers;
 pub mod integration;
 pub mod plugin;
+pub mod simnet_events;

--- a/crates/core/src/tests/simnet_events.rs
+++ b/crates/core/src/tests/simnet_events.rs
@@ -35,19 +35,19 @@ fn log_keeps_at_most_the_buffer_capacity() {
 }
 
 #[test]
-fn emit_delivers_the_abort_through_a_full_buffer() {
+fn an_abort_delivers_through_a_full_buffer() {
     let (svm, simnet_events_rx) = empty_events_channel();
 
     for i in 0..1024 {
         svm.simnet_events_tx.info(format!("noise {i}"));
     }
 
-    // Before the sender newtype, this event went through the same silent
-    // try_send as the noise and vanished. emit blocks until the reader
-    // makes room, so it arrives.
+    // The aborted() method is lossless: the buffer is full of noise, so
+    // the call blocks until the reader makes room, and the abort
+    // arrives.
     let tx = svm.simnet_events_tx.clone();
     let emitter = std::thread::spawn(move || {
-        tx.emit(SimnetEvent::Aborted("out of lamports".to_string()));
+        tx.aborted("out of lamports");
     });
 
     let mut received = Vec::new();

--- a/crates/core/src/tests/simnet_events.rs
+++ b/crates/core/src/tests/simnet_events.rs
@@ -1,0 +1,92 @@
+//! Pins the delivery behavior of the simnet events channel.
+//!
+//! The channel is `crossbeam_channel::bounded(1024)` (`surfnet/svm.rs`), and
+//! core sends on it with `let _ = tx.try_send(...)` at dozens of sites. On a
+//! bounded channel `try_send` fails when the buffer is full, so under
+//! backpressure those sites drop events silently, with no distinction
+//! between a log line and an `Aborted`. These tests demonstrate the drop and
+//! measure it, so a later change to the sending policy has a pinned before.
+
+use surfpool_types::SimnetEvent;
+
+use crate::surfnet::svm::{SurfnetSvm, SurfnetSvmConfig};
+
+/// Build a surfnet and drain whatever construction queued, so each test
+/// starts from an empty buffer with the real channel.
+fn empty_events_channel() -> (SurfnetSvm, crossbeam_channel::Receiver<SimnetEvent>) {
+    let (svm, simnet_events_rx, _geyser_rx) =
+        SurfnetSvm::new(SurfnetSvmConfig::default()).expect("surfnet should build");
+    while simnet_events_rx.try_recv().is_ok() {}
+    (svm, simnet_events_rx)
+}
+
+#[test]
+fn the_events_channel_refuses_the_1025th_event() {
+    let (svm, _rx) = empty_events_channel();
+
+    let mut accepted = 0u32;
+    while svm
+        .simnet_events_tx
+        .try_send(SimnetEvent::info(format!("filler {accepted}")))
+        .is_ok()
+    {
+        accepted += 1;
+    }
+
+    assert_eq!(accepted, 1024, "the buffer holds exactly its bound");
+}
+
+#[test]
+fn a_full_buffer_drops_an_abort_silently() {
+    let (svm, simnet_events_rx) = empty_events_channel();
+
+    for i in 0..1024 {
+        svm.simnet_events_tx
+            .try_send(SimnetEvent::info(format!("noise {i}")))
+            .expect("the first 1024 sends are accepted");
+    }
+
+    // The idiom used at the core call sites, verbatim: the Result vanishes,
+    // and with it the abort.
+    let _ = svm
+        .simnet_events_tx
+        .try_send(SimnetEvent::Aborted("out of lamports".to_string()));
+
+    let received: Vec<SimnetEvent> = simnet_events_rx.try_iter().collect();
+    assert_eq!(received.len(), 1024);
+    assert!(
+        !received
+            .iter()
+            .any(|e| matches!(e, SimnetEvent::Aborted(_))),
+        "the abort was dropped; 1024 log lines were kept instead"
+    );
+}
+
+#[test]
+fn a_burst_beyond_capacity_loses_the_newest_events() {
+    let (svm, simnet_events_rx) = empty_events_channel();
+
+    const BURST: usize = 4096;
+    for i in 0..BURST {
+        let _ = svm
+            .simnet_events_tx
+            .try_send(SimnetEvent::info(format!("{i}")));
+    }
+
+    let received: Vec<usize> = simnet_events_rx
+        .try_iter()
+        .filter_map(|e| match e {
+            SimnetEvent::InfoLog(_, msg) => msg.parse().ok(),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(received.len(), 1024, "3072 of 4096 events were dropped");
+    assert_eq!(
+        received,
+        (0..1024).collect::<Vec<_>>(),
+        "the survivors are the oldest events; everything after the buffer \
+         filled was lost, so under backpressure the freshest information is \
+         what disappears"
+    );
+}

--- a/crates/core/src/tests/simnet_events.rs
+++ b/crates/core/src/tests/simnet_events.rs
@@ -1,11 +1,12 @@
-//! Pins the delivery behavior of the simnet events channel.
+//! Pins the delivery contract of the simnet events channel.
 //!
-//! The channel is `crossbeam_channel::bounded(1024)` (`surfnet/svm.rs`), and
-//! core sends on it with `let _ = tx.try_send(...)` at dozens of sites. On a
-//! bounded channel `try_send` fails when the buffer is full, so under
-//! backpressure those sites drop events silently, with no distinction
-//! between a log line and an `Aborted`. These tests demonstrate the drop and
-//! measure it, so a later change to the sending policy has a pinned before.
+//! The channel is bounded(1024) and the sender is a [`SimnetEventsTx`],
+//! which owns the two delivery policies: `log` is lossy by contract
+//! (telemetry may drop under backpressure), `emit` is lossless (lifecycle
+//! events block until the reader drains). The first commit on this branch
+//! pinned the old behavior, where every core send was a silent `try_send`
+//! and a full buffer dropped an `Aborted` exactly like a log line; these
+//! tests assert the split that replaced it.
 
 use surfpool_types::SimnetEvent;
 
@@ -21,56 +22,61 @@ fn empty_events_channel() -> (SurfnetSvm, crossbeam_channel::Receiver<SimnetEven
 }
 
 #[test]
-fn the_events_channel_refuses_the_1025th_event() {
-    let (svm, _rx) = empty_events_channel();
-
-    let mut accepted = 0u32;
-    while svm
-        .simnet_events_tx
-        .try_send(SimnetEvent::info(format!("filler {accepted}")))
-        .is_ok()
-    {
-        accepted += 1;
-    }
-
-    assert_eq!(accepted, 1024, "the buffer holds exactly its bound");
-}
-
-#[test]
-fn a_full_buffer_drops_an_abort_silently() {
+fn log_keeps_at_most_the_buffer_capacity() {
     let (svm, simnet_events_rx) = empty_events_channel();
 
-    for i in 0..1024 {
-        svm.simnet_events_tx
-            .try_send(SimnetEvent::info(format!("noise {i}")))
-            .expect("the first 1024 sends are accepted");
+    for i in 0..1025 {
+        svm.simnet_events_tx.info(format!("filler {i}"));
     }
 
-    // The idiom used at the core call sites, verbatim: the Result vanishes,
-    // and with it the abort.
-    let _ = svm
-        .simnet_events_tx
-        .try_send(SimnetEvent::Aborted("out of lamports".to_string()));
-
     let received: Vec<SimnetEvent> = simnet_events_rx.try_iter().collect();
-    assert_eq!(received.len(), 1024);
-    assert!(
-        !received
-            .iter()
-            .any(|e| matches!(e, SimnetEvent::Aborted(_))),
-        "the abort was dropped; 1024 log lines were kept instead"
+    assert_eq!(
+        received.len(),
+        1024,
+        "the 1,025th log line is dropped, and dropping it returns immediately"
     );
 }
 
 #[test]
-fn a_burst_beyond_capacity_loses_the_newest_events() {
+fn emit_delivers_the_abort_through_a_full_buffer() {
+    let (svm, simnet_events_rx) = empty_events_channel();
+
+    for i in 0..1024 {
+        svm.simnet_events_tx.info(format!("noise {i}"));
+    }
+
+    // Before the sender newtype, this event went through the same silent
+    // try_send as the noise and vanished. emit blocks until the reader
+    // makes room, so it arrives.
+    let tx = svm.simnet_events_tx.clone();
+    let emitter = std::thread::spawn(move || {
+        tx.emit(SimnetEvent::Aborted("out of lamports".to_string()));
+    });
+
+    let mut received = Vec::new();
+    // 1024 noise lines plus the abort.
+    for _ in 0..1025 {
+        received.push(
+            simnet_events_rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("every event arrives once the reader drains"),
+        );
+    }
+    emitter.join().unwrap();
+
+    assert!(
+        matches!(&received[1024], SimnetEvent::Aborted(msg) if msg == "out of lamports"),
+        "the abort queued behind the noise instead of dropping"
+    );
+}
+
+#[test]
+fn a_log_burst_beyond_capacity_sheds_the_newest_lines() {
     let (svm, simnet_events_rx) = empty_events_channel();
 
     const BURST: usize = 4096;
     for i in 0..BURST {
-        let _ = svm
-            .simnet_events_tx
-            .try_send(SimnetEvent::info(format!("{i}")));
+        svm.simnet_events_tx.info(format!("{i}"));
     }
 
     let received: Vec<usize> = simnet_events_rx
@@ -81,12 +87,16 @@ fn a_burst_beyond_capacity_loses_the_newest_events() {
         })
         .collect();
 
-    assert_eq!(received.len(), 1024, "3072 of 4096 events were dropped");
+    assert_eq!(
+        received.len(),
+        1024,
+        "3072 of 4096 log lines were shed, the lossy contract log declares"
+    );
     assert_eq!(
         received,
         (0..1024).collect::<Vec<_>>(),
-        "the survivors are the oldest events; everything after the buffer \
-         filled was lost, so under backpressure the freshest information is \
-         what disappears"
+        "the survivors are the oldest lines; a reader that falls behind \
+         loses recent telemetry, never lifecycle events, which go through \
+         emit"
     );
 }

--- a/crates/core/src/tests/simnet_events.rs
+++ b/crates/core/src/tests/simnet_events.rs
@@ -3,10 +3,7 @@
 //! The channel is bounded(1024) and the sender is a [`SimnetEventsTx`],
 //! which owns the two delivery policies: `log` is lossy by contract
 //! (telemetry may drop under backpressure), `emit` is lossless (lifecycle
-//! events block until the reader drains). The first commit on this branch
-//! pinned the old behavior, where every core send was a silent `try_send`
-//! and a full buffer dropped an `Aborted` exactly like a log line; these
-//! tests assert the split that replaced it.
+//! events block until the reader drains).
 
 use surfpool_types::SimnetEvent;
 

--- a/crates/mcp/src/surfpool/start_surfnet.rs
+++ b/crates/mcp/src/surfpool/start_surfnet.rs
@@ -112,10 +112,7 @@ pub fn run_headless(surfnet_id: u16, rpc_port: u16, ws_port: u16) -> StartSurfne
         match result {
             Ok(Ok(_)) => {}
             Ok(Err(e)) => {
-                let _ = simnet_events_tx.send(SimnetEvent::error(format!(
-                    "Surfnet operational error: {}",
-                    e
-                )));
+                simnet_events_tx.error(format!("Surfnet operational error: {}", e));
             }
             Err(panic_payload) => {
                 let panic_msg = match panic_payload.downcast_ref::<&'static str>() {
@@ -125,10 +122,7 @@ pub fn run_headless(surfnet_id: u16, rpc_port: u16, ws_port: u16) -> StartSurfne
                         None => "Surfnet thread panicked with an unknown payload",
                     },
                 };
-                let _ = simnet_events_tx.send(SimnetEvent::error(format!(
-                    "Surfnet thread panic: {}",
-                    panic_msg
-                )));
+                simnet_events_tx.error(format!("Surfnet thread panic: {}", panic_msg));
             }
         }
         Ok::<(), String>(())

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -569,6 +569,67 @@ impl SimnetEvent {
     }
 }
 
+/// Sending half of the simnet events channel.
+///
+/// Owns the delivery policy so call sites state intent only: `log` may drop
+/// under backpressure; `emit` may not, and blocks until the reader drains.
+/// The channel is bounded, so without this split every sender re-decides the
+/// policy inline, and a dropped lifecycle event silently breaks any frontend
+/// holding a model of the surfnet.
+#[derive(Clone, Debug)]
+pub struct SimnetEventsTx(Sender<SimnetEvent>);
+
+impl SimnetEventsTx {
+    pub fn channel(capacity: usize) -> (Self, crossbeam_channel::Receiver<SimnetEvent>) {
+        let (tx, rx) = crossbeam_channel::bounded(capacity);
+        (Self(tx), rx)
+    }
+
+    /// An unbounded sender for buffering contexts (the bundle sandbox), where
+    /// the reader is the code that created the channel and drains it fully.
+    /// `log` and `emit` are equivalent on an unbounded channel.
+    pub fn unbounded() -> (Self, crossbeam_channel::Receiver<SimnetEvent>) {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        (Self(tx), rx)
+    }
+
+    /// Telemetry, lossy by contract: dropping a log line under load is the
+    /// chosen behavior, stated here once instead of at every call site.
+    pub fn info(&self, msg: impl Into<String>) {
+        self.log(SimnetEvent::info(msg));
+    }
+
+    pub fn warn(&self, msg: impl Into<String>) {
+        self.log(SimnetEvent::warn(msg));
+    }
+
+    pub fn error(&self, msg: impl Into<String>) {
+        self.log(SimnetEvent::error(msg));
+    }
+
+    pub fn debug(&self, msg: impl Into<String>) {
+        self.log(SimnetEvent::debug(msg));
+    }
+
+    /// Lossy delivery for log-class events: under backpressure the event is
+    /// dropped rather than stalling the sender.
+    pub fn log(&self, event: SimnetEvent) {
+        let _ = self.0.try_send(event);
+    }
+
+    /// Lossless delivery for lifecycle events: blocks on a full buffer. A
+    /// disconnected receiver means shutdown, and the event no longer has an
+    /// audience.
+    ///
+    /// Never call this while holding the SVM lock: the reader may need that
+    /// lock to drain, so a blocked emit under the guard wedges every thread
+    /// behind it. Guard-context code sends with `log` and the receiver
+    /// recovers state it missed by reading the SVM, not the event stream.
+    pub fn emit(&self, event: SimnetEvent) {
+        let _ = self.0.send(event);
+    }
+}
+
 #[derive(Debug)]
 pub enum TransactionStatusEvent {
     Success(TransactionConfirmationStatus),
@@ -2149,5 +2210,56 @@ mod tests {
 
         let config: SurfpoolConfig = serde_json::from_value(config_json).unwrap();
         assert_eq!(config.startup_planner, StartupPlanner::Runloop);
+    }
+}
+
+#[cfg(test)]
+mod simnet_events_tx_tests {
+    use super::*;
+
+    /// `log` returns immediately on a full buffer and the event is gone.
+    #[test]
+    fn log_drops_on_a_full_buffer() {
+        let (tx, rx) = SimnetEventsTx::channel(1);
+        tx.info("first");
+        tx.info("second");
+
+        let received: Vec<SimnetEvent> = rx.try_iter().collect();
+        assert_eq!(received.len(), 1);
+        assert!(
+            matches!(&received[0], SimnetEvent::InfoLog(_, msg) if msg == "first"),
+            "the buffer kept the first event and dropped the second"
+        );
+    }
+
+    /// `emit` blocks on a full buffer and delivers once the reader drains.
+    #[test]
+    fn emit_blocks_until_the_reader_drains() {
+        let (tx, rx) = SimnetEventsTx::channel(1);
+        tx.info("filler");
+
+        let sender = std::thread::spawn(move || {
+            tx.emit(SimnetEvent::Aborted("must arrive".to_string()));
+        });
+
+        // The abort cannot be in the buffer until the filler is drained.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            matches!(rx.recv().unwrap(), SimnetEvent::InfoLog(_, _)),
+            "the filler is still first in line"
+        );
+        let next = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("the blocked emit completes once there is room");
+        assert!(matches!(next, SimnetEvent::Aborted(msg) if msg == "must arrive"));
+        sender.join().unwrap();
+    }
+
+    /// `emit` returns rather than panicking when the receiver is gone.
+    #[test]
+    fn emit_shrugs_at_a_disconnected_receiver() {
+        let (tx, rx) = SimnetEventsTx::channel(1);
+        drop(rx);
+        tx.emit(SimnetEvent::Aborted("no audience".to_string()));
     }
 }

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -626,7 +626,7 @@ impl SimnetEventsTx {
     /// Never call this while holding the SVM lock: the reader may need that
     /// lock to drain, so a blocked emit under the guard wedges every thread
     /// behind it.
-    pub fn emit(&self, event: SimnetEvent) {
+    fn emit(&self, event: SimnetEvent) {
         let _ = self.0.send(event);
     }
 
@@ -647,49 +647,49 @@ impl SimnetEventsTx {
         }
     }
 
-    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// Lossless: blocks on a full buffer; never call
     /// while holding the SVM lock.
     pub fn core_started(&self, replayed_transaction_count: u64) {
         self.emit(SimnetEvent::CoreStarted(replayed_transaction_count));
     }
 
-    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// Lossless: blocks on a full buffer; never call
     /// while holding the SVM lock.
     pub fn connected(&self, url: impl Into<String>) {
         self.emit(SimnetEvent::Connected(url.into()));
     }
 
-    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// Lossless: blocks on a full buffer; never call
     /// while holding the SVM lock.
     pub fn aborted(&self, reason: impl Into<String>) {
         self.emit(SimnetEvent::Aborted(reason.into()));
     }
 
-    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// Lossless: blocks on a full buffer; never call
     /// while holding the SVM lock.
     pub fn shutdown(&self) {
         self.emit(SimnetEvent::Shutdown);
     }
 
-    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// Lossless: blocks on a full buffer; never call
     /// while holding the SVM lock.
     pub fn clock_update(&self, command: ClockCommand) {
         self.emit(SimnetEvent::ClockUpdate(command));
     }
 
-    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// Lossless: blocks on a full buffer; never call
     /// while holding the SVM lock.
     pub fn epoch_info_update(&self, epoch_info: EpochInfo) {
         self.emit(SimnetEvent::EpochInfoUpdate(epoch_info));
     }
 
-    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// Lossless: blocks on a full buffer; never call
     /// while holding the SVM lock.
     pub fn runbook_started(&self, runbook_id: impl Into<String>) {
         self.emit(SimnetEvent::RunbookStarted(runbook_id.into()));
     }
 
-    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// Lossless: blocks on a full buffer; never call
     /// while holding the SVM lock.
     pub fn runbook_completed(
         &self,

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -623,8 +623,7 @@ impl SimnetEventsTx {
     ///
     /// Never call this while holding the SVM lock: the reader may need that
     /// lock to drain, so a blocked emit under the guard wedges every thread
-    /// behind it. Guard-context code sends with `log` and the receiver
-    /// recovers state it missed by reading the SVM, not the event stream.
+    /// behind it.
     pub fn emit(&self, event: SimnetEvent) {
         let _ = self.0.send(event);
     }

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -593,20 +593,22 @@ impl SimnetEventsTx {
         (Self(tx), rx)
     }
 
-    /// Telemetry, lossy by contract: dropping a log line under load is the
-    /// chosen behavior, stated here once instead of at every call site.
+    /// Lossy ([`Self::log`]): may drop under backpressure.
     pub fn info(&self, msg: impl Into<String>) {
         self.log(SimnetEvent::info(msg));
     }
 
+    /// Lossy ([`Self::log`]): may drop under backpressure.
     pub fn warn(&self, msg: impl Into<String>) {
         self.log(SimnetEvent::warn(msg));
     }
 
+    /// Lossy ([`Self::log`]): may drop under backpressure.
     pub fn error(&self, msg: impl Into<String>) {
         self.log(SimnetEvent::error(msg));
     }
 
+    /// Lossy ([`Self::log`]): may drop under backpressure.
     pub fn debug(&self, msg: impl Into<String>) {
         self.log(SimnetEvent::debug(msg));
     }
@@ -626,6 +628,105 @@ impl SimnetEventsTx {
     /// behind it.
     pub fn emit(&self, event: SimnetEvent) {
         let _ = self.0.send(event);
+    }
+
+    /// Routes a pre-built event by its class: telemetry and guard-context
+    /// state events go through `log`, lifecycle events through `emit`. For
+    /// forwarding buffered events (the startup replay); a new call site
+    /// names its event instead.
+    pub fn forward(&self, event: SimnetEvent) {
+        match &event {
+            SimnetEvent::InfoLog(..)
+            | SimnetEvent::WarnLog(..)
+            | SimnetEvent::ErrorLog(..)
+            | SimnetEvent::DebugLog(..)
+            | SimnetEvent::SystemClockUpdated(..)
+            | SimnetEvent::StartupStatusChanged(..)
+            | SimnetEvent::AccountUpdate(..) => self.log(event),
+            _ => self.emit(event),
+        }
+    }
+
+    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// while holding the SVM lock.
+    pub fn core_started(&self, replayed_transaction_count: u64) {
+        self.emit(SimnetEvent::CoreStarted(replayed_transaction_count));
+    }
+
+    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// while holding the SVM lock.
+    pub fn connected(&self, url: impl Into<String>) {
+        self.emit(SimnetEvent::Connected(url.into()));
+    }
+
+    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// while holding the SVM lock.
+    pub fn aborted(&self, reason: impl Into<String>) {
+        self.emit(SimnetEvent::Aborted(reason.into()));
+    }
+
+    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// while holding the SVM lock.
+    pub fn shutdown(&self) {
+        self.emit(SimnetEvent::Shutdown);
+    }
+
+    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// while holding the SVM lock.
+    pub fn clock_update(&self, command: ClockCommand) {
+        self.emit(SimnetEvent::ClockUpdate(command));
+    }
+
+    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// while holding the SVM lock.
+    pub fn epoch_info_update(&self, epoch_info: EpochInfo) {
+        self.emit(SimnetEvent::EpochInfoUpdate(epoch_info));
+    }
+
+    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// while holding the SVM lock.
+    pub fn runbook_started(&self, runbook_id: impl Into<String>) {
+        self.emit(SimnetEvent::RunbookStarted(runbook_id.into()));
+    }
+
+    /// Lossless ([`Self::emit`]): blocks on a full buffer; never call
+    /// while holding the SVM lock.
+    pub fn runbook_completed(
+        &self,
+        runbook_id: impl Into<String>,
+        diagnostics: Option<Vec<String>>,
+    ) {
+        self.emit(SimnetEvent::RunbookCompleted(
+            runbook_id.into(),
+            diagnostics,
+        ));
+    }
+
+    /// Senders hold the SVM lock when startup transitions publish, so this
+    /// logs: a blocked send under the guard wedges every thread behind it,
+    /// and the startup watch channel is the reliable readiness signal.
+    pub fn startup_status_changed(&self, status: SurfnetStartupStatus) {
+        self.log(SimnetEvent::StartupStatusChanged(status));
+    }
+
+    /// Senders hold the SVM lock; logs for the same reason as
+    /// [`Self::startup_status_changed`]. Readers recover the clock from the
+    /// SVM.
+    pub fn system_clock_updated(&self, clock: Clock) {
+        self.log(SimnetEvent::SystemClockUpdated(clock));
+    }
+
+    /// Senders hold the SVM lock; logs for the same reason as
+    /// [`Self::startup_status_changed`]. The transaction is in storage and
+    /// queryable regardless.
+    pub fn transaction_processed(&self, meta: TransactionMetadata, err: Option<TransactionError>) {
+        self.log(SimnetEvent::transaction_processed(meta, err));
+    }
+
+    /// Senders hold the SVM lock; logs for the same reason as
+    /// [`Self::startup_status_changed`]. The account state is in the SVM.
+    pub fn account_update(&self, pubkey: Pubkey) {
+        self.log(SimnetEvent::account_update(pubkey));
     }
 }
 


### PR DESCRIPTION
While working #731 I kept meeting the same statement, at over a hundred call sites across core and cli:

```rust
let _ = svm_locker
    .simnet_events_tx()
    .try_send(SimnetEvent::error(format!("Failed to seal startup plan: {e}")));
```

Each site combines three decisions:

1. the transport (`try_send` vs `send`, so whether the caller may block);
2. the failure policy (`let _ =`, so what a refused event costs); 😰 
3. the construction (`SimnetEvent::error(format!(...))`, the wire shape
   inline).

The channel is `crossbeam_channel::bounded(1024)`, so on a full buffer `try_send` fails and `let _ =` discards the failure. The result is two policies nobody chose: core drops events silently under backpressure, cli blocks the sending thread. `Aborted`, `Shutdown`, and `CoreStarted` go through the same silent drop as log lines; a frontend that misses one holds a wrong model of the surfnet.

### Decision table

Since the review is circling the delivery contract, here it is as a decision table: given a delivery policy and the channel's state, each cell is what happens to the event and to the sender. `log` sacrifices the event under contention; `emit` sacrifices the sender's progress. Neither decision is made at the call site, which is what the type brings to the design. 

<table>
  <thead>
    <tr>
      <th rowspan="2">Delivery policy</th>
      <th colspan="3">Channel state</th>
    </tr>
    <tr>
      <th>buffer has room</th>
      <th>buffer full</th>
      <th>receiver disconnected</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><code>log</code></td>
      <td>deliver</td>
      <td>drop the incoming event, by contract</td>
      <td>drop (no audience)</td>
    </tr>
    <tr>
      <td><code>emit</code></td>
      <td>deliver</td>
      <td>block until the reader drains</td>
      <td>drop (no audience)</td>
    </tr>
  </tbody>
</table>

<details><summary> 👉  How to Read it 👈 </summary>

Pick the policy row, then the channel-state column. The contrast cell pair: `log` on a full buffer drops the incoming event, while `emit` on the same full buffer blocks the sender until the reader drains. Same channel state, different action; the delivery policy is the only input that changed.

Two rules sit outside the grid:

1. **Lock context, a legality rule rather than a runtime cell:** `emit`
   while holding the SVM guard is illegal. The reader may need that lock
   to drain, so blocking on a full channel while holding the guard
   deadlocks the very reader that would make progress possible; exactly
   the deadlock the measurement tests caught. The
   classification rule for call sites is therefore lock context, not event
   importance: anything sent while holding the SVM guard uses `log`.
2. **The unbounded constructor collapses the table:** in buffering contexts
   (the bundle sandbox), the "buffer full" column is unreachable and `log`
   and `emit` coincide. The distinction only exists on a bounded channel,
   which is where every long-lived reader lives.

The type owns the delivery policy; channel state determines its consequence; lock context determines which policy is legal.

</details>

## The change

`SimnetEventsTx` (in `surfpool-types`, next to `SimnetEvent`) owns the delivery policy:

- `log(event)` is lossy by contract: telemetry may drop under backpressure.
  `info` / `warn` / `error` / `debug` conveniences construct and log in one
  call.
- `emit(event)` is lossless: lifecycle events block until the reader drains.

Call sites state intent only:

```rust
// telemetry, may drop under load
svm_locker.simnet_events_tx().error(format!("Failed to seal startup plan: {e}"));

// lifecycle, may not be lost
simnet_events_tx.emit(SimnetEvent::Aborted(e.to_string()));
```

The classification is auditable: `grep 'emit('` lists every send that claims lossless-ness (17 sites), and a reviewer can dispute any claim.

One rule bounds the classification: `emit` is never called while holding the SVM lock, because the reader may need that lock to drain, and a blocked send under the guard wedges every thread behind it (the test suite demonstrates this: an `emit` of `SystemClockUpdated` from `confirm_current_block` under the write guard deadlocked the full run). Guard-context sends use `log`; readers recover missed state from the SVM, not the event stream. The rule is documented on `emit`.

## Observed Before / after

The first commit adds tests against the real `SurfnetSvm` channel and pins the old behavior; the last state asserts the contract. Both runs 3/3.

| behavior                         | before                                | after                                                            |
|----------------------------------|---------------------------------------|------------------------------------------------------------------|
| 1,025th event on a full buffer   | silently refused                      | `log`: refused by declared contract; `emit`: blocks, delivers    |
| `Aborted` behind 1,024 log lines | dropped, indistinguishable from noise | delivered; queued behind the noise, received as event 1,025      |
| 4,096-event log burst            | 3,072 lost, newest first (accident)   | 3,072 shed, newest first (contract; lifecycle goes through emit) |

## Behavior changes

- Lifecycle events sent from runloop level and cli (`Connected`,
  `EpochInfoUpdate`, `CoreStarted`, `ClockUpdate`, `Aborted`, `Shutdown`,
  `RunbookStarted`, `RunbookCompleted`) are now lossless.
- cli's blocking sends of plain log lines become droppable: a slow TUI reader
  sheds telemetry instead of stalling the sending thread.
- Guard-context sends keep their lossy behavior, now stated as `log` instead
  of implied by `let _ = try_send`.

## Breaking change

`SurfnetSvm.simnet_events_tx` is a `pub` field and its type changes from `Sender<SimnetEvent>` to `SimnetEventsTx`, a semver major on `surfpool-core`.

## Reference

The sender-owns-policy shape follows Stefan Baumgartner's "Refactoring in Rust" (https://www.youtube.com/watch?v=wuBkzT_3CDU): mint a type that names the thing, let methods carry the policy, and call sites state intent.

## Testing

1. `cargo test -p surfpool-types simnet_events_tx`
1. `cargo test -p surfpool-core --lib simnet_events`