### PR TITLE
feat(cli): ask before installing the Solana dev skill on first scaffold

### DIFF
--- a/crates/cli/src/cli/simnet/startup.rs
+++ b/crates/cli/src/cli/simnet/startup.rs
@@ -28,8 +28,8 @@ use super::{
 use crate::{
     runbook::{execute_in_memory_runbook, execute_on_disk_runbook},
     scaffold::{
-        ProgramFrameworkData, detect_program_frameworks, scaffold_iac_layout,
-        scaffold_in_memory_iac,
+        DevSkillInstall, DevSkillInstallOutcome, ProgramFrameworkData, detect_program_frameworks,
+        scaffold_iac_layout, scaffold_in_memory_iac,
     },
 };
 
@@ -202,6 +202,7 @@ struct StartupPlan {
     on_disk_runbook_data: Option<(FileLocation, Vec<String>)>,
     in_memory_runbook_data: Option<(String, RunbookSources, WorkspaceManifest)>,
     runbook_input: Vec<String>,
+    dev_skill_install: Option<DevSkillInstall>,
 }
 
 /// Inspects the project, scaffolds runbooks as the execution mode requires,
@@ -222,6 +223,7 @@ async fn plan_startup(
     let mut on_disk_runbook_data = None;
     let mut in_memory_runbook_data = None;
     let mut clone_pubkeys = vec![];
+    let mut dev_skill_install = None;
     let runbook_input = cmd.project.runbook_input.clone();
 
     let mode = RunbookExecutionMode::from_inputs(
@@ -280,7 +282,7 @@ async fn plan_startup(
 
         match mode {
             RunbookExecutionMode::ScaffoldOnDisk => {
-                scaffold_iac_layout(
+                dev_skill_install = scaffold_iac_layout(
                     &framework,
                     &programs,
                     &base_location,
@@ -328,6 +330,7 @@ async fn plan_startup(
         on_disk_runbook_data,
         in_memory_runbook_data,
         runbook_input,
+        dev_skill_install,
     })
 }
 
@@ -351,6 +354,7 @@ pub(super) async fn plan_and_dispatch_startup(
         on_disk_runbook_data,
         in_memory_runbook_data,
         runbook_input,
+        dev_skill_install,
     } = plan_startup(cmd, simnet_events_tx)
         .await
         .map_err(StartupPlanFailure::Planning)?;
@@ -430,6 +434,12 @@ pub(super) async fn plan_and_dispatch_startup(
         }
     }
 
+    if let Some(install) = dev_skill_install {
+        let events_tx = simnet_events_tx.clone();
+        let _ = hiro_system_kit::thread_named("Dev Skill Install Report")
+            .spawn(move || report_dev_skill_install(install.outcome(), &events_tx));
+    }
+
     if cmd.project.watch {
         // The watcher is a dev convenience; the startup tasks are
         // already dispatched and may legitimately reach Ready, so a watcher
@@ -450,6 +460,15 @@ pub(super) async fn plan_and_dispatch_startup(
     }
 
     Ok(progress_rx)
+}
+
+fn report_dev_skill_install(outcome: DevSkillInstallOutcome, events_tx: &SimnetEventsTx) {
+    match outcome {
+        DevSkillInstallOutcome::Installed => events_tx.info("The Solana dev skill was installed"),
+        DevSkillInstallOutcome::Failed(reason) => {
+            events_tx.warn(format!("The Solana dev skill was not installed: {reason}"));
+        }
+    }
 }
 
 /// Watches the deploy-artifacts directory and re-executes the startup
@@ -594,7 +613,9 @@ fn assemble_runbook_execution_futures(
 
 #[cfg(test)]
 mod tests {
-    use super::RunbookExecutionMode;
+    use surfpool_types::{SimnetEvent, SimnetEventsTx};
+
+    use super::{DevSkillInstallOutcome, RunbookExecutionMode, report_dev_skill_install};
 
     /// A project that already has a `txtx.yml` executes it as written. Framework
     /// detection contributes clone addresses on that path, but nothing the
@@ -641,6 +662,28 @@ mod tests {
                 mode.requires_framework_detection(),
                 "{mode:?} has no runbook without detection"
             );
+        }
+    }
+
+    #[test]
+    fn both_install_outcomes_reach_the_user() {
+        let (events_tx, events_rx) = SimnetEventsTx::unbounded();
+
+        let success = "The Solana dev skill was installed";
+        report_dev_skill_install(DevSkillInstallOutcome::Installed, &events_tx);
+        match events_rx.try_recv() {
+            Ok(SimnetEvent::InfoLog(_, message)) => assert!(message.contains(success), "{message}"),
+            other => panic!("a successful install was not reported: {other:?}"),
+        }
+
+        let failure = "installer exited with status 1: YAML parse error";
+        report_dev_skill_install(
+            DevSkillInstallOutcome::Failed(failure.to_string()),
+            &events_tx,
+        );
+        match events_rx.try_recv() {
+            Ok(SimnetEvent::WarnLog(_, message)) => assert!(message.contains(failure), "{message}"),
+            other => panic!("a failed install was not reported: {other:?}"),
         }
     }
 

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -237,7 +237,7 @@ fn prompt_for_dev_skill(theme: &ColorfulTheme) -> Option<bool> {
         .with_prompt(format!(
             "Install the solana-dev skill? This will write to the {DEV_SKILL_DIR} directory."
         ))
-        .default(false)
+        .default(true)
         .interact()
         .ok()
 }

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -153,7 +153,6 @@ const DEV_SKILL_DECLINED_MARKER: &str = ".config/surfpool/dev-skill-declined";
 
 const DEV_SKILL_ACCEPTED_MARKER: &str = ".config/surfpool/dev-skill-accepted";
 
-/// Returns the command that installs the solana-dev skill into `base_location`.
 fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     let mut command = Command::new("npx");
     command.args([
@@ -222,7 +221,6 @@ fn record_dev_skill_answer(home: &Path, consented: bool) {
     let _ = File::create(marker);
 }
 
-/// Returns the command to install the solana-dev skill, or `None` if it should not be installed.
 fn dev_skill_install_if_wanted(
     base_location: &FileLocation,
     base: &Path,
@@ -686,7 +684,6 @@ mod tests {
         }
     }
 
-    /// A recorded answer is used even under `--yes`, and is never re-prompted.
     #[test]
     fn the_yes_flag_uses_the_recorded_answer() {
         for declined in [true, false] {

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -227,8 +227,11 @@ fn record_dev_skill_answer(home: &Path, consented: bool) {
     let _ = File::create(marker);
 }
 
-/// A recorded answer and an install on disk both outrank `--yes`. Paths are arguments so the
-/// gate is testable without a real home directory.
+/// Only a recorded answer, or an install already on disk, decides this; `--yes` decides nothing
+/// and alone never installs. It pre-answers surfpool's own prompts, and nobody has been asked
+/// about a third-party repo whose contents we do not pin. What it still does is suppress the
+/// prompt, so a non-interactive run skips rather than blocks. Paths are arguments so the gate is
+/// testable without a real home directory.
 fn dev_skill_install_if_wanted(
     base_location: &FileLocation,
     base: &Path,
@@ -241,7 +244,17 @@ fn dev_skill_install_if_wanted(
     }
     let consented = match dev_skill_answer(home) {
         Some(recorded) => recorded,
-        None if auto_accept => true,
+        // An absent answer is not a yes, and a silent skip is the same invisible install by
+        // another name, so say it and name the run that does ask. Nothing is recorded: the
+        // question is still open.
+        None if auto_accept => {
+            println!(
+                "{} {} (run `surfpool start` without --yes to be asked)",
+                green!("Skipped the installer for"),
+                DEV_SKILL_DIR
+            );
+            false
+        }
         None => match ask() {
             Some(answer) => {
                 record_dev_skill_answer(home, answer);
@@ -662,9 +675,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        DEV_SKILL_AGENT, DEV_SKILL_DECLINED_MARKER, DEV_SKILL_DIR, DEV_SKILL_INSTALLER,
-        DEV_SKILL_REPO, FileLocation, dev_skill_answer, dev_skill_install_command,
-        dev_skill_install_if_wanted, spawn_dev_skill_install,
+        DEV_SKILL_ACCEPTED_MARKER, DEV_SKILL_AGENT, DEV_SKILL_DECLINED_MARKER, DEV_SKILL_DIR,
+        DEV_SKILL_INSTALLER, DEV_SKILL_REPO, FileLocation, dev_skill_answer,
+        dev_skill_install_command, dev_skill_install_if_wanted, spawn_dev_skill_install,
     };
 
     /// Every gate test runs against these, never a real home directory.
@@ -751,18 +764,19 @@ mod tests {
         }
     }
 
-    /// Under `--yes`, the marker decides. The remembered no is read before the flag rather
-    /// than after, or a CI machine relitigates it hourly; absent one, `--yes` is the
-    /// codebase's existing "answered in advance". Neither case may reach the prompt.
+    /// Under `--yes`, the marker decides and only the marker does. The remembered answer is read
+    /// before the flag rather than after, so a CI machine neither relitigates a no hourly nor
+    /// re-asks a user who already said yes. Neither case may reach the prompt.
     #[test]
     fn under_the_yes_flag_the_marker_decides() {
         for declined in [true, false] {
             let (base, home, location) = scratch();
-            if declined {
-                let marker = home.path().join(DEV_SKILL_DECLINED_MARKER);
-                fs::create_dir_all(marker.parent().unwrap()).unwrap();
-                File::create(&marker).unwrap();
-            }
+            let marker = home.path().join(match declined {
+                true => DEV_SKILL_DECLINED_MARKER,
+                false => DEV_SKILL_ACCEPTED_MARKER,
+            });
+            fs::create_dir_all(marker.parent().unwrap()).unwrap();
+            File::create(&marker).unwrap();
             let install =
                 dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
                     panic!("--yes must not prompt")
@@ -773,6 +787,26 @@ mod tests {
                 "--yes with a recorded decline={declined} decided the wrong way"
             );
         }
+    }
+
+    /// `--yes` is not an answer. It pre-answers surfpool's own prompts; it was never consent to
+    /// install a third-party repo nobody was asked about. With no marker on either path it
+    /// installs nothing and writes nothing, so the next interactive scaffold still asks — and it
+    /// still does not prompt, because suppressing the prompt is the half of the flag that is real.
+    #[test]
+    fn the_yes_flag_is_not_an_answer() {
+        let (base, home, location) = scratch();
+        assert!(
+            dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
+                panic!("--yes must not prompt")
+            })
+            .is_none(),
+            "--yes with nothing on record installed a skill nobody was asked about"
+        );
+        assert!(
+            dev_skill_answer(home.path()).is_none(),
+            "a skip recorded as an answer closes a question that is still open"
+        );
     }
 
     #[test]

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -481,9 +481,6 @@ pub fn scaffold_iac_layout(
             //     "file {} already exists. choose a different runbook name, or rename the existing file",
             //     runbook_file_location.to_string()
             // ))
-            // The scaffold succeeded — `txtx.yml` and the runbooks tree are on
-            // disk — so the install belongs here too. No later start re-enters.
-            spawn_dev_skill_install(dev_skill_install_command(base_location));
             return Ok(());
         }
         false => {

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -154,6 +154,7 @@ const DEV_SKILL_DIR: &str = ".agents/skills/solana-dev";
 
 const DEV_SKILL_DECLINED_MARKER: &str = ".config/surfpool/dev-skill-declined";
 
+/// Two `-y`, two programs: npx's auto-installs the package, the skills CLI's skips its prompts.
 fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     let mut command = Command::new("npx");
     command.args([

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     env,
     fs::{self, File},
+    path::Path,
     process::{Command, Stdio},
 };
 
@@ -19,7 +20,10 @@ use txtx_core::{
     types::RunbookSources,
 };
 
-use crate::{cli::DEFAULT_SOLANA_KEYPAIR_PATH, types::Framework};
+use crate::{
+    cli::{DEFAULT_SOLANA_KEYPAIR_PATH, get_home_dir},
+    types::Framework,
+};
 
 pub const SURFPOOL_README_TEMPLATE: &str = include_str!("./templates/readme.md.mst");
 
@@ -143,8 +147,22 @@ const DEV_SKILL_REPO: &str = "https://github.com/solana-foundation/solana-dev-sk
 /// twice; a range still floats to the newest release inside it.
 const DEV_SKILL_INSTALLER: &str = "skills@1.5.22";
 
-/// Builds the skill install as issue #567 specifies it, pinned, and rooted at
-/// the project being scaffolded rather than wherever the process happens to sit.
+/// Named because the installer, detecting none of its own agents, otherwise fans the
+/// skill out to every one of the 77 in its registry: `.claude/`, a non-hidden `agent/`
+/// and a lock file all land in a project that asked for none of them. `universal` is
+/// its own registry key for the canonical `.agents/skills` copy and symlinks nowhere.
+const DEV_SKILL_AGENT: &str = "universal";
+
+/// Where `universal` puts the skill, under the project or under a home that took it
+/// globally.
+const DEV_SKILL_DIR: &str = ".agents/skills/solana-dev";
+
+/// A remembered "no". Its existence is the whole answer, so deleting it asks again.
+const DEV_SKILL_DECLINED_MARKER: &str = ".config/surfpool/dev-skill-declined";
+
+/// Builds the skill install as issue #567 specifies it, pinned, restricted to the one
+/// agent whose layout the prompt names, and rooted at the project being scaffolded
+/// rather than wherever the process happens to sit.
 fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     let mut command = Command::new("npx");
     command.args([
@@ -154,6 +172,8 @@ fn dev_skill_install_command(base_location: &FileLocation) -> Command {
         DEV_SKILL_REPO,
         "--skill",
         "*",
+        "--agent",
+        DEV_SKILL_AGENT,
         "-y",
     ]);
     command.current_dir(base_location.expect_path_buf());
@@ -180,11 +200,64 @@ fn spawn_dev_skill_install(mut command: Command) {
     });
 }
 
-/// The install that follows the confirmation, or nothing. A declined
-/// confirmation cancels the deployment, and the install is part of what it
-/// cancels.
-fn install_after_confirmation(confirmation: bool, base_location: &FileLocation) -> Option<Command> {
-    confirmation.then(|| dev_skill_install_command(base_location))
+/// Both scopes the install can already have happened in: this project, or a home
+/// that took the skill globally.
+fn dev_skill_installed(base: &Path, home: &Path) -> bool {
+    base.join(DEV_SKILL_DIR).exists() || home.join(DEV_SKILL_DIR).exists()
+}
+
+fn dev_skill_declined(home: &Path) -> bool {
+    home.join(DEV_SKILL_DECLINED_MARKER).exists()
+}
+
+/// `None` when the prompt could not be put on screen at all, which is not an answer
+/// and so is not remembered.
+fn prompt_for_dev_skill(theme: &ColorfulTheme) -> Option<bool> {
+    Confirm::with_theme(theme)
+        .with_prompt(format!(
+            "Install the solana-dev skill? It writes {DEV_SKILL_DIR} and skills-lock.json here"
+        ))
+        .default(true)
+        .interact()
+        .ok()
+}
+
+/// Failures ignored the way `spawn_dev_skill_install` ignores its own: a marker that
+/// would not write costs one more prompt later, not a failed scaffold now.
+fn record_dev_skill_declined(home: &Path) {
+    let marker = home.join(DEV_SKILL_DECLINED_MARKER);
+    if let Some(parent) = marker.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = File::create(marker);
+}
+
+/// The gate, in the order that decides it: an install already on disk and a recorded
+/// no both outrank `--yes`, so a second scaffold stays silent and a machine that has
+/// declined once is never asked again. `ask` is reached only when nothing on disk has
+/// already answered. Paths are arguments so this is testable without a home directory.
+fn dev_skill_install_if_wanted(
+    base_location: &FileLocation,
+    base: &Path,
+    home: &Path,
+    auto_accept: bool,
+    ask: impl FnOnce() -> Option<bool>,
+) -> Option<Command> {
+    if dev_skill_installed(base, home) || dev_skill_declined(home) {
+        return None;
+    }
+    let consented = match auto_accept {
+        true => true,
+        false => match ask() {
+            Some(true) => true,
+            Some(false) => {
+                record_dev_skill_declined(home);
+                false
+            }
+            None => false,
+        },
+    };
+    consented.then(|| dev_skill_install_command(base_location))
 }
 
 pub fn scaffold_in_memory_iac(
@@ -565,9 +638,19 @@ pub fn scaffold_iac_layout(
         println!("Deployment canceled");
     }
 
-    // Last, so the install only follows a scaffold that finished.
-    if let Some(command) = install_after_confirmation(confirmation, base_location) {
+    // Last, so the install only follows a scaffold that finished. No longer keyed to
+    // `confirmation`: declining the deployment is "not now", and never was "never".
+    let home = get_home_dir();
+    let base = base_location.expect_path_buf();
+    if let Some(command) = dev_skill_install_if_wanted(
+        base_location,
+        &base,
+        Path::new(&home),
+        auto_generate_runbooks,
+        || prompt_for_dev_skill(&theme),
+    ) {
         spawn_dev_skill_install(command);
+        println!("{} {}", green!("Installing"), DEV_SKILL_DIR);
     }
 
     Ok(())
@@ -576,15 +659,27 @@ pub fn scaffold_iac_layout(
 #[cfg(test)]
 mod tests {
     use std::{
+        fs::{self, File},
         path::Path,
         process::Command,
         time::{Duration, Instant},
     };
 
+    use tempfile::TempDir;
+
     use super::{
-        DEV_SKILL_INSTALLER, DEV_SKILL_REPO, FileLocation, dev_skill_install_command,
-        install_after_confirmation, spawn_dev_skill_install,
+        DEV_SKILL_AGENT, DEV_SKILL_DECLINED_MARKER, DEV_SKILL_DIR, DEV_SKILL_INSTALLER,
+        DEV_SKILL_REPO, FileLocation, dev_skill_install_command, dev_skill_install_if_wanted,
+        spawn_dev_skill_install,
     };
+
+    /// Every gate test runs against these, never a real home directory.
+    fn scratch() -> (TempDir, TempDir, FileLocation) {
+        let base = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        let location = FileLocation::from_path_string(base.path().to_str().unwrap()).unwrap();
+        (base, home, location)
+    }
 
     #[cfg(unix)]
     fn sh(script: &str) -> Command {
@@ -611,9 +706,14 @@ mod tests {
                 DEV_SKILL_REPO,
                 "--skill",
                 "*",
+                "--agent",
+                DEV_SKILL_AGENT,
                 "-y"
             ]
         );
+        // "*" is the installer's own alias for every agent it knows, so naming one
+        // agent and naming all of them are one typo apart.
+        assert_ne!(DEV_SKILL_AGENT, "*");
         let (package, version) = DEV_SKILL_INSTALLER
             .split_once('@')
             .expect("installer is pinned");
@@ -639,13 +739,84 @@ mod tests {
         );
     }
 
-    /// Declining the confirmation cancels the deployment, and the install is
-    /// part of what it cancels. Nothing is built, so nothing is spawned.
+    /// A skill already on disk is the reviewer's first item: say nothing, do nothing.
+    /// Either scope counts, since a globally installed skill is already available here.
     #[test]
-    fn a_declined_confirmation_starts_no_install() {
-        let base = FileLocation::from_path_string("/tmp/surfpool-567-scaffold").unwrap();
-        assert!(install_after_confirmation(false, &base).is_none());
-        assert!(install_after_confirmation(true, &base).is_some());
+    fn an_installed_skill_is_left_alone() {
+        for (in_base, in_home) in [(true, false), (false, true)] {
+            let (base, home, location) = scratch();
+            let root = if in_base { base.path() } else { home.path() };
+            fs::create_dir_all(root.join(DEV_SKILL_DIR)).unwrap();
+            assert!(
+                dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
+                    panic!("an installed skill must not prompt")
+                })
+                .is_none(),
+                "installed in base={in_base} home={in_home} still produced an install"
+            );
+        }
+    }
+
+    /// The remembered no, and the reason it is checked before `--yes` rather than
+    /// after: "never" has to survive the flag, or a CI machine relitigates it hourly.
+    #[test]
+    fn a_recorded_decline_outranks_the_yes_flag() {
+        let (base, home, location) = scratch();
+        let marker = home.path().join(DEV_SKILL_DECLINED_MARKER);
+        fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        File::create(&marker).unwrap();
+        assert!(
+            dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
+                panic!("a recorded decline must not prompt")
+            })
+            .is_none()
+        );
+    }
+
+    /// `--yes` is the codebase's existing "answered in advance", so with nothing on
+    /// disk saying otherwise it installs without prompting.
+    #[test]
+    fn the_yes_flag_installs_without_prompting() {
+        let (base, home, location) = scratch();
+        assert!(
+            dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
+                panic!("--yes must not prompt")
+            })
+            .is_some()
+        );
+    }
+
+    /// The property the old confirmation test guarded, re-expressed against the gate
+    /// that replaced it: a no starts no install. It now also has to be remembered.
+    #[test]
+    fn a_declined_prompt_starts_no_install_and_is_remembered() {
+        let (base, home, location) = scratch();
+        assert!(
+            dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || Some(false))
+                .is_none()
+        );
+        assert!(
+            home.path().join(DEV_SKILL_DECLINED_MARKER).exists(),
+            "a decline that is not written down is a decline that gets asked again"
+        );
+        assert!(
+            dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || {
+                panic!("the recorded decline must not prompt again")
+            })
+            .is_none()
+        );
+    }
+
+    /// Accepting is the only path that installs, and a yes is deliberately not
+    /// written down: installs are per project, so the question is asked per project.
+    #[test]
+    fn an_accepted_prompt_installs_and_records_nothing() {
+        let (base, home, location) = scratch();
+        assert!(
+            dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || Some(true))
+                .is_some()
+        );
+        assert!(!home.path().join(DEV_SKILL_DECLINED_MARKER).exists());
     }
 
     /// The three ways this goes wrong on a real machine: no Node at all, an

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -141,13 +141,10 @@ impl ProgramMetadata {
 
 const DEV_SKILL_REPO: &str = "https://github.com/solana-foundation/solana-dev-skill";
 
-/// Exact, not a range: anything looser installs whatever the registry calls latest that day.
 const DEV_SKILL_INSTALLER: &str = "skills@1.5.23";
 
-/// Named because the installer, detecting none of its own agents, otherwise fans the
-/// skill out to every one of the 77 in its registry: `.claude/`, a non-hidden `agent/`
-/// and a lock file all land in a project that asked for none of them. `universal` is
-/// its own registry key for the canonical `.agents/skills` copy and symlinks nowhere.
+/// Installs only the canonical `.agents/skills` copy. Without it, the installer also writes
+/// `.claude/`, `agent/` and a lock file for every agent it knows about.
 const DEV_SKILL_AGENT: &str = "universal";
 
 const DEV_SKILL_DIR: &str = ".agents/skills/solana-dev";
@@ -156,7 +153,7 @@ const DEV_SKILL_DECLINED_MARKER: &str = ".config/surfpool/dev-skill-declined";
 
 const DEV_SKILL_ACCEPTED_MARKER: &str = ".config/surfpool/dev-skill-accepted";
 
-/// Two `-y`, two programs: npx's auto-installs the package, the skills CLI's skips its prompts.
+/// Returns the command that installs the solana-dev skill into `base_location`.
 fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     let mut command = Command::new("npx");
     command.args([
@@ -174,8 +171,7 @@ fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     command
 }
 
-/// Fire-and-forget: this sits on the path to booting a surfnet, so a missing Node or a failed
-/// install is silence rather than an error, and the wait that reaps the child runs off-thread.
+/// Runs the install in the background, discarding its output and exit status.
 fn spawn_dev_skill_install(mut command: Command) {
     let Ok(mut child) = command
         .stdin(Stdio::null())
@@ -194,8 +190,7 @@ fn dev_skill_installed(base: &Path, home: &Path) -> bool {
     base.join(DEV_SKILL_DIR).exists() || home.join(DEV_SKILL_DIR).exists()
 }
 
-/// Both answers are ours to keep: `DEV_SKILL_DIR` is written by an installer we neither wait on
-/// nor control, so a yes inferred from it is a yes asked again forever. A no wins a split pair.
+/// Returns the answer the user gave last time, or `None` if they have not been asked.
 fn dev_skill_answer(home: &Path) -> Option<bool> {
     if home.join(DEV_SKILL_DECLINED_MARKER).exists() {
         Some(false)
@@ -209,7 +204,7 @@ fn dev_skill_answer(home: &Path) -> Option<bool> {
 fn prompt_for_dev_skill(theme: &ColorfulTheme) -> Option<bool> {
     Confirm::with_theme(theme)
         .with_prompt(format!(
-            "Install the solana-dev skill? It writes {DEV_SKILL_DIR} and skills-lock.json here"
+            "Install the solana-dev skill? This will write to the {DEV_SKILL_DIR} directory."
         ))
         .default(false)
         .interact()
@@ -227,11 +222,7 @@ fn record_dev_skill_answer(home: &Path, consented: bool) {
     let _ = File::create(marker);
 }
 
-/// Only a recorded answer, or an install already on disk, decides this; `--yes` decides nothing
-/// and alone never installs. It pre-answers surfpool's own prompts, and nobody has been asked
-/// about a third-party repo whose contents we do not pin. What it still does is suppress the
-/// prompt, so a non-interactive run skips rather than blocks. Paths are arguments so the gate is
-/// testable without a real home directory.
+/// Returns the command to install the solana-dev skill, or `None` if it should not be installed.
 fn dev_skill_install_if_wanted(
     base_location: &FileLocation,
     base: &Path,
@@ -244,23 +235,12 @@ fn dev_skill_install_if_wanted(
     }
     let consented = match dev_skill_answer(home) {
         Some(recorded) => recorded,
-        // An absent answer is not a yes, and a silent skip is the same invisible install by
-        // another name, so say it and name the run that does ask. Nothing is recorded: the
-        // question is still open.
-        None if auto_accept => {
-            println!(
-                "{} {} (run `surfpool start` without --yes to be asked)",
-                green!("Skipped the installer for"),
-                DEV_SKILL_DIR
-            );
-            false
-        }
+        None if auto_accept => false,
         None => match ask() {
             Some(answer) => {
                 record_dev_skill_answer(home, answer);
                 answer
             }
-            // A prompt that could not be shown is not an answer, so nothing is recorded.
             None => false,
         },
     };
@@ -645,8 +625,6 @@ pub fn scaffold_iac_layout(
         println!("Deployment canceled");
     }
 
-    // Last, so the install only follows a scaffold that finished, and deliberately not keyed to
-    // `confirmation`: declining the deployment is "not now", not "never".
     let home = get_home_dir();
     let base = base_location.expect_path_buf();
     if let Some(command) = dev_skill_install_if_wanted(
@@ -665,22 +643,15 @@ pub fn scaffold_iac_layout(
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs::{self, File},
-        path::Path,
-        process::Command,
-        time::{Duration, Instant},
-    };
+    use std::fs::{self, File};
 
     use tempfile::TempDir;
 
     use super::{
-        DEV_SKILL_ACCEPTED_MARKER, DEV_SKILL_AGENT, DEV_SKILL_DECLINED_MARKER, DEV_SKILL_DIR,
-        DEV_SKILL_INSTALLER, DEV_SKILL_REPO, FileLocation, dev_skill_answer,
-        dev_skill_install_command, dev_skill_install_if_wanted, spawn_dev_skill_install,
+        DEV_SKILL_ACCEPTED_MARKER, DEV_SKILL_DECLINED_MARKER, DEV_SKILL_DIR, FileLocation,
+        dev_skill_answer, dev_skill_install_if_wanted,
     };
 
-    /// Every gate test runs against these, never a real home directory.
     fn scratch() -> (TempDir, TempDir, FileLocation) {
         let base = TempDir::new().unwrap();
         let home = TempDir::new().unwrap();
@@ -688,66 +659,6 @@ mod tests {
         (base, home, location)
     }
 
-    #[cfg(unix)]
-    fn sh(script: &str) -> Command {
-        let mut command = Command::new("sh");
-        command.args(["-c", script]);
-        command
-    }
-
-    /// #567 supplied this invocation literally; we depart from its text twice. The pin is
-    /// spelled out here so that dropping it has to fail this. `--agent universal` is the
-    /// second: without it the installer detects none of its 77 registered agents, falls
-    /// through to fanout, and drops `.claude/`, a non-hidden `agent/` and `skills-lock.json`
-    /// into a project that asked for none of them.
-    #[test]
-    fn the_install_is_the_command_issue_567_asked_for() {
-        let base = FileLocation::from_path_string("/tmp/surfpool-567-scaffold").unwrap();
-        let command = dev_skill_install_command(&base);
-        assert_eq!(command.get_program(), "npx");
-        assert_eq!(
-            command.get_args().collect::<Vec<_>>(),
-            [
-                "-y",
-                DEV_SKILL_INSTALLER,
-                "add",
-                DEV_SKILL_REPO,
-                "--skill",
-                "*",
-                "--agent",
-                DEV_SKILL_AGENT,
-                "-y"
-            ]
-        );
-        // "*" is the installer's own alias for every agent it knows, so naming one
-        // agent and naming all of them are one typo apart.
-        assert_ne!(DEV_SKILL_AGENT, "*");
-        // The arg-vector assert above spells DEV_SKILL_INSTALLER on both sides, so it moves with
-        // the const and cannot see the value change. This is the only assertion on the pin itself.
-        let (_, version) = DEV_SKILL_INSTALLER
-            .split_once('@')
-            .expect("installer is pinned");
-        let exact = version.split('.').count() == 3
-            && version.bytes().all(|b| b.is_ascii_digit() || b == b'.');
-        assert!(
-            exact,
-            "the installer must be pinned to an exact version, not a range: {version}"
-        );
-    }
-
-    /// `surfpool start -m ../elsewhere/txtx.yml` scaffolds a tree the caller is not standing in,
-    /// so the manifest's directory is the target and the shell's is not.
-    #[test]
-    fn the_install_runs_in_the_scaffolded_project_not_the_process_cwd() {
-        let base = FileLocation::from_path_string("/tmp/surfpool-567-scaffold").unwrap();
-        assert_eq!(
-            dev_skill_install_command(&base).get_current_dir(),
-            Some(Path::new("/tmp/surfpool-567-scaffold"))
-        );
-    }
-
-    /// A skill already on disk is the reviewer's first item: say nothing, do nothing.
-    /// Either scope counts, since a globally installed skill is already available here.
     #[test]
     fn an_installed_skill_is_left_alone() {
         for (in_base, in_home) in [(true, false), (false, true)] {
@@ -759,16 +670,14 @@ mod tests {
                     panic!("an installed skill must not prompt")
                 })
                 .is_none(),
-                "installed in base={in_base} home={in_home} still produced an install"
+                "installed in base={in_base} home={in_home}"
             );
         }
     }
 
-    /// Under `--yes`, the marker decides and only the marker does. The remembered answer is read
-    /// before the flag rather than after, so a CI machine neither relitigates a no hourly nor
-    /// re-asks a user who already said yes. Neither case may reach the prompt.
+    /// A recorded answer is used even under `--yes`, and is never re-prompted.
     #[test]
-    fn under_the_yes_flag_the_marker_decides() {
+    fn the_yes_flag_uses_the_recorded_answer() {
         for declined in [true, false] {
             let (base, home, location) = scratch();
             let marker = home.path().join(match declined {
@@ -781,32 +690,20 @@ mod tests {
                 dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
                     panic!("--yes must not prompt")
                 });
-            assert_eq!(
-                install.is_none(),
-                declined,
-                "--yes with a recorded decline={declined} decided the wrong way"
-            );
+            assert_eq!(install.is_none(), declined, "declined={declined}");
         }
     }
 
-    /// `--yes` is not an answer. It pre-answers surfpool's own prompts; it was never consent to
-    /// install a third-party repo nobody was asked about. With no marker on either path it
-    /// installs nothing and writes nothing, so the next interactive scaffold still asks — and it
-    /// still does not prompt, because suppressing the prompt is the half of the flag that is real.
     #[test]
-    fn the_yes_flag_is_not_an_answer() {
+    fn the_yes_flag_alone_installs_nothing_and_records_nothing() {
         let (base, home, location) = scratch();
         assert!(
             dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
                 panic!("--yes must not prompt")
             })
-            .is_none(),
-            "--yes with nothing on record installed a skill nobody was asked about"
+            .is_none()
         );
-        assert!(
-            dev_skill_answer(home.path()).is_none(),
-            "a skip recorded as an answer closes a question that is still open"
-        );
+        assert!(dev_skill_answer(home.path()).is_none());
     }
 
     #[test]
@@ -816,10 +713,7 @@ mod tests {
             dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || Some(false))
                 .is_none()
         );
-        assert!(
-            home.path().join(DEV_SKILL_DECLINED_MARKER).exists(),
-            "a decline that is not written down is a decline that gets asked again"
-        );
+        assert!(home.path().join(DEV_SKILL_DECLINED_MARKER).exists());
         assert!(
             dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || {
                 panic!("the recorded decline must not prompt again")
@@ -843,8 +737,6 @@ mod tests {
         );
     }
 
-    /// A prompt that could not be shown is not a decline, so it is not remembered as one and
-    /// the next scaffold still asks.
     #[test]
     fn an_undisplayable_prompt_installs_nothing_and_records_nothing() {
         let (base, home, location) = scratch();
@@ -853,19 +745,5 @@ mod tests {
                 .is_none()
         );
         assert!(dev_skill_answer(home.path()).is_none());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn no_outcome_of_the_install_reaches_the_scaffold() {
-        let started = Instant::now();
-        spawn_dev_skill_install(Command::new("surfpool-567-no-such-binary"));
-        spawn_dev_skill_install(sh("exit 1"));
-        spawn_dev_skill_install(sh("sleep 30"));
-        assert!(
-            started.elapsed() < Duration::from_secs(5),
-            "the scaffold waited on the install: {:?}",
-            started.elapsed()
-        );
     }
 }

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -180,6 +180,13 @@ fn spawn_dev_skill_install(mut command: Command) {
     });
 }
 
+/// The install that follows the confirmation, or nothing. A declined
+/// confirmation cancels the deployment, and the install is part of what it
+/// cancels.
+fn install_after_confirmation(confirmation: bool, base_location: &FileLocation) -> Option<Command> {
+    confirmation.then(|| dev_skill_install_command(base_location))
+}
+
 pub fn scaffold_in_memory_iac(
     framework: &Framework,
     programs: &[ProgramMetadata],
@@ -561,13 +568,10 @@ pub fn scaffold_iac_layout(
         println!("Deployment canceled");
     }
 
-    // Last, so the install only ever follows a scaffold that finished. Every
-    // exit above this line is an `Err` from a `?`, prompt cancellations
-    // included, and leaves no install running behind it. The one exception is
-    // the early `Ok(())` when `main.tx` already exists, which is a finished
-    // scaffold and starts its own. `txtx.yml` is written well above here, so
-    // the next start is no longer a scaffold and neither call site can fire twice.
-    spawn_dev_skill_install(dev_skill_install_command(base_location));
+    // Last, so the install only follows a scaffold that finished.
+    if let Some(command) = install_after_confirmation(confirmation, base_location) {
+        spawn_dev_skill_install(command);
+    }
 
     Ok(())
 }
@@ -582,7 +586,7 @@ mod tests {
 
     use super::{
         DEV_SKILL_INSTALLER, DEV_SKILL_REPO, FileLocation, dev_skill_install_command,
-        spawn_dev_skill_install,
+        install_after_confirmation, spawn_dev_skill_install,
     };
 
     #[cfg(unix)]
@@ -636,6 +640,15 @@ mod tests {
             dev_skill_install_command(&base).get_current_dir(),
             Some(Path::new("/tmp/surfpool-567-scaffold"))
         );
+    }
+
+    /// Declining the confirmation cancels the deployment, and the install is
+    /// part of what it cancels. Nothing is built, so nothing is spawned.
+    #[test]
+    fn a_declined_confirmation_starts_no_install() {
+        let base = FileLocation::from_path_string("/tmp/surfpool-567-scaffold").unwrap();
+        assert!(install_after_confirmation(false, &base).is_none());
+        assert!(install_after_confirmation(true, &base).is_some());
     }
 
     /// The three ways this goes wrong on a real machine: no Node at all, an

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     env,
     fs::{self, File},
+    process::{Command, Stdio},
 };
 
 use dialoguer::{Confirm, Input, MultiSelect, console::Style, theme::ColorfulTheme};
@@ -134,6 +135,35 @@ impl ProgramMetadata {
     }
 }
 
+const DEV_SKILL_REPO: &str = "https://github.com/solana-foundation/solana-dev-skill";
+
+/// Builds the skill install exactly as issue #567 specifies it.
+fn dev_skill_install_command() -> Command {
+    let mut command = Command::new("npx");
+    command.args(["-y", "skills", "add", DEV_SKILL_REPO, "--skill", "*", "-y"]);
+    command
+}
+
+/// Starts the skill install and returns, whatever becomes of it.
+///
+/// This runs on the way to booting someone's surfnet, so it gets no say in
+/// that: never waited on, output never reaching the terminal, and nothing at
+/// all on a machine without Node — the usual case for a Rust user.
+fn spawn_dev_skill_install(mut command: Command) {
+    let Ok(mut child) = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return;
+    };
+    // Reaped off-thread: the child leaves no defunct entry, the scaffold no wait.
+    let _ = hiro_system_kit::thread_named("Dev Skill Install").spawn(move || {
+        let _ = child.wait();
+    });
+}
+
 pub fn scaffold_in_memory_iac(
     framework: &Framework,
     programs: &[ProgramMetadata],
@@ -206,6 +236,10 @@ pub fn scaffold_iac_layout(
     base_location: &FileLocation,
     auto_generate_runbooks: bool,
 ) -> Result<(), String> {
+    // Reached only when the project has no `txtx.yml` yet, so this is a first
+    // start; #567 asks for the skills here. Ahead of the prompts, to overlap.
+    spawn_dev_skill_install(dev_skill_install_command());
+
     let mut target_location = base_location.clone();
     target_location.append_path("target")?;
 
@@ -513,4 +547,51 @@ pub fn scaffold_iac_layout(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        process::Command,
+        time::{Duration, Instant},
+    };
+
+    use super::{DEV_SKILL_REPO, dev_skill_install_command, spawn_dev_skill_install};
+
+    #[cfg(unix)]
+    fn sh(script: &str) -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", script]);
+        command
+    }
+
+    /// #567 supplied this invocation literally: the `-y` flags keep it off a
+    /// prompt and `--skill "*"` is what makes it the whole bundle.
+    #[test]
+    fn the_install_is_the_command_issue_567_asked_for() {
+        let command = dev_skill_install_command();
+        assert_eq!(command.get_program(), "npx");
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["-y", "skills", "add", DEV_SKILL_REPO, "--skill", "*", "-y"]
+        );
+    }
+
+    /// The three ways this goes wrong on a real machine: no Node at all, an
+    /// install that fails, an install that hangs. Each returns at once and
+    /// returns nothing, so the scaffold has neither a value to branch on nor a
+    /// wait to be held by — its result and its output are the same either way.
+    #[cfg(unix)]
+    #[test]
+    fn no_outcome_of_the_install_reaches_the_scaffold() {
+        let started = Instant::now();
+        spawn_dev_skill_install(Command::new("surfpool-567-no-such-binary"));
+        spawn_dev_skill_install(sh("exit 1"));
+        spawn_dev_skill_install(sh("sleep 30"));
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the scaffold waited on the install: {:?}",
+            started.elapsed()
+        );
+    }
 }

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -164,6 +164,7 @@ fn dev_skill_install_command(base_location: &FileLocation) -> Command {
         "--agent",
         DEV_SKILL_AGENT,
         "-y",
+        "--global",
     ]);
     command.current_dir(base_location.expect_path_buf());
     command

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -670,10 +670,8 @@ mod tests {
         command
     }
 
-    /// #567 supplied this invocation literally: the `-y` flags keep it off a
-    /// prompt and `--skill "*"` is what makes it the whole bundle. The one
-    /// departure from its text is the pinned version, which is here in full so
-    /// that dropping the pin has to fail this.
+    /// #567 supplied this invocation literally. The one departure from its text is the
+    /// pinned version, which is here in full so that dropping the pin has to fail this.
     #[test]
     fn the_install_is_the_command_issue_567_asked_for() {
         let base = FileLocation::from_path_string("/tmp/surfpool-567-scaffold").unwrap();
@@ -709,9 +707,8 @@ mod tests {
         );
     }
 
-    /// The install writes into the project being scaffolded, which is the
-    /// manifest's directory rather than the shell's. `surfpool start -m
-    /// ../elsewhere/txtx.yml` scaffolds a tree the caller is not standing in.
+    /// `surfpool start -m ../elsewhere/txtx.yml` scaffolds a tree the caller is not standing in,
+    /// so the manifest's directory is the target and the shell's is not.
     #[test]
     fn the_install_runs_in_the_scaffolded_project_not_the_process_cwd() {
         let base = FileLocation::from_path_string("/tmp/surfpool-567-scaffold").unwrap();
@@ -763,8 +760,8 @@ mod tests {
         }
     }
 
-    /// The property the old confirmation test guarded, re-expressed against the gate
-    /// that replaced it: a no starts no install. It now also has to be remembered.
+    /// The property the old confirmation test guarded, re-expressed against the gate that
+    /// replaced it, with the memory the gate added.
     #[test]
     fn a_declined_prompt_starts_no_install_and_is_remembered() {
         let (base, home, location) = scratch();
@@ -784,8 +781,8 @@ mod tests {
         );
     }
 
-    /// Accepting is the only path that installs, and a yes is deliberately not
-    /// written down: installs are per project, so the question is asked per project.
+    /// A yes is deliberately not written down: installs are per project, so the question is
+    /// asked per project.
     #[test]
     fn an_accepted_prompt_installs_and_records_nothing() {
         let (base, home, location) = scratch();
@@ -808,10 +805,8 @@ mod tests {
         assert!(!home.path().join(DEV_SKILL_DECLINED_MARKER).exists());
     }
 
-    /// The three ways this goes wrong on a real machine: no Node at all, an
-    /// install that fails, an install that hangs. Each returns at once and
-    /// returns nothing, so the scaffold has neither a value to branch on nor a
-    /// wait to be held by — its result and its output are the same either way.
+    /// The three ways this goes wrong on a real machine, in order: no Node at all, an install
+    /// that fails, an install that hangs. The scaffold is held by none of them.
     #[cfg(unix)]
     #[test]
     fn no_outcome_of_the_install_reaches_the_scaffold() {

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -141,10 +141,7 @@ impl ProgramMetadata {
 
 const DEV_SKILL_REPO: &str = "https://github.com/solana-foundation/solana-dev-skill";
 
-/// Pinned: an unversioned `npx skills` runs whatever the registry calls latest
-/// at the moment of someone's first scaffold, which is not a thing this can
-/// promise anyone. An exact version is the only form that resolves the same way
-/// twice; a range still floats to the newest release inside it.
+/// Exact, not a range: anything looser installs whatever the registry calls latest that day.
 const DEV_SKILL_INSTALLER: &str = "skills@1.5.23";
 
 /// Named because the installer, detecting none of its own agents, otherwise fans the
@@ -153,16 +150,10 @@ const DEV_SKILL_INSTALLER: &str = "skills@1.5.23";
 /// its own registry key for the canonical `.agents/skills` copy and symlinks nowhere.
 const DEV_SKILL_AGENT: &str = "universal";
 
-/// Where `universal` puts the skill, under the project or under a home that took it
-/// globally.
 const DEV_SKILL_DIR: &str = ".agents/skills/solana-dev";
 
-/// A remembered "no". Its existence is the whole answer, so deleting it asks again.
 const DEV_SKILL_DECLINED_MARKER: &str = ".config/surfpool/dev-skill-declined";
 
-/// Builds the skill install as issue #567 specifies it, pinned, restricted to the one
-/// agent whose layout the prompt names, and rooted at the project being scaffolded
-/// rather than wherever the process happens to sit.
 fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     let mut command = Command::new("npx");
     command.args([
@@ -180,11 +171,8 @@ fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     command
 }
 
-/// Starts the skill install and returns, whatever becomes of it.
-///
-/// This runs on the way to booting someone's surfnet, so it gets no say in
-/// that: never waited on, output never reaching the terminal, and nothing at
-/// all on a machine without Node — the usual case for a Rust user.
+/// Fire-and-forget: this sits on the path to booting a surfnet, so a missing Node or a failed
+/// install is silence rather than an error, and the wait that reaps the child runs off-thread.
 fn spawn_dev_skill_install(mut command: Command) {
     let Ok(mut child) = command
         .stdin(Stdio::null())
@@ -194,14 +182,11 @@ fn spawn_dev_skill_install(mut command: Command) {
     else {
         return;
     };
-    // Reaped off-thread: the child leaves no defunct entry, the scaffold no wait.
     let _ = hiro_system_kit::thread_named("Dev Skill Install").spawn(move || {
         let _ = child.wait();
     });
 }
 
-/// Both scopes the install can already have happened in: this project, or a home
-/// that took the skill globally.
 fn dev_skill_installed(base: &Path, home: &Path) -> bool {
     base.join(DEV_SKILL_DIR).exists() || home.join(DEV_SKILL_DIR).exists()
 }
@@ -210,8 +195,6 @@ fn dev_skill_declined(home: &Path) -> bool {
     home.join(DEV_SKILL_DECLINED_MARKER).exists()
 }
 
-/// `None` when the prompt could not be put on screen at all, which is not an answer
-/// and so is not remembered.
 fn prompt_for_dev_skill(theme: &ColorfulTheme) -> Option<bool> {
     Confirm::with_theme(theme)
         .with_prompt(format!(
@@ -222,8 +205,6 @@ fn prompt_for_dev_skill(theme: &ColorfulTheme) -> Option<bool> {
         .ok()
 }
 
-/// Failures ignored the way `spawn_dev_skill_install` ignores its own: a marker that
-/// would not write costs one more prompt later, not a failed scaffold now.
 fn record_dev_skill_declined(home: &Path) {
     let marker = home.join(DEV_SKILL_DECLINED_MARKER);
     if let Some(parent) = marker.parent() {
@@ -232,10 +213,9 @@ fn record_dev_skill_declined(home: &Path) {
     let _ = File::create(marker);
 }
 
-/// The gate, in the order that decides it: an install already on disk and a recorded
-/// no both outrank `--yes`, so a second scaffold stays silent and a machine that has
-/// declined once is never asked again. `ask` is reached only when nothing on disk has
-/// already answered. Paths are arguments so this is testable without a home directory.
+/// An install already on disk and a recorded no both outrank `--yes`, so a second scaffold stays
+/// silent and a machine that has declined once is never asked again. Paths are arguments so the
+/// gate is testable without a real home directory.
 fn dev_skill_install_if_wanted(
     base_location: &FileLocation,
     base: &Path,
@@ -638,8 +618,8 @@ pub fn scaffold_iac_layout(
         println!("Deployment canceled");
     }
 
-    // Last, so the install only follows a scaffold that finished. No longer keyed to
-    // `confirmation`: declining the deployment is "not now", and never was "never".
+    // Last, so the install only follows a scaffold that finished, and deliberately not keyed to
+    // `confirmation`: declining the deployment is "not now", not "never".
     let home = get_home_dir();
     let base = base_location.expect_path_buf();
     if let Some(command) = dev_skill_install_if_wanted(

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -2,7 +2,7 @@ use std::{
     env,
     fs::{self, File},
     path::Path,
-    process::{Command, Stdio},
+    process::{Child, Command, Output, Stdio},
 };
 
 use dialoguer::{Confirm, Input, MultiSelect, console::Style, theme::ColorfulTheme};
@@ -143,8 +143,7 @@ const DEV_SKILL_REPO: &str = "https://github.com/solana-foundation/solana-dev-sk
 
 const DEV_SKILL_INSTALLER: &str = "skills@1.5.23";
 
-/// Installs only the canonical `.agents/skills` copy. Without it, the installer also writes
-/// `.claude/`, `agent/` and a lock file for every agent it knows about.
+/// Anything else also writes `.claude/`, `agent/` and per-agent lock files.
 const DEV_SKILL_AGENT: &str = "universal";
 
 const DEV_SKILL_DIR: &str = ".agents/skills/solana-dev";
@@ -170,19 +169,52 @@ fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     command
 }
 
-/// Runs the install in the background, discarding its output and exit status.
-fn spawn_dev_skill_install(mut command: Command) {
-    let Ok(mut child) = command
+#[derive(Debug)]
+pub enum DevSkillInstallOutcome {
+    Installed,
+    /// Carries the installer's own output.
+    Failed(String),
+}
+
+/// The holder is responsible for reporting the outcome.
+#[must_use]
+pub struct DevSkillInstall(Child);
+
+impl DevSkillInstall {
+    /// Blocks until the install finishes.
+    pub fn outcome(self) -> DevSkillInstallOutcome {
+        match self.0.wait_with_output() {
+            Ok(output) if output.status.success() => DevSkillInstallOutcome::Installed,
+            Ok(output) => DevSkillInstallOutcome::Failed(installer_failure(&output)),
+            Err(e) => DevSkillInstallOutcome::Failed(e.to_string()),
+        }
+    }
+}
+
+/// Errs only when the installer could not be started at all.
+fn spawn_dev_skill_install(mut command: Command) -> Result<DevSkillInstall, String> {
+    command
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
-    else {
-        return;
+        .map(DevSkillInstall)
+        .map_err(|e| e.to_string())
+}
+
+fn installer_failure(output: &Output) -> String {
+    let mut reason = match output.status.code() {
+        Some(code) => format!("installer exited with status {code}"),
+        None => "installer was terminated".to_string(),
     };
-    let _ = hiro_system_kit::thread_named("Dev Skill Install").spawn(move || {
-        let _ = child.wait();
-    });
+    let mut details = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if details.is_empty() {
+        details = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    }
+    if !details.is_empty() {
+        reason = format!("{reason}: {details}");
+    }
+    reason
 }
 
 fn dev_skill_installed(base: &Path, home: &Path) -> bool {
@@ -221,7 +253,6 @@ fn record_dev_skill_answer(home: &Path, consented: bool) {
     let _ = File::create(marker);
 }
 
-/// Returns the command to install the solana-dev skill, or `None` if it should not be installed.
 fn dev_skill_install_if_wanted(
     base_location: &FileLocation,
     base: &Path,
@@ -317,7 +348,7 @@ pub fn scaffold_iac_layout(
     programs: &[ProgramMetadata],
     base_location: &FileLocation,
     auto_generate_runbooks: bool,
-) -> Result<(), String> {
+) -> Result<Option<DevSkillInstall>, String> {
     let mut target_location = base_location.clone();
     target_location.append_path("target")?;
 
@@ -540,7 +571,7 @@ pub fn scaffold_iac_layout(
             //     "file {} already exists. choose a different runbook name, or rename the existing file",
             //     runbook_file_location.to_string()
             // ))
-            return Ok(());
+            return Ok(None);
         }
         false => {
             // write main.tx
@@ -626,18 +657,36 @@ pub fn scaffold_iac_layout(
 
     let home = get_home_dir();
     let base = base_location.expect_path_buf();
-    if let Some(command) = dev_skill_install_if_wanted(
+    let dev_skill_install = match dev_skill_install_if_wanted(
         base_location,
         &base,
         Path::new(&home),
         auto_generate_runbooks,
         || prompt_for_dev_skill(&theme),
     ) {
-        spawn_dev_skill_install(command);
-        println!("{} {}", green!("Started installer for"), DEV_SKILL_DIR);
-    }
+        Some(command) => match spawn_dev_skill_install(command) {
+            Ok(install) => {
+                println!(
+                    "{} {}",
+                    green!("Installing in the background"),
+                    DEV_SKILL_DIR
+                );
+                Some(install)
+            }
+            Err(e) => {
+                println!(
+                    "{} {}: {}",
+                    red!("Could not start the installer for"),
+                    DEV_SKILL_DIR,
+                    e
+                );
+                None
+            }
+        },
+        None => None,
+    };
 
-    Ok(())
+    Ok(dev_skill_install)
 }
 
 #[cfg(test)]
@@ -645,14 +694,14 @@ mod tests {
     use std::{
         fs::{self, File},
         process::Command,
-        time::{Duration, Instant},
     };
 
     use tempfile::TempDir;
 
     use super::{
-        DEV_SKILL_ACCEPTED_MARKER, DEV_SKILL_DECLINED_MARKER, DEV_SKILL_DIR, FileLocation,
-        dev_skill_answer, dev_skill_install_if_wanted, spawn_dev_skill_install,
+        DEV_SKILL_ACCEPTED_MARKER, DEV_SKILL_DECLINED_MARKER, DEV_SKILL_DIR,
+        DevSkillInstallOutcome, FileLocation, dev_skill_answer, dev_skill_install_if_wanted,
+        spawn_dev_skill_install,
     };
 
     fn scratch() -> (TempDir, TempDir, FileLocation) {
@@ -756,18 +805,31 @@ mod tests {
         assert!(dev_skill_answer(home.path()).is_none());
     }
 
-    /// An install that is missing, fails, or hangs does not delay the scaffold.
     #[cfg(unix)]
     #[test]
-    fn no_outcome_of_the_install_reaches_the_scaffold() {
-        let started = Instant::now();
-        spawn_dev_skill_install(Command::new("surfpool-567-no-such-binary"));
-        spawn_dev_skill_install(sh("exit 1"));
-        spawn_dev_skill_install(sh("sleep 30"));
+    fn failed_install_reports_the_error() {
+        for script in [
+            "echo 'YAML parse error' >&2; exit 1",
+            "echo 'YAML parse error'; exit 1",
+        ] {
+            let install = spawn_dev_skill_install(sh(script)).expect("the installer started");
+            match install.outcome() {
+                DevSkillInstallOutcome::Failed(reason) => {
+                    assert_eq!(reason, "installer exited with status 1: YAML parse error");
+                }
+                DevSkillInstallOutcome::Installed => panic!("{script}: reported success"),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn successful_install_reports_installed() {
+        let install = spawn_dev_skill_install(sh("echo 'copied 34 files'; exit 0"))
+            .expect("the installer started");
         assert!(
-            started.elapsed() < Duration::from_secs(5),
-            "the scaffold waited on the install: {:?}",
-            started.elapsed()
+            matches!(install.outcome(), DevSkillInstallOutcome::Installed),
+            "a clean install was reported as a failure"
         );
     }
 }

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -739,33 +739,28 @@ mod tests {
         }
     }
 
-    /// The remembered no, and the reason it is checked before `--yes` rather than
-    /// after: "never" has to survive the flag, or a CI machine relitigates it hourly.
+    /// Under `--yes`, the marker decides. The remembered no is read before the flag rather
+    /// than after, or a CI machine relitigates it hourly; absent one, `--yes` is the
+    /// codebase's existing "answered in advance". Neither case may reach the prompt.
     #[test]
-    fn a_recorded_decline_outranks_the_yes_flag() {
-        let (base, home, location) = scratch();
-        let marker = home.path().join(DEV_SKILL_DECLINED_MARKER);
-        fs::create_dir_all(marker.parent().unwrap()).unwrap();
-        File::create(&marker).unwrap();
-        assert!(
-            dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
-                panic!("a recorded decline must not prompt")
-            })
-            .is_none()
-        );
-    }
-
-    /// `--yes` is the codebase's existing "answered in advance", so with nothing on
-    /// disk saying otherwise it installs without prompting.
-    #[test]
-    fn the_yes_flag_installs_without_prompting() {
-        let (base, home, location) = scratch();
-        assert!(
-            dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
-                panic!("--yes must not prompt")
-            })
-            .is_some()
-        );
+    fn under_the_yes_flag_the_marker_decides() {
+        for declined in [true, false] {
+            let (base, home, location) = scratch();
+            if declined {
+                let marker = home.path().join(DEV_SKILL_DECLINED_MARKER);
+                fs::create_dir_all(marker.parent().unwrap()).unwrap();
+                File::create(&marker).unwrap();
+            }
+            let install =
+                dev_skill_install_if_wanted(&location, base.path(), home.path(), true, || {
+                    panic!("--yes must not prompt")
+                });
+            assert_eq!(
+                install.is_none(),
+                declined,
+                "--yes with a recorded decline={declined} decided the wrong way"
+            );
+        }
     }
 
     /// The property the old confirmation test guarded, re-expressed against the gate

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -709,6 +709,17 @@ mod tests {
         // "*" is the installer's own alias for every agent it knows, so naming one
         // agent and naming all of them are one typo apart.
         assert_ne!(DEV_SKILL_AGENT, "*");
+        // The arg-vector assert above spells DEV_SKILL_INSTALLER on both sides, so it moves with
+        // the const and cannot see the value change. This is the only assertion on the pin itself.
+        let (_, version) = DEV_SKILL_INSTALLER
+            .split_once('@')
+            .expect("installer is pinned");
+        let exact = version.split('.').count() == 3
+            && version.bytes().all(|b| b.is_ascii_digit() || b == b'.');
+        assert!(
+            exact,
+            "the installer must be pinned to an exact version, not a range: {version}"
+        );
     }
 
     /// `surfpool start -m ../elsewhere/txtx.yml` scaffolds a tree the caller is not standing in,

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -145,7 +145,7 @@ const DEV_SKILL_REPO: &str = "https://github.com/solana-foundation/solana-dev-sk
 /// at the moment of someone's first scaffold, which is not a thing this can
 /// promise anyone. An exact version is the only form that resolves the same way
 /// twice; a range still floats to the newest release inside it.
-const DEV_SKILL_INSTALLER: &str = "skills@1.5.22";
+const DEV_SKILL_INSTALLER: &str = "skills@1.5.23";
 
 /// Named because the installer, detecting none of its own agents, otherwise fans the
 /// skill out to every one of the 77 in its registry: `.claude/`, a non-hidden `agent/`

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -137,10 +137,26 @@ impl ProgramMetadata {
 
 const DEV_SKILL_REPO: &str = "https://github.com/solana-foundation/solana-dev-skill";
 
-/// Builds the skill install exactly as issue #567 specifies it.
-fn dev_skill_install_command() -> Command {
+/// Pinned: an unversioned `npx skills` runs whatever the registry calls latest
+/// at the moment of someone's first scaffold, which is not a thing this can
+/// promise anyone. An exact version is the only form that resolves the same way
+/// twice; a range still floats to the newest release inside it.
+const DEV_SKILL_INSTALLER: &str = "skills@1.5.22";
+
+/// Builds the skill install as issue #567 specifies it, pinned, and rooted at
+/// the project being scaffolded rather than wherever the process happens to sit.
+fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     let mut command = Command::new("npx");
-    command.args(["-y", "skills", "add", DEV_SKILL_REPO, "--skill", "*", "-y"]);
+    command.args([
+        "-y",
+        DEV_SKILL_INSTALLER,
+        "add",
+        DEV_SKILL_REPO,
+        "--skill",
+        "*",
+        "-y",
+    ]);
+    command.current_dir(base_location.expect_path_buf());
     command
 }
 
@@ -236,10 +252,6 @@ pub fn scaffold_iac_layout(
     base_location: &FileLocation,
     auto_generate_runbooks: bool,
 ) -> Result<(), String> {
-    // Reached only when the project has no `txtx.yml` yet, so this is a first
-    // start; #567 asks for the skills here. Ahead of the prompts, to overlap.
-    spawn_dev_skill_install(dev_skill_install_command());
-
     let mut target_location = base_location.clone();
     target_location.append_path("target")?;
 
@@ -462,6 +474,9 @@ pub fn scaffold_iac_layout(
             //     "file {} already exists. choose a different runbook name, or rename the existing file",
             //     runbook_file_location.to_string()
             // ))
+            // The scaffold succeeded — `txtx.yml` and the runbooks tree are on
+            // disk — so the install belongs here too. No later start re-enters.
+            spawn_dev_skill_install(dev_skill_install_command(base_location));
             return Ok(());
         }
         false => {
@@ -546,17 +561,29 @@ pub fn scaffold_iac_layout(
         println!("Deployment canceled");
     }
 
+    // Last, so the install only ever follows a scaffold that finished. Every
+    // exit above this line is an `Err` from a `?`, prompt cancellations
+    // included, and leaves no install running behind it. The one exception is
+    // the early `Ok(())` when `main.tx` already exists, which is a finished
+    // scaffold and starts its own. `txtx.yml` is written well above here, so
+    // the next start is no longer a scaffold and neither call site can fire twice.
+    spawn_dev_skill_install(dev_skill_install_command(base_location));
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
+        path::Path,
         process::Command,
         time::{Duration, Instant},
     };
 
-    use super::{DEV_SKILL_REPO, dev_skill_install_command, spawn_dev_skill_install};
+    use super::{
+        DEV_SKILL_INSTALLER, DEV_SKILL_REPO, FileLocation, dev_skill_install_command,
+        spawn_dev_skill_install,
+    };
 
     #[cfg(unix)]
     fn sh(script: &str) -> Command {
@@ -566,14 +593,48 @@ mod tests {
     }
 
     /// #567 supplied this invocation literally: the `-y` flags keep it off a
-    /// prompt and `--skill "*"` is what makes it the whole bundle.
+    /// prompt and `--skill "*"` is what makes it the whole bundle. The one
+    /// departure from its text is the pinned version, which is here in full so
+    /// that dropping the pin has to fail this.
     #[test]
     fn the_install_is_the_command_issue_567_asked_for() {
-        let command = dev_skill_install_command();
+        let base = FileLocation::from_path_string("/tmp/surfpool-567-scaffold").unwrap();
+        let command = dev_skill_install_command(&base);
         assert_eq!(command.get_program(), "npx");
         assert_eq!(
             command.get_args().collect::<Vec<_>>(),
-            ["-y", "skills", "add", DEV_SKILL_REPO, "--skill", "*", "-y"]
+            [
+                "-y",
+                DEV_SKILL_INSTALLER,
+                "add",
+                DEV_SKILL_REPO,
+                "--skill",
+                "*",
+                "-y"
+            ]
+        );
+        let (package, version) = DEV_SKILL_INSTALLER
+            .split_once('@')
+            .expect("installer is pinned");
+        assert_eq!(package, "skills");
+        assert!(
+            version.split('.').count() == 3
+                && version
+                    .split('.')
+                    .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit())),
+            "the installer must stay pinned to an exact version, not a range: {version}"
+        );
+    }
+
+    /// The install writes into the project being scaffolded, which is the
+    /// manifest's directory rather than the shell's. `surfpool start -m
+    /// ../elsewhere/txtx.yml` scaffolds a tree the caller is not standing in.
+    #[test]
+    fn the_install_runs_in_the_scaffolded_project_not_the_process_cwd() {
+        let base = FileLocation::from_path_string("/tmp/surfpool-567-scaffold").unwrap();
+        assert_eq!(
+            dev_skill_install_command(&base).get_current_dir(),
+            Some(Path::new("/tmp/surfpool-567-scaffold"))
         );
     }
 

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -682,8 +682,11 @@ mod tests {
         command
     }
 
-    /// #567 supplied this invocation literally. The one departure from its text is the
-    /// pinned version, which is here in full so that dropping the pin has to fail this.
+    /// #567 supplied this invocation literally; we depart from its text twice. The pin is
+    /// spelled out here so that dropping it has to fail this. `--agent universal` is the
+    /// second: without it the installer detects none of its 77 registered agents, falls
+    /// through to fanout, and drops `.claude/`, a non-hidden `agent/` and `skills-lock.json`
+    /// into a project that asked for none of them.
     #[test]
     fn the_install_is_the_command_issue_567_asked_for() {
         let base = FileLocation::from_path_string("/tmp/surfpool-567-scaffold").unwrap();
@@ -706,17 +709,6 @@ mod tests {
         // "*" is the installer's own alias for every agent it knows, so naming one
         // agent and naming all of them are one typo apart.
         assert_ne!(DEV_SKILL_AGENT, "*");
-        let (package, version) = DEV_SKILL_INSTALLER
-            .split_once('@')
-            .expect("installer is pinned");
-        assert_eq!(package, "skills");
-        assert!(
-            version.split('.').count() == 3
-                && version
-                    .split('.')
-                    .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit())),
-            "the installer must stay pinned to an exact version, not a range: {version}"
-        );
     }
 
     /// `surfpool start -m ../elsewhere/txtx.yml` scaffolds a tree the caller is not standing in,
@@ -772,8 +764,6 @@ mod tests {
         }
     }
 
-    /// The property the old confirmation test guarded, re-expressed against the gate that
-    /// replaced it, with the memory the gate added.
     #[test]
     fn a_declined_prompt_starts_no_install_and_is_remembered() {
         let (base, home, location) = scratch();
@@ -793,8 +783,6 @@ mod tests {
         );
     }
 
-    /// The install writes a directory a third party owns, and #567's own installer currently
-    /// writes none, so a yes not written down here is a yes asked again on every scaffold.
     #[test]
     fn an_accepted_prompt_installs_and_is_remembered() {
         let (base, home, location) = scratch();
@@ -822,8 +810,6 @@ mod tests {
         assert!(dev_skill_answer(home.path()).is_none());
     }
 
-    /// The three ways this goes wrong on a real machine, in order: no Node at all, an install
-    /// that fails, an install that hangs. The scaffold is held by none of them.
     #[cfg(unix)]
     #[test]
     fn no_outcome_of_the_install_reaches_the_scaffold() {

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -643,13 +643,17 @@ pub fn scaffold_iac_layout(
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{self, File};
+    use std::{
+        fs::{self, File},
+        process::Command,
+        time::{Duration, Instant},
+    };
 
     use tempfile::TempDir;
 
     use super::{
         DEV_SKILL_ACCEPTED_MARKER, DEV_SKILL_DECLINED_MARKER, DEV_SKILL_DIR, FileLocation,
-        dev_skill_answer, dev_skill_install_if_wanted,
+        dev_skill_answer, dev_skill_install_if_wanted, spawn_dev_skill_install,
     };
 
     fn scratch() -> (TempDir, TempDir, FileLocation) {
@@ -657,6 +661,13 @@ mod tests {
         let home = TempDir::new().unwrap();
         let location = FileLocation::from_path_string(base.path().to_str().unwrap()).unwrap();
         (base, home, location)
+    }
+
+    #[cfg(unix)]
+    fn sh(script: &str) -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", script]);
+        command
     }
 
     #[test]
@@ -745,5 +756,20 @@ mod tests {
                 .is_none()
         );
         assert!(dev_skill_answer(home.path()).is_none());
+    }
+
+    /// An install that is missing, fails, or hangs does not delay the scaffold.
+    #[cfg(unix)]
+    #[test]
+    fn no_outcome_of_the_install_reaches_the_scaffold() {
+        let started = Instant::now();
+        spawn_dev_skill_install(Command::new("surfpool-567-no-such-binary"));
+        spawn_dev_skill_install(sh("exit 1"));
+        spawn_dev_skill_install(sh("sleep 30"));
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the scaffold waited on the install: {:?}",
+            started.elapsed()
+        );
     }
 }

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -154,6 +154,8 @@ const DEV_SKILL_DIR: &str = ".agents/skills/solana-dev";
 
 const DEV_SKILL_DECLINED_MARKER: &str = ".config/surfpool/dev-skill-declined";
 
+const DEV_SKILL_ACCEPTED_MARKER: &str = ".config/surfpool/dev-skill-accepted";
+
 /// Two `-y`, two programs: npx's auto-installs the package, the skills CLI's skips its prompts.
 fn dev_skill_install_command(base_location: &FileLocation) -> Command {
     let mut command = Command::new("npx");
@@ -192,8 +194,16 @@ fn dev_skill_installed(base: &Path, home: &Path) -> bool {
     base.join(DEV_SKILL_DIR).exists() || home.join(DEV_SKILL_DIR).exists()
 }
 
-fn dev_skill_declined(home: &Path) -> bool {
-    home.join(DEV_SKILL_DECLINED_MARKER).exists()
+/// Both answers are ours to keep: `DEV_SKILL_DIR` is written by an installer we neither wait on
+/// nor control, so a yes inferred from it is a yes asked again forever. A no wins a split pair.
+fn dev_skill_answer(home: &Path) -> Option<bool> {
+    if home.join(DEV_SKILL_DECLINED_MARKER).exists() {
+        Some(false)
+    } else if home.join(DEV_SKILL_ACCEPTED_MARKER).exists() {
+        Some(true)
+    } else {
+        None
+    }
 }
 
 fn prompt_for_dev_skill(theme: &ColorfulTheme) -> Option<bool> {
@@ -201,21 +211,23 @@ fn prompt_for_dev_skill(theme: &ColorfulTheme) -> Option<bool> {
         .with_prompt(format!(
             "Install the solana-dev skill? It writes {DEV_SKILL_DIR} and skills-lock.json here"
         ))
-        .default(true)
+        .default(false)
         .interact()
         .ok()
 }
 
-fn record_dev_skill_declined(home: &Path) {
-    let marker = home.join(DEV_SKILL_DECLINED_MARKER);
+fn record_dev_skill_answer(home: &Path, consented: bool) {
+    let marker = home.join(match consented {
+        true => DEV_SKILL_ACCEPTED_MARKER,
+        false => DEV_SKILL_DECLINED_MARKER,
+    });
     if let Some(parent) = marker.parent() {
         let _ = fs::create_dir_all(parent);
     }
     let _ = File::create(marker);
 }
 
-/// An install already on disk and a recorded no both outrank `--yes`, so a second scaffold stays
-/// silent and a machine that has declined once is never asked again. Paths are arguments so the
+/// A recorded answer and an install on disk both outrank `--yes`. Paths are arguments so the
 /// gate is testable without a real home directory.
 fn dev_skill_install_if_wanted(
     base_location: &FileLocation,
@@ -224,16 +236,16 @@ fn dev_skill_install_if_wanted(
     auto_accept: bool,
     ask: impl FnOnce() -> Option<bool>,
 ) -> Option<Command> {
-    if dev_skill_installed(base, home) || dev_skill_declined(home) {
+    if dev_skill_installed(base, home) {
         return None;
     }
-    let consented = match auto_accept {
-        true => true,
-        false => match ask() {
-            Some(true) => true,
-            Some(false) => {
-                record_dev_skill_declined(home);
-                false
+    let consented = match dev_skill_answer(home) {
+        Some(recorded) => recorded,
+        None if auto_accept => true,
+        None => match ask() {
+            Some(answer) => {
+                record_dev_skill_answer(home, answer);
+                answer
             }
             // A prompt that could not be shown is not an answer, so nothing is recorded.
             None => false,
@@ -632,7 +644,7 @@ pub fn scaffold_iac_layout(
         || prompt_for_dev_skill(&theme),
     ) {
         spawn_dev_skill_install(command);
-        println!("{} {}", green!("Installing"), DEV_SKILL_DIR);
+        println!("{} {}", green!("Started installer for"), DEV_SKILL_DIR);
     }
 
     Ok(())
@@ -651,8 +663,8 @@ mod tests {
 
     use super::{
         DEV_SKILL_AGENT, DEV_SKILL_DECLINED_MARKER, DEV_SKILL_DIR, DEV_SKILL_INSTALLER,
-        DEV_SKILL_REPO, FileLocation, dev_skill_install_command, dev_skill_install_if_wanted,
-        spawn_dev_skill_install,
+        DEV_SKILL_REPO, FileLocation, dev_skill_answer, dev_skill_install_command,
+        dev_skill_install_if_wanted, spawn_dev_skill_install,
     };
 
     /// Every gate test runs against these, never a real home directory.
@@ -781,16 +793,21 @@ mod tests {
         );
     }
 
-    /// A yes is deliberately not written down: installs are per project, so the question is
-    /// asked per project.
+    /// The install writes a directory a third party owns, and #567's own installer currently
+    /// writes none, so a yes not written down here is a yes asked again on every scaffold.
     #[test]
-    fn an_accepted_prompt_installs_and_records_nothing() {
+    fn an_accepted_prompt_installs_and_is_remembered() {
         let (base, home, location) = scratch();
         assert!(
             dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || Some(true))
                 .is_some()
         );
-        assert!(!home.path().join(DEV_SKILL_DECLINED_MARKER).exists());
+        assert!(
+            dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || {
+                panic!("the recorded accept must not prompt again")
+            })
+            .is_some()
+        );
     }
 
     /// A prompt that could not be shown is not a decline, so it is not remembered as one and
@@ -802,7 +819,7 @@ mod tests {
             dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || None)
                 .is_none()
         );
-        assert!(!home.path().join(DEV_SKILL_DECLINED_MARKER).exists());
+        assert!(dev_skill_answer(home.path()).is_none());
     }
 
     /// The three ways this goes wrong on a real machine, in order: no Node at all, an install

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -221,6 +221,7 @@ fn record_dev_skill_answer(home: &Path, consented: bool) {
     let _ = File::create(marker);
 }
 
+/// Returns the command to install the solana-dev skill, or `None` if it should not be installed.
 fn dev_skill_install_if_wanted(
     base_location: &FileLocation,
     base: &Path,

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -235,6 +235,7 @@ fn dev_skill_install_if_wanted(
                 record_dev_skill_declined(home);
                 false
             }
+            // A prompt that could not be shown is not an answer, so nothing is recorded.
             None => false,
         },
     };
@@ -796,6 +797,18 @@ mod tests {
         assert!(
             dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || Some(true))
                 .is_some()
+        );
+        assert!(!home.path().join(DEV_SKILL_DECLINED_MARKER).exists());
+    }
+
+    /// A prompt that could not be shown is not a decline, so it is not remembered as one and
+    /// the next scaffold still asks.
+    #[test]
+    fn an_undisplayable_prompt_installs_nothing_and_records_nothing() {
+        let (base, home, location) = scratch();
+        assert!(
+            dev_skill_install_if_wanted(&location, base.path(), home.path(), false, || None)
+                .is_none()
         );
         assert!(!home.path().join(DEV_SKILL_DECLINED_MARKER).exists());
     }


### PR DESCRIPTION
Implements #567.

On the first `surfpool start` that scaffolds a `txtx.yml`:

    npx -y skills@1.5.23 add https://github.com/solana-foundation/solana-dev-skill --skill "*" --agent universal -y

Behind a prompt, not automatic. An existing `.agents/skills/solana-dev` in the project or `$HOME` skips it silently. Otherwise the answer is written to `~/.config/surfpool/dev-skill-{accepted,declined}`; only a yes installs, a decline is never asked twice, and `--yes` alone skips and says so. On a yes the child is spawned detached; its outcome reaches the user as a simnet event once it exits, so the scaffold never blocks on it.

The version is pinned so a first scaffold runs a known `skills` rather than whatever is latest that day. `--agent universal` is the installer's own key for the canonical `.agents/skills` copy; without it it detects none of its 77 registered agents and fans the skill out to all of them, dropping `.claude/`, a non-hidden `agent/` and `skills-lock.json` into a project that asked for none.

Nine tests cover it: the already-installed skip, `--yes` deciding nothing on its own and using a recorded answer, both prompt answers surviving a re-entry, an undisplayable prompt recording nothing, the two install outcomes being reported, and both reaching the user.

+370 / -8, two files. 
