### PR TITLE
fix(core): honor commitment for remote account batches

### DIFF
--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -311,9 +311,10 @@ impl SurfnetRemoteClient {
 
         let remote_accounts = self
             .client
-            .get_multiple_accounts(pubkeys)
+            .get_multiple_accounts_with_commitment(pubkeys, commitment_config)
             .await
-            .map_err(SurfpoolError::get_multiple_accounts)?;
+            .map_err(SurfpoolError::get_multiple_accounts)?
+            .value;
         debug!("Fetched {:?} accounts from remote", pubkeys);
         debug!(
             "Found accounts for pubkeys: {:#?}",
@@ -854,6 +855,62 @@ mod tests {
                 }
             }
         }
+    }
+
+    struct RecordsRequests {
+        requests: Arc<Mutex<Vec<(RpcRequest, serde_json::Value)>>>,
+    }
+
+    #[async_trait]
+    impl RpcSender for RecordsRequests {
+        async fn send(
+            &self,
+            request: RpcRequest,
+            params: serde_json::Value,
+        ) -> ClientResult<serde_json::Value> {
+            self.requests
+                .lock()
+                .expect("request recorder mutex should not be poisoned")
+                .push((request, params));
+            Ok(json!({
+                "context": { "slot": 1 },
+                "value": [null],
+            }))
+        }
+
+        fn get_transport_stats(&self) -> RpcTransportStats {
+            RpcTransportStats::default()
+        }
+
+        fn url(&self) -> String {
+            "http://records.example".to_string()
+        }
+    }
+
+    #[tokio::test]
+    async fn multiple_account_fetch_uses_the_requested_commitment() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let client = SurfnetRemoteClient {
+            client: RpcClient::new_sender(
+                RecordsRequests {
+                    requests: Arc::clone(&requests),
+                },
+                RpcClientConfig::default(),
+            ),
+        };
+
+        let pubkey = Pubkey::new_unique();
+        client
+            .get_multiple_accounts(&[pubkey], CommitmentConfig::confirmed())
+            .await
+            .expect("remote account fetch should succeed");
+
+        let requests = requests
+            .lock()
+            .expect("request recorder mutex should not be poisoned");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].0, RpcRequest::GetMultipleAccounts);
+        assert_eq!(requests[0].1[1]["commitment"], "confirmed");
     }
 
     /// A call that never completes, whether because the endpoint went quiet


### PR DESCRIPTION
## Summary

`SurfnetRemoteClient::get_multiple_accounts` accepts a caller-selected commitment, but its primary account batch used `RpcClient::get_multiple_accounts`, which silently applied the client's default commitment. Companion mint/program-account fetches in the same method already used the requested commitment.

Use `get_multiple_accounts_with_commitment` for the primary batch as well, then extract the contextual response value. This keeps every remote account fetched by the operation at the same requested commitment.

## Regression test

The new test records the outgoing JSON-RPC request through a custom `RpcSender`. It requests `confirmed` and asserts that the `getMultipleAccounts` config actually contains `"commitment": "confirmed"`; before this patch it observed `"finalized"`.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test -p surfpool-core surfnet::remote::tests -- --test-threads=1` — 3 passed
- `cargo clippy -p surfpool-core --lib --no-default-features` — completed with existing repository warnings only
- `git diff --check`

I also attempted the complete `surfpool-core` lib suite locally. It reached 469 passing tests before the shared runner exhausted its open-file limit; the remaining failures reported `Too many open files`, rather than assertion failures from this change. GitHub CI can run the full suite in its normal environment.
