### PR TITLE
fix(core): refactor account update to prevent race condition

### DIFF
--- a/crates/core/src/rpc/accounts_data.rs
+++ b/crates/core/src/rpc/accounts_data.rs
@@ -705,7 +705,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        surfnet::{GetAccountResult, remote::SurfnetRemoteClient, svm::AccountUpdatePolicy},
+        surfnet::{
+            AccountSource, GetAccountResult, remote::SurfnetRemoteClient, svm::AccountUpdatePolicy,
+        },
         tests::helpers::TestSetup,
         types::SyntheticBlockhash,
     };
@@ -745,7 +747,7 @@ mod tests {
             .context
             .svm_locker
             .apply_account_update(
-                GetAccountResult::FoundAccount(mint_pk, mint_account, true),
+                GetAccountResult::FoundAccount(mint_pk, mint_account, AccountSource::Generated),
                 AccountUpdatePolicy::Authoritative,
             )
             .unwrap();
@@ -781,7 +783,11 @@ mod tests {
             .context
             .svm_locker
             .apply_account_update(
-                GetAccountResult::FoundAccount(token_account_pk, token_account, true),
+                GetAccountResult::FoundAccount(
+                    token_account_pk,
+                    token_account,
+                    AccountSource::Generated,
+                ),
                 AccountUpdatePolicy::Authoritative,
             )
             .unwrap();
@@ -1562,7 +1568,7 @@ mod tests {
             .context
             .svm_locker
             .apply_account_update(
-                GetAccountResult::FoundAccount(pk1, account1, true),
+                GetAccountResult::FoundAccount(pk1, account1, AccountSource::Generated),
                 AccountUpdatePolicy::Authoritative,
             )
             .unwrap();
@@ -1570,7 +1576,7 @@ mod tests {
             .context
             .svm_locker
             .apply_account_update(
-                GetAccountResult::FoundAccount(pk3, account3, true),
+                GetAccountResult::FoundAccount(pk3, account3, AccountSource::Generated),
                 AccountUpdatePolicy::Authoritative,
             )
             .unwrap();

--- a/crates/core/src/rpc/accounts_data.rs
+++ b/crates/core/src/rpc/accounts_data.rs
@@ -383,8 +383,6 @@ impl AccountsData for SurfpoolAccountsDataRpc {
             if let Some(m) = crate::telemetry::metrics() {
                 m.record_rpc_request("getAccountInfo", rpc_start.elapsed().as_millis() as u64);
             }
-            svm_locker.write_account_update(account_update.clone());
-
             let ui_account = if let Some(((pubkey, account), token_data)) =
                 account_update.map_account_with_token_data()
             {
@@ -452,8 +450,6 @@ impl AccountsData for SurfpoolAccountsDataRpc {
                     rpc_start.elapsed().as_millis() as u64,
                 );
             }
-
-            svm_locker.write_multiple_account_updates(&account_updates);
 
             // Convert account updates to UI accounts, order is already preserved by get_multiple_accounts
             let mut ui_accounts = vec![];
@@ -544,8 +540,6 @@ impl AccountsData for SurfpoolAccountsDataRpc {
                 .await?
                 .inner;
 
-            svm_locker.write_account_update(token_account_result.clone());
-
             let token_account = token_account_result.map_account()?;
 
             let (mint_pubkey, _amount) = if is_supported_token_program(&token_account.owner) {
@@ -570,8 +564,6 @@ impl AccountsData for SurfpoolAccountsDataRpc {
             } = svm_locker
                 .get_account(&remote_ctx, &mint_pubkey, None)
                 .await?;
-
-            svm_locker.write_account_update(mint_account_result.clone());
 
             let mint_account = mint_account_result.map_account()?;
 
@@ -634,8 +626,6 @@ impl AccountsData for SurfpoolAccountsDataRpc {
             } = svm_locker
                 .get_account(&remote_ctx, &mint_pubkey, None)
                 .await?;
-
-            svm_locker.write_account_update(mint_account_result.clone());
 
             let mint_account = mint_account_result.map_account()?;
 
@@ -715,7 +705,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        surfnet::{GetAccountResult, remote::SurfnetRemoteClient},
+        surfnet::{GetAccountResult, remote::SurfnetRemoteClient, svm::AccountUpdatePolicy},
         tests::helpers::TestSetup,
         types::SyntheticBlockhash,
     };
@@ -754,7 +744,11 @@ mod tests {
         setup
             .context
             .svm_locker
-            .write_account_update(GetAccountResult::FoundAccount(mint_pk, mint_account, true));
+            .apply_account_update(
+                GetAccountResult::FoundAccount(mint_pk, mint_account, true),
+                AccountUpdatePolicy::Authoritative,
+            )
+            .unwrap();
 
         let token_account_pk = Pubkey::new_unique();
 
@@ -786,11 +780,11 @@ mod tests {
         setup
             .context
             .svm_locker
-            .write_account_update(GetAccountResult::FoundAccount(
-                token_account_pk,
-                token_account,
-                true,
-            ));
+            .apply_account_update(
+                GetAccountResult::FoundAccount(token_account_pk, token_account, true),
+                AccountUpdatePolicy::Authoritative,
+            )
+            .unwrap();
 
         let res = setup
             .rpc
@@ -1567,11 +1561,19 @@ mod tests {
         setup
             .context
             .svm_locker
-            .write_account_update(GetAccountResult::FoundAccount(pk1, account1, true));
+            .apply_account_update(
+                GetAccountResult::FoundAccount(pk1, account1, true),
+                AccountUpdatePolicy::Authoritative,
+            )
+            .unwrap();
         setup
             .context
             .svm_locker
-            .write_account_update(GetAccountResult::FoundAccount(pk3, account3, true));
+            .apply_account_update(
+                GetAccountResult::FoundAccount(pk3, account3, true),
+                AccountUpdatePolicy::Authoritative,
+            )
+            .unwrap();
 
         // Request accounts in order: [pk1, pk2, pk3]
         // pk1 and pk3 are local, pk2 is missing (will try remote fetch and fail)

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -48,7 +48,7 @@ use crate::{
     error::{SurfpoolError, SurfpoolResult},
     rpc::utils::{adjust_default_transaction_config, get_default_transaction_config},
     surfnet::{
-        FINALIZATION_SLOT_THRESHOLD, GetAccountResult, GetTransactionResult,
+        CoupledAccount, FINALIZATION_SLOT_THRESHOLD, GetAccountResult, GetTransactionResult,
         locker::SvmAccessContext, svm::MAX_RECENT_BLOCKHASHES_STANDARD,
     },
     types::{SurfnetTransactionStatus, surfpool_tx_metadata_to_litesvm_tx_metadata},
@@ -1901,9 +1901,10 @@ impl Full for SurfpoolFullRpc {
                         }
                     }
                     // According to SIMD 0186, program data is tracked as well as program accounts
-                    GetAccountResult::FoundProgramAccount(
+                    GetAccountResult::FoundCoupledAccount(
                         (pubkey, account),
-                        (pd_pubkey, pd_account),
+                        CoupledAccount::ProgramData(pd_pubkey, pd_account),
+                        _,
                     ) => {
                         if seen_accounts.insert(*pubkey) {
                             loaded_accounts_data_size += account.data.len() as u64;
@@ -1914,9 +1915,10 @@ impl Full for SurfpoolFullRpc {
                             }
                         }
                     }
-                    GetAccountResult::FoundTokenAccount(
+                    GetAccountResult::FoundCoupledAccount(
                         (pubkey, account),
-                        (td_pubkey, td_account),
+                        CoupledAccount::Mint(td_pubkey, td_account),
+                        _,
                     ) => {
                         if seen_accounts.insert(*pubkey) {
                             loaded_accounts_data_size += account.data.len() as u64;

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -1937,8 +1937,6 @@ impl Full for SurfpoolFullRpc {
                 track_accounts_data_size(res);
             }
 
-            svm_locker.write_multiple_account_updates(&account_updates);
-
             // Convert TransactionLoadedAddresses to LoadedAddresses before it gets consumed
             let loaded_addresses_data = loaded_addresses.as_ref().map(|la| la.loaded_addresses());
 
@@ -1950,7 +1948,6 @@ impl Full for SurfpoolFullRpc {
                 for res in alt_updates.iter() {
                     track_accounts_data_size(res);
                 }
-                svm_locker.write_multiple_account_updates(&alt_updates);
             }
 
             let replacement_blockhash = if config.replace_recent_blockhash {

--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -1047,8 +1047,7 @@ async fn snapshot_accounts(
                 }
             }
             crate::surfnet::GetAccountResult::FoundAccount(_, account, _)
-            | crate::surfnet::GetAccountResult::FoundProgramAccount((_, account), _)
-            | crate::surfnet::GetAccountResult::FoundTokenAccount((_, account), _) => {
+            | crate::surfnet::GetAccountResult::FoundCoupledAccount((_, account), _, _) => {
                 account.clone()
             }
         };

--- a/crates/core/src/rpc/minimal.rs
+++ b/crates/core/src/rpc/minimal.rs
@@ -631,8 +631,6 @@ impl Minimal for SurfpoolMinimalRpc {
                 GetAccountResult::None(_) => 0,
             };
 
-            svm_locker.write_account_update(account_update);
-
             #[cfg(feature = "prometheus")]
             if let Some(m) = crate::telemetry::metrics() {
                 m.record_rpc_request("getBalance", rpc_start.elapsed().as_millis() as u64);

--- a/crates/core/src/rpc/minimal.rs
+++ b/crates/core/src/rpc/minimal.rs
@@ -626,8 +626,7 @@ impl Minimal for SurfpoolMinimalRpc {
 
             let balance = match &account_update {
                 GetAccountResult::FoundAccount(_, account, _)
-                | GetAccountResult::FoundProgramAccount((_, account), _)
-                | GetAccountResult::FoundTokenAccount((_, account), _) => account.lamports,
+                | GetAccountResult::FoundCoupledAccount((_, account), _, _) => account.lamports,
                 GetAccountResult::None(_) => 0,
             };
 

--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -30,7 +30,9 @@ use crate::{
         State,
         utils::{decode_and_deserialize, verify_pubkey, verify_pubkeys},
     },
-    surfnet::{GetAccountResult, locker::SvmAccessContext, svm::AccountUpdatePolicy},
+    surfnet::{
+        AccountSource, GetAccountResult, locker::SvmAccessContext, svm::AccountUpdatePolicy,
+    },
     types::{
         TimeTravelConfig, TokenAccount, build_confidential_token_account_data,
         mint_has_transfer_fee_config,
@@ -1422,7 +1424,7 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
         Box::pin(async move {
             let (account_to_set, latest_absolute_slot) = if let Some(account) = account_update_opt {
                 (
-                    GetAccountResult::FoundAccount(pubkey, account, true),
+                    GetAccountResult::FoundAccount(pubkey, account, AccountSource::Generated),
                     svm_locker.get_latest_absolute_slot(),
                 )
             } else {
@@ -1445,7 +1447,7 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
                                     rent_epoch: 0,
                                     data: vec![],
                                 },
-                                true, // indicate that the account should be updated in the SVM, since it's new
+                                AccountSource::Generated,
                             )
                 }))).await?;
 
@@ -1676,7 +1678,7 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
                                 rent_epoch: 0,
                                 data,
                             },
-                            true, // indicate that the account should be updated in the SVM, since it's new
+                            AccountSource::Generated,
                         )
                     })),
                 )

--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -30,7 +30,7 @@ use crate::{
         State,
         utils::{decode_and_deserialize, verify_pubkey, verify_pubkeys},
     },
-    surfnet::{GetAccountResult, locker::SvmAccessContext},
+    surfnet::{GetAccountResult, locker::SvmAccessContext, svm::AccountUpdatePolicy},
     types::{
         TimeTravelConfig, TokenAccount, build_confidential_token_account_data,
         mint_has_transfer_fee_config,
@@ -1453,7 +1453,7 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
                 (account_result_to_update, slot)
             };
 
-            svm_locker.write_account_update(account_to_set);
+            svm_locker.apply_account_update(account_to_set, AccountUpdatePolicy::Authoritative)?;
 
             Ok(RpcResponse {
                 context: RpcResponseContext::new(latest_absolute_slot),
@@ -1642,8 +1642,6 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
             let mint_has_transfer_fee = confidential.is_some()
                 && !get_mint_result.is_none()
                 && mint_has_transfer_fee_config(get_mint_result.expected_data());
-            svm_locker.write_account_update(get_mint_result);
-
             let minimum_rent = svm_locker.with_svm_reader(|svm_reader| {
                 svm_reader.inner.minimum_balance_for_rent_exemption(
                     TokenAccount::get_packed_len_for_token_program_id(&token_program_id),
@@ -1722,7 +1720,7 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
                 account.data = final_account_bytes.clone();
                 Ok(())
             })?;
-            svm_locker.write_account_update(token_account);
+            svm_locker.apply_account_update(token_account, AccountUpdatePolicy::Authoritative)?;
 
             Ok(RpcResponse {
                 context: RpcResponseContext::new(slot),

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -577,11 +577,6 @@ pub async fn start_block_production_runloop(
                                 .await
                             {
                                 Ok(account_updates) => {
-                                    // The locker holds one write guard while applying the complete
-                                    // batch, so Ready cannot expose a partially installed clone set.
-                                    svm_locker
-                                        .write_multiple_account_updates(&account_updates.inner);
-
                                     // A cloned account the datasource does not have is not a
                                     // failure: hydration did complete, and some workflows clone
                                     // addresses that do not exist yet. Warn, though, because the

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -45,7 +45,7 @@ use crate::{
         surfnet_cheatcodes::SurfnetCheatcodes, ws::Rpc,
     },
     surfnet::{
-        GetAccountResult, GeyserEvent, PluginCommand, locker::SurfnetSvmLocker,
+        AccountSource, GetAccountResult, GeyserEvent, PluginCommand, locker::SurfnetSvmLocker,
         remote::SurfnetRemoteClient,
     },
 };
@@ -1166,7 +1166,7 @@ mod absent_after_hydration_tests {
         let results = vec![
             GetAccountResult::None(missing),
             GetAccountResult::None(offline),
-            GetAccountResult::FoundAccount(found, Account::default(), true),
+            GetAccountResult::FoundAccount(found, Account::default(), AccountSource::Generated),
         ];
 
         assert_eq!(

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -379,7 +379,47 @@ impl SurfnetSvmLocker {
             )?;
         }
 
-        Ok(fetched_account)
+        Self::refresh_coupled_account(svm_writer, fetched_account)
+    }
+
+    /// Rebuilds the returned coupled result from the state that is now live in
+    /// LiteSVM. Hydration may intentionally keep a newer local dependency,
+    /// so returning the original fetched composite would expose stale data to
+    /// callers even though the SVM itself is correct.
+    fn refresh_coupled_account(
+        svm_writer: &SurfnetSvm,
+        account_result: GetAccountResult,
+    ) -> SurfpoolResult<GetAccountResult> {
+        let GetAccountResult::FoundCoupledAccount((pubkey, account), coupled, source) =
+            account_result
+        else {
+            return Ok(account_result);
+        };
+
+        let coupled = match coupled {
+            CoupledAccount::ProgramData(coupled_pubkey, fallback_account) => {
+                let local = svm_writer.inner.get_account_result(&coupled_pubkey)?;
+                let account = match local {
+                    GetAccountResult::None(_) => fallback_account,
+                    local => Some(local.map_account()?),
+                };
+                CoupledAccount::ProgramData(coupled_pubkey, account)
+            }
+            CoupledAccount::Mint(coupled_pubkey, fallback_account) => {
+                let local = svm_writer.inner.get_account_result(&coupled_pubkey)?;
+                let account = match local {
+                    GetAccountResult::None(_) => fallback_account,
+                    local => Some(local.map_account()?),
+                };
+                CoupledAccount::Mint(coupled_pubkey, account)
+            }
+        };
+
+        Ok(GetAccountResult::FoundCoupledAccount(
+            (pubkey, account),
+            coupled,
+            source,
+        ))
     }
 
     fn offline_account_owners(svm_writer: &SurfnetSvm) -> Vec<Pubkey> {
@@ -4680,7 +4720,7 @@ mod tests {
                 .unwrap();
         });
 
-        locker
+        let resolved = locker
             .resolve_account_after_fetch(
                 primary,
                 Some(GetAccountResult::FoundCoupledAccount(
@@ -4690,6 +4730,15 @@ mod tests {
                 )),
             )
             .unwrap();
+
+        match resolved.inner {
+            GetAccountResult::FoundCoupledAccount(
+                (_, _),
+                CoupledAccount::Mint(_, Some(returned_dependency)),
+                _,
+            ) => assert_eq!(returned_dependency, local_dependency),
+            other => panic!("expected a coupled token result, got {other:?}"),
+        }
 
         locker.with_svm_reader(|svm| {
             assert_eq!(

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -64,8 +64,9 @@ use txtx_addon_kit::indexmap::IndexSet;
 use uuid::Uuid;
 
 use super::{
-    AccountFactory, GetAccountResult, GetTransactionResult, GeyserEvent, SignatureSubscriptionType,
-    SurfnetSvm, remote::SurfnetRemoteClient, svm::AccountUpdatePolicy,
+    AccountFactory, AccountSource, CoupledAccount, GetAccountResult, GetTransactionResult,
+    GeyserEvent, SignatureSubscriptionType, SurfnetSvm, remote::SurfnetRemoteClient,
+    svm::AccountUpdatePolicy,
 };
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
@@ -283,8 +284,7 @@ impl SurfnetSvmLocker {
     ) -> GetAccountResult {
         match result {
             GetAccountResult::FoundAccount(_, account, _)
-            | GetAccountResult::FoundProgramAccount((_, account), _)
-            | GetAccountResult::FoundTokenAccount((_, account), _)
+            | GetAccountResult::FoundCoupledAccount((_, account), _, _)
                 if offline_owners.contains(&account.owner) =>
             {
                 GetAccountResult::None(*requested_pubkey)
@@ -344,7 +344,11 @@ impl SurfnetSvmLocker {
     ) -> SurfpoolResult<GetAccountResult> {
         let local_account = svm_writer.inner.get_account_result(&pubkey)?;
         if !local_account.is_none() {
-            if local_account.requires_update() {
+            if local_account
+                .source()
+                .and_then(AccountUpdatePolicy::for_source)
+                .is_some()
+            {
                 svm_writer.apply_account_update(
                     local_account.clone(),
                     AccountUpdatePolicy::HydrateIfAbsent,
@@ -424,7 +428,12 @@ impl SurfnetSvmLocker {
             } else {
                 Ok(result)
             }
-        } else if result.inner.requires_update() {
+        } else if result
+            .inner
+            .source()
+            .and_then(AccountUpdatePolicy::for_source)
+            .is_some()
+        {
             // An account read from the configured database must be restored to
             // LiteSVM. Re-check under the write lock so a concurrent local
             // write wins over the stale database value.
@@ -446,7 +455,12 @@ impl SurfnetSvmLocker {
                 .await?
         } else {
             let result = self.get_account_local(pubkey);
-            if result.inner.requires_update() {
+            if result
+                .inner
+                .source()
+                .and_then(AccountUpdatePolicy::for_source)
+                .is_some()
+            {
                 self.resolve_account_after_fetch(*pubkey, None)?
             } else {
                 result
@@ -509,7 +523,12 @@ impl SurfnetSvmLocker {
         }
 
         if missing_accounts.is_empty() {
-            if local_results.iter().any(GetAccountResult::requires_update) {
+            if local_results.iter().any(|result| {
+                result
+                    .source()
+                    .and_then(AccountUpdatePolicy::for_source)
+                    .is_some()
+            }) {
                 return self.resolve_accounts_after_fetch(pubkeys, HashMap::new());
             }
 
@@ -558,7 +577,12 @@ impl SurfnetSvmLocker {
             .await?
         } else {
             let results = self.get_multiple_accounts_local(pubkeys);
-            if results.inner.iter().any(GetAccountResult::requires_update) {
+            if results.inner.iter().any(|result| {
+                result
+                    .source()
+                    .and_then(AccountUpdatePolicy::for_source)
+                    .is_some()
+            }) {
                 self.resolve_accounts_after_fetch(pubkeys, HashMap::new())?
             } else {
                 results
@@ -695,18 +719,20 @@ impl SurfnetSvmLocker {
                                 GetAccountResult::FoundAccount(_, account, _) => {
                                     accounts_to_load.push((*pubkey, account, true));
                                 }
-                                GetAccountResult::FoundProgramAccount(
+                                GetAccountResult::FoundCoupledAccount(
                                     (program_pubkey, program_account),
-                                    (data_pubkey, data_account_opt),
+                                    CoupledAccount::ProgramData(data_pubkey, data_account_opt),
+                                    _,
                                 ) => {
                                     accounts_to_load.push((program_pubkey, program_account, true));
                                     if let Some(data_account) = data_account_opt {
                                         accounts_to_load.push((data_pubkey, data_account, true));
                                     }
                                 }
-                                GetAccountResult::FoundTokenAccount(
+                                GetAccountResult::FoundCoupledAccount(
                                     (token_pubkey, token_account),
-                                    (mint_pubkey, mint_account_opt),
+                                    CoupledAccount::Mint(mint_pubkey, mint_account_opt),
+                                    _,
                                 ) => {
                                     accounts_to_load.push((token_pubkey, token_account, true));
                                     if let Some(mint_account) = mint_account_opt {
@@ -738,7 +764,11 @@ impl SurfnetSvmLocker {
             for (pubkey, account, fetched_from_remote) in accounts_to_load {
                 let load_result = if fetched_from_remote {
                     svm.apply_account_update(
-                        GetAccountResult::FoundAccount(pubkey, account.clone(), true),
+                        GetAccountResult::FoundAccount(
+                            pubkey,
+                            account.clone(),
+                            AccountSource::Remote,
+                        ),
                         AccountUpdatePolicy::HydrateIfAbsent,
                     )
                 } else {
@@ -1838,8 +1868,7 @@ impl SurfnetSvmLocker {
                         capture.insert(pubkey, None);
                     }
                     GetAccountResult::FoundAccount(pubkey, account, _)
-                    | GetAccountResult::FoundProgramAccount((pubkey, account), _)
-                    | GetAccountResult::FoundTokenAccount((pubkey, account), _) => {
+                    | GetAccountResult::FoundCoupledAccount((pubkey, account), _, _) => {
                         capture.insert(pubkey, Some(account));
                     }
                 }
@@ -3494,15 +3523,18 @@ impl SurfnetSvmLocker {
                             new_authority,
                         )?;
 
-                        get_account_result = GetAccountResult::FoundProgramAccount(
+                        get_account_result = GetAccountResult::FoundCoupledAccount(
                             (*pubkey, program_account.clone()),
-                            (programdata_address, Some(programdata_account.clone())),
+                            CoupledAccount::ProgramData(
+                                programdata_address,
+                                Some(programdata_account.clone()),
+                            ),
+                            AccountSource::Generated,
                         );
 
                         original_authority
                     }
-                    GetAccountResult::FoundProgramAccount(_, _)
-                    | GetAccountResult::FoundTokenAccount(_, _) => {
+                    GetAccountResult::FoundCoupledAccount(_, _, _) => {
                         return Err(SurfpoolError::invalid_program_account(
                             pubkey,
                             "Not a program account",
@@ -3510,16 +3542,18 @@ impl SurfnetSvmLocker {
                     }
                 }
             }
-            GetAccountResult::FoundProgramAccount(_, (_, None)) => {
+            GetAccountResult::FoundCoupledAccount(_, CoupledAccount::ProgramData(_, None), _) => {
                 return Err(SurfpoolError::invalid_program_account(
                     program_id,
                     "Program data account does not exist",
                 ));
             }
-            GetAccountResult::FoundProgramAccount(_, (_, Some(programdata_account))) => {
-                update_programdata_account(&program_id, programdata_account, new_authority)?
-            }
-            GetAccountResult::FoundTokenAccount(_, _) => {
+            GetAccountResult::FoundCoupledAccount(
+                _,
+                CoupledAccount::ProgramData(_, Some(programdata_account)),
+                _,
+            ) => update_programdata_account(&program_id, programdata_account, new_authority)?,
+            GetAccountResult::FoundCoupledAccount(_, CoupledAccount::Mint(_, _), _) => {
                 return Err(SurfpoolError::invalid_program_account(
                     program_id,
                     "Not a program account",
@@ -4168,7 +4202,7 @@ impl SurfnetSvmLocker {
                             executable: true,
                             rent_epoch: 0,
                         },
-                        true,
+                        AccountSource::Generated,
                     )
                 })),
             )
@@ -4177,7 +4211,7 @@ impl SurfnetSvmLocker {
         // Check if account was created before consuming it
         let was_program_created = matches!(
             program_account_result,
-            GetAccountResult::FoundAccount(_, _, true)
+            GetAccountResult::FoundAccount(_, _, AccountSource::Generated)
         );
 
         // Ensure we have a valid program account
@@ -4202,7 +4236,11 @@ impl SurfnetSvmLocker {
         // Persist the program account if it was newly created
         if was_program_created {
             self.apply_account_update(
-                GetAccountResult::FoundAccount(program_id, program_account.clone(), true),
+                GetAccountResult::FoundAccount(
+                    program_id,
+                    program_account.clone(),
+                    AccountSource::Generated,
+                ),
                 AccountUpdatePolicy::Authoritative,
             )?;
         }
@@ -4263,7 +4301,7 @@ impl SurfnetSvmLocker {
                             executable: false,
                             rent_epoch: 0,
                         },
-                        true,
+                        AccountSource::Generated,
                     )
                 })),
             )
@@ -4541,7 +4579,7 @@ mod tests {
                 executable: false,
                 rent_epoch: 0,
             },
-            true,
+            AccountSource::Remote,
         );
 
         // This represents a request that observed the account as absent and
@@ -4645,9 +4683,10 @@ mod tests {
         locker
             .resolve_account_after_fetch(
                 primary,
-                Some(GetAccountResult::FoundTokenAccount(
+                Some(GetAccountResult::FoundCoupledAccount(
                     (primary, remote_primary),
-                    (dependency, Some(remote_dependency)),
+                    CoupledAccount::Mint(dependency, Some(remote_dependency)),
+                    AccountSource::Remote,
                 )),
             )
             .unwrap();
@@ -4698,7 +4737,7 @@ mod tests {
                         executable: false,
                         rent_epoch: 0,
                     },
-                    true,
+                    AccountSource::Remote,
                 ),
             ),
             (
@@ -4712,7 +4751,7 @@ mod tests {
                         executable: false,
                         rent_epoch: 0,
                     },
-                    true,
+                    AccountSource::Remote,
                 ),
             ),
         ]);

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -65,7 +65,7 @@ use uuid::Uuid;
 
 use super::{
     AccountFactory, GetAccountResult, GetTransactionResult, GeyserEvent, SignatureSubscriptionType,
-    SurfnetSvm, remote::SurfnetRemoteClient,
+    SurfnetSvm, remote::SurfnetRemoteClient, svm::AccountUpdatePolicy,
 };
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
@@ -293,6 +293,110 @@ impl SurfnetSvmLocker {
         }
     }
 
+    /// Re-checks local state after an asynchronous fetch, returning the local
+    /// account when another writer won the race.
+    fn resolve_account_after_fetch(
+        &self,
+        pubkey: Pubkey,
+        fetched_account: Option<GetAccountResult>,
+    ) -> SurfpoolContextualizedResult<GetAccountResult> {
+        self.with_svm_writer(move |svm_writer| {
+            let account = Self::resolve_fetched_account(svm_writer, pubkey, fetched_account)?;
+            Ok(SvmAccessContext::new(
+                svm_writer.get_latest_absolute_slot(),
+                svm_writer.latest_epoch_info(),
+                svm_writer.latest_blockhash(),
+                account,
+            ))
+        })
+    }
+
+    /// Re-checks and resolves a batch under one writer lock so callers never
+    /// expose a partially hydrated account set.
+    fn resolve_accounts_after_fetch(
+        &self,
+        pubkeys: &[Pubkey],
+        fetched_accounts: HashMap<Pubkey, GetAccountResult>,
+    ) -> SurfpoolContextualizedResult<Vec<GetAccountResult>> {
+        self.with_svm_writer(move |svm_writer| {
+            let mut accounts = Vec::with_capacity(pubkeys.len());
+            for pubkey in pubkeys {
+                accounts.push(Self::resolve_fetched_account(
+                    svm_writer,
+                    *pubkey,
+                    fetched_accounts.get(pubkey).cloned(),
+                )?);
+            }
+
+            Ok(SvmAccessContext::new(
+                svm_writer.get_latest_absolute_slot(),
+                svm_writer.latest_epoch_info(),
+                svm_writer.latest_blockhash(),
+                accounts,
+            ))
+        })
+    }
+
+    fn resolve_fetched_account(
+        svm_writer: &mut SurfnetSvm,
+        pubkey: Pubkey,
+        fetched_account: Option<GetAccountResult>,
+    ) -> SurfpoolResult<GetAccountResult> {
+        let local_account = svm_writer.inner.get_account_result(&pubkey)?;
+        if !local_account.is_none() {
+            if local_account.requires_update() {
+                svm_writer.apply_account_update(
+                    local_account.clone(),
+                    AccountUpdatePolicy::HydrateIfAbsent,
+                )?;
+            }
+            return Ok(local_account);
+        }
+
+        if svm_writer
+            .offline_accounts
+            .contains_key(&pubkey.to_string())?
+        {
+            return Ok(GetAccountResult::None(pubkey));
+        }
+
+        let Some(fetched_account) = fetched_account else {
+            return Ok(GetAccountResult::None(pubkey));
+        };
+
+        let offline_owners = Self::offline_account_owners(svm_writer);
+        let fetched_account =
+            Self::filter_downloaded_account_result(&pubkey, fetched_account, &offline_owners);
+
+        if !fetched_account.is_none() {
+            svm_writer.apply_account_update(
+                fetched_account.clone(),
+                AccountUpdatePolicy::HydrateIfAbsent,
+            )?;
+        }
+
+        Ok(fetched_account)
+    }
+
+    fn offline_account_owners(svm_writer: &SurfnetSvm) -> Vec<Pubkey> {
+        svm_writer
+            .offline_accounts
+            .into_iter()
+            .unwrap_or_else(|e| {
+                warn!("Failed to iterate offline_accounts: {}", e);
+                Box::new(std::iter::empty())
+            })
+            .filter(|(_, config)| config.include_owned_accounts)
+            .filter_map(|(key, _)| match key.parse() {
+                Ok(pubkey) => Some(pubkey),
+                Err(e) => {
+                    warn!("Invalid pubkey in offline_accounts: {}: {}", key, e);
+                    None
+                }
+            })
+            .collect()
+    }
+
     /// Retrieves a local account from the SVM cache, returning a contextualized result.
     pub fn get_account_local(&self, pubkey: &Pubkey) -> SvmAccessContext<GetAccountResult> {
         self.with_contextualized_svm_reader(|svm_reader| {
@@ -315,18 +419,16 @@ impl SurfnetSvmLocker {
             let is_offline = self.is_account_offline(pubkey);
 
             if !is_offline {
-                let offline_owners = self.get_offline_account_owners();
                 let remote_account = client.get_account(pubkey, commitment_config).await?;
-                Ok(
-                    result.with_new_value(Self::filter_downloaded_account_result(
-                        pubkey,
-                        remote_account,
-                        &offline_owners,
-                    )),
-                )
+                self.resolve_account_after_fetch(*pubkey, Some(remote_account))
             } else {
                 Ok(result)
             }
+        } else if result.inner.requires_update() {
+            // An account read from the configured database must be restored to
+            // LiteSVM. Re-check under the write lock so a concurrent local
+            // write wins over the stale database value.
+            self.resolve_account_after_fetch(*pubkey, None)
         } else {
             Ok(result)
         }
@@ -343,7 +445,12 @@ impl SurfnetSvmLocker {
             self.get_account_local_then_remote(remote_client, pubkey, *commitment_config)
                 .await?
         } else {
-            self.get_account_local(pubkey)
+            let result = self.get_account_local(pubkey);
+            if result.inner.requires_update() {
+                self.resolve_account_after_fetch(*pubkey, None)?
+            } else {
+                result
+            }
         };
 
         match (&result.inner, factory) {
@@ -402,7 +509,11 @@ impl SurfnetSvmLocker {
         }
 
         if missing_accounts.is_empty() {
-            // All accounts found locally, already in correct order
+            if local_results.iter().any(GetAccountResult::requires_update) {
+                return self.resolve_accounts_after_fetch(pubkeys, HashMap::new());
+            }
+
+            // All accounts found in LiteSVM, already in correct order.
             return Ok(SvmAccessContext::new(
                 slot,
                 latest_epoch_info,
@@ -419,49 +530,16 @@ impl SurfnetSvmLocker {
             .get_multiple_accounts(&missing_accounts, commitment_config)
             .await?;
 
-        // Build map of pubkey -> remote result for O(1) lookup
-        let offline_owners = self.get_offline_account_owners();
+        // Build map of pubkey -> remote result for O(1) lookup. Offline-owner
+        // filtering occurs under the final writer lock, after the remote await,
+        // so a concurrent offline marker cannot be bypassed.
         let remote_map: HashMap<Pubkey, GetAccountResult> = missing_accounts
             .iter()
             .copied()
             .zip(remote_results.into_iter())
-            .map(|(requested_pubkey, result)| {
-                (
-                    requested_pubkey,
-                    Self::filter_downloaded_account_result(
-                        &requested_pubkey,
-                        result,
-                        &offline_owners,
-                    ),
-                )
-            })
             .collect();
 
-        // Replace None entries with remote results while preserving order
-        // We iterate through original pubkeys array to ensure order is explicit
-        let combined_results: Vec<GetAccountResult> = pubkeys
-            .iter()
-            .zip(local_results.into_iter())
-            .map(|(pubkey, local_result)| {
-                match local_result {
-                    GetAccountResult::None(_) => remote_map
-                        .get(pubkey)
-                        .cloned()
-                        .unwrap_or(GetAccountResult::None(*pubkey)),
-                    found => {
-                        debug!("Keeping local account: {}", pubkey);
-                        found
-                    } // Keep found accounts (no clone, just move)
-                }
-            })
-            .collect();
-
-        Ok(SvmAccessContext::new(
-            slot,
-            latest_epoch_info,
-            latest_blockhash,
-            combined_results,
-        ))
+        self.resolve_accounts_after_fetch(pubkeys, remote_map)
     }
 
     /// Retrieves multiple accounts, using local or remote context and applying factory defaults if provided.
@@ -479,7 +557,12 @@ impl SurfnetSvmLocker {
             )
             .await?
         } else {
-            self.get_multiple_accounts_local(pubkeys)
+            let results = self.get_multiple_accounts_local(pubkeys);
+            if results.inner.iter().any(GetAccountResult::requires_update) {
+                self.resolve_accounts_after_fetch(pubkeys, HashMap::new())?
+            } else {
+                results
+            }
         };
 
         let mut combined = Vec::with_capacity(results.inner.len());
@@ -522,7 +605,10 @@ impl SurfnetSvmLocker {
         let mut loaded_count = 0;
 
         // Separate accounts into those with data and those needing remote fetch
-        let mut accounts_to_load: Vec<(Pubkey, Account)> = Vec::new();
+        // The boolean records whether an entry was fetched because a snapshot
+        // value was `null`. Explicit snapshot values intentionally overwrite
+        // local state; fetched values must not overwrite a newer local write.
+        let mut accounts_to_load: Vec<(Pubkey, Account, bool)> = Vec::new();
         let mut pubkeys_to_fetch: Vec<Pubkey> = Vec::new();
 
         for (pubkey_str, account_snapshot_opt) in snapshot.iter() {
@@ -578,7 +664,7 @@ impl SurfnetSvmLocker {
                         rent_epoch: account_snapshot.rent_epoch,
                     };
 
-                    accounts_to_load.push((pubkey, account));
+                    accounts_to_load.push((pubkey, account, false));
                 }
                 None => {
                     // Queue for remote fetch if client is available
@@ -607,24 +693,24 @@ impl SurfnetSvmLocker {
                         for (pubkey, result) in pubkeys_to_fetch.iter().zip(remote_results) {
                             match result {
                                 GetAccountResult::FoundAccount(_, account, _) => {
-                                    accounts_to_load.push((*pubkey, account));
+                                    accounts_to_load.push((*pubkey, account, true));
                                 }
                                 GetAccountResult::FoundProgramAccount(
                                     (program_pubkey, program_account),
                                     (data_pubkey, data_account_opt),
                                 ) => {
-                                    accounts_to_load.push((program_pubkey, program_account));
+                                    accounts_to_load.push((program_pubkey, program_account, true));
                                     if let Some(data_account) = data_account_opt {
-                                        accounts_to_load.push((data_pubkey, data_account));
+                                        accounts_to_load.push((data_pubkey, data_account, true));
                                     }
                                 }
                                 GetAccountResult::FoundTokenAccount(
                                     (token_pubkey, token_account),
                                     (mint_pubkey, mint_account_opt),
                                 ) => {
-                                    accounts_to_load.push((token_pubkey, token_account));
+                                    accounts_to_load.push((token_pubkey, token_account, true));
                                     if let Some(mint_account) = mint_account_opt {
-                                        accounts_to_load.push((mint_pubkey, mint_account));
+                                        accounts_to_load.push((mint_pubkey, mint_account, true));
                                     }
                                 }
                                 GetAccountResult::None(_) => {
@@ -643,18 +729,40 @@ impl SurfnetSvmLocker {
             }
         }
 
-        accounts_to_load.sort_by_key(|(_, account)| snapshot_load_priority(account));
+        accounts_to_load.sort_by_key(|(_, account, _)| snapshot_load_priority(account));
 
         // Load all accounts into the SVM
         self.with_svm_writer(|svm| {
             let slot = svm.get_latest_absolute_slot();
 
-            for (pubkey, account) in accounts_to_load {
-                if let Err(e) = svm.set_account(&pubkey, account.clone()) {
-                    svm.simnet_events_tx
+            for (pubkey, account, fetched_from_remote) in accounts_to_load {
+                let load_result = if fetched_from_remote {
+                    svm.apply_account_update(
+                        GetAccountResult::FoundAccount(pubkey, account.clone(), true),
+                        AccountUpdatePolicy::HydrateIfAbsent,
+                    )
+                } else {
+                    svm.set_account(&pubkey, account.clone())
+                };
+                if let Err(e) = load_result {
+                    let _ = svm
+                        .simnet_events_tx
                         .warn(format!("Failed to set account '{}': {}", pubkey, e));
                     continue;
                 }
+
+                // Deliberately inspect LiteSVM only. Conditional remote hydration may
+                // lose to newer live state, and `set_account` can persist before
+                // LiteSVM rejects an account (for example, an incomplete program).
+                // A DB hit alone must not produce a Geyser startup update for an
+                // account that is not actually available in the live SVM.
+                let Some(account) = svm.inner.get_account_no_db(&pubkey) else {
+                    let _ = svm.simnet_events_tx.warn(format!(
+                        "Account '{}' was not present after snapshot load",
+                        pubkey
+                    ));
+                    continue;
+                };
 
                 // Send startup account update to geyser
                 let write_version = svm.increment_write_version();
@@ -768,12 +876,8 @@ impl SurfnetSvmLocker {
             combined.append(&mut remote_non_circulating_pubkeys);
             combined.append(&mut remote_circulating_pubkeys);
 
-            let get_account_results = self
-                .get_multiple_accounts_with_remote_fallback(client, &combined, commitment_config)
-                .await?
-                .inner;
-
-            self.write_multiple_account_updates(&get_account_results);
+            self.get_multiple_accounts_with_remote_fallback(client, &combined, commitment_config)
+                .await?;
         }
 
         // now that our local cache is aware of all large remote accounts, we can get the largest accounts locally
@@ -1700,17 +1804,15 @@ impl SurfnetSvmLocker {
             .inner;
 
         // We also need the pubkeys of the ALTs to be pulled from the remote, so we'll do a fetch for them
-        let alt_account_updates = self
-            .get_multiple_accounts(
-                remote_ctx,
-                &tx_loaded_addresses
-                    .as_ref()
-                    .map(|l| l.alt_addresses())
-                    .unwrap_or_default(),
-                None,
-            )
-            .await?
-            .inner;
+        self.get_multiple_accounts(
+            remote_ctx,
+            &tx_loaded_addresses
+                .as_ref()
+                .map(|l| l.alt_addresses())
+                .unwrap_or_default(),
+            None,
+        )
+        .await?;
 
         let readonly_account_states = transaction_accounts
             .iter()
@@ -1727,15 +1829,6 @@ impl SurfnetSvmLocker {
                 }
             })
             .collect::<HashMap<_, _>>();
-
-        self.with_svm_writer(|svm_writer| {
-            for update in &account_updates {
-                svm_writer.write_account_update(update.clone());
-            }
-            for update in alt_account_updates {
-                svm_writer.write_account_update(update);
-            }
-        });
 
         let pre_execution_capture = {
             let mut capture = ExecutionCapture::new();
@@ -2421,33 +2514,17 @@ impl SurfnetSvmLocker {
     }
 }
 
-/// Functions for writing account updates to the underlying SurfnetSvm instance
+/// Functions for materializing account lookup results into the underlying SVM.
 impl SurfnetSvmLocker {
-    /// Writes a single account update into the SVM state if present.
-    pub fn write_account_update(&self, account_update: GetAccountResult) {
-        if !account_update.requires_update() {
-            return;
-        }
-
+    /// Applies an account lookup result using the explicit source-precedence policy.
+    pub(crate) fn apply_account_update(
+        &self,
+        account_update: GetAccountResult,
+        policy: AccountUpdatePolicy,
+    ) -> SurfpoolResult<()> {
         self.with_svm_writer(move |svm_writer| {
-            svm_writer.write_account_update(account_update.clone())
+            svm_writer.apply_account_update(account_update, policy)
         })
-    }
-
-    /// Writes multiple account updates into the SVM state when any are present.
-    pub fn write_multiple_account_updates(&self, account_updates: &[GetAccountResult]) {
-        if account_updates
-            .iter()
-            .all(|update| !update.requires_update())
-        {
-            return;
-        }
-
-        self.with_svm_writer(move |svm_writer| {
-            for update in account_updates {
-                svm_writer.write_account_update(update.clone());
-            }
-        });
     }
 
     /// Resets an account in the SVM state for refresh/streaming.
@@ -2606,24 +2683,7 @@ impl SurfnetSvmLocker {
 
     /// Gets all owners whose accounts are marked offline.
     pub fn get_offline_account_owners(&self) -> Vec<Pubkey> {
-        self.with_svm_reader(|svm_reader| {
-            svm_reader
-                .offline_accounts
-                .into_iter()
-                .unwrap_or_else(|e| {
-                    warn!("Failed to iterate offline_accounts: {}", e);
-                    Box::new(std::iter::empty())
-                })
-                .filter(|(_, config)| config.include_owned_accounts)
-                .filter_map(|(k, _)| match k.parse() {
-                    Ok(pk) => Some(pk),
-                    Err(e) => {
-                        warn!("Invalid pubkey in offline_accounts: {}: {}", k, e);
-                        None
-                    }
-                })
-                .collect()
-        })
+        self.with_svm_reader(Self::offline_account_owners)
     }
 
     /// Registers a scenario for execution
@@ -3494,7 +3554,7 @@ impl SurfnetSvmLocker {
             }
         };
 
-        self.write_account_update(get_account_result);
+        self.apply_account_update(get_account_result, AccountUpdatePolicy::Authoritative)?;
 
         Ok(SvmAccessContext::new(
             slot,
@@ -4141,11 +4201,10 @@ impl SurfnetSvmLocker {
 
         // Persist the program account if it was newly created
         if was_program_created {
-            self.write_account_update(GetAccountResult::FoundAccount(
-                program_id,
-                program_account.clone(),
-                true,
-            ));
+            self.apply_account_update(
+                GetAccountResult::FoundAccount(program_id, program_account.clone(), true),
+                AccountUpdatePolicy::Authoritative,
+            )?;
         }
         Ok(program_account)
     }
@@ -4428,13 +4487,22 @@ mod tests {
     use solana_account::Account;
     use solana_account_decoder::UiAccountEncoding;
     use solana_epoch_schedule::EpochSchedule;
+    use solana_keypair::Keypair;
+    use solana_message::{Message, VersionedMessage};
+    use solana_sdk_ids::system_program;
+    use solana_signer::Signer;
+    use solana_system_interface::instruction as system_instruction;
+    use solana_transaction::versioned::VersionedTransaction;
     use solana_transaction_status::TransactionStatusMeta;
 
     use super::*;
     use crate::{
         rpc::full::RpcTransactionsForAddressFilters,
         scenarios::registry::PYTH_V2_IDL_CONTENT,
-        surfnet::{BlockHeader, SurfnetSvm, svm::apply_override_to_decoded_account},
+        surfnet::{
+            BlockHeader, SurfnetSvm,
+            svm::{SurfnetSvmConfig, apply_override_to_decoded_account},
+        },
     };
 
     /// A real `PriceUpdateV2` account. Its `VerificationLevel` is the one-byte `Full` variant and
@@ -4452,6 +4520,223 @@ mod tests {
             0x00, 0x00, 0x00, 0xa0, 0x7c, 0x1a, 0x38, 0x63, 0x0a, 0x00, 0x00, 0x94, 0xa6, 0xb9,
             0xb5, 0x00, 0x00, 0x00, 0x00, 0x8c, 0x5e, 0x6d, 0x16, 0x00, 0x00, 0x00, 0x00, 0x00,
         ]
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn delayed_remote_account_cannot_overwrite_locally_created_account() {
+        let (svm, _simnet_events_rx, _geyser_events_rx) =
+            SurfnetSvm::new_with_db(Some(":memory:"), SurfnetSvmConfig::default()).unwrap();
+        let locker = SurfnetSvmLocker::new(svm);
+        let payer = Keypair::new();
+        let created = Keypair::new();
+        let created_pubkey = created.pubkey();
+
+        let delayed_remote_result = GetAccountResult::FoundAccount(
+            created_pubkey,
+            Account {
+                lamports: 99,
+                data: vec![9, 9, 9],
+                owner: Pubkey::new_unique(),
+                executable: false,
+                rent_epoch: 0,
+            },
+            true,
+        );
+
+        // This represents a request that observed the account as absent and
+        // is now blocked on its upstream response.
+        assert!(
+            locker
+                .with_svm_reader(|svm| { svm.inner.get_account_no_db(&created_pubkey).is_none() })
+        );
+
+        let _ = locker.airdrop(&payer.pubkey(), 1_000_000_000).unwrap();
+        let rent_exempt_lamports =
+            locker.with_svm_reader(|svm| svm.inner.minimum_balance_for_rent_exemption(0));
+        let create_instruction = system_instruction::create_account(
+            &payer.pubkey(),
+            &created_pubkey,
+            rent_exempt_lamports,
+            0,
+            &system_program::id(),
+        );
+        let message = Message::new_with_blockhash(
+            &[create_instruction],
+            Some(&payer.pubkey()),
+            &locker.latest_absolute_blockhash(),
+        );
+        let transaction =
+            VersionedTransaction::try_new(VersionedMessage::Legacy(message), &[&payer, &created])
+                .unwrap();
+        let (status_tx, _status_rx) = crossbeam_channel::unbounded();
+        locker
+            .process_transaction(&None, transaction, status_tx, true, true)
+            .await
+            .unwrap();
+
+        // Release the delayed upstream result after the local transaction has
+        // created the account. The resolver must return and retain local state.
+        let resolved = locker
+            .resolve_account_after_fetch(created_pubkey, Some(delayed_remote_result))
+            .unwrap()
+            .inner
+            .map_account()
+            .unwrap();
+        assert_eq!(resolved.lamports, rent_exempt_lamports);
+        assert!(resolved.data.is_empty());
+        assert_eq!(resolved.owner, system_program::id());
+
+        locker.with_svm_reader(|svm| {
+            let in_memory = svm
+                .inner
+                .get_account_no_db(&created_pubkey)
+                .expect("locally created account should remain in LiteSVM");
+            let in_db: Account = svm
+                .inner
+                .db
+                .as_ref()
+                .expect("configured account database should exist")
+                .get(&created_pubkey.to_string())
+                .unwrap()
+                .expect("locally created account should remain in the database")
+                .into();
+
+            assert_eq!(in_memory.lamports, rent_exempt_lamports);
+            assert_eq!(in_db.lamports, rent_exempt_lamports);
+            assert!(in_memory.data.is_empty());
+            assert!(in_db.data.is_empty());
+        });
+    }
+
+    #[test]
+    fn fetched_dependency_does_not_overwrite_newer_local_account() {
+        let (svm, _simnet_events_rx, _geyser_events_rx) = SurfnetSvm::default();
+        let locker = SurfnetSvmLocker::new(svm);
+        let primary = Pubkey::new_unique();
+        let dependency = Pubkey::new_unique();
+        let local_dependency = Account {
+            lamports: 7,
+            data: vec![7],
+            owner: spl_token_interface::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        let remote_dependency = Account {
+            lamports: 3,
+            data: vec![3],
+            owner: spl_token_interface::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        let remote_primary = Account {
+            lamports: 5,
+            data: vec![5],
+            owner: spl_token_interface::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+
+        locker.with_svm_writer(|svm| {
+            svm.set_account(&dependency, local_dependency.clone())
+                .unwrap();
+        });
+
+        locker
+            .resolve_account_after_fetch(
+                primary,
+                Some(GetAccountResult::FoundTokenAccount(
+                    (primary, remote_primary),
+                    (dependency, Some(remote_dependency)),
+                )),
+            )
+            .unwrap();
+
+        locker.with_svm_reader(|svm| {
+            assert_eq!(
+                svm.inner.get_account_no_db(&dependency),
+                Some(local_dependency)
+            );
+            assert_eq!(
+                svm.inner
+                    .get_account_no_db(&primary)
+                    .expect("primary account should be hydrated")
+                    .lamports,
+                5
+            );
+        });
+    }
+
+    #[test]
+    fn batch_fetch_keeps_newer_local_account_and_hydrates_missing_account() {
+        let (svm, _simnet_events_rx, _geyser_events_rx) = SurfnetSvm::default();
+        let locker = SurfnetSvmLocker::new(svm);
+        let locally_written = Pubkey::new_unique();
+        let missing = Pubkey::new_unique();
+        let local_account = Account {
+            lamports: 11,
+            data: vec![1],
+            owner: Pubkey::new_unique(),
+            executable: false,
+            rent_epoch: 0,
+        };
+
+        locker.with_svm_writer(|svm| {
+            svm.set_account(&locally_written, local_account.clone())
+                .unwrap();
+        });
+
+        let fetched_accounts = HashMap::from([
+            (
+                locally_written,
+                GetAccountResult::FoundAccount(
+                    locally_written,
+                    Account {
+                        lamports: 1,
+                        data: vec![9],
+                        owner: Pubkey::new_unique(),
+                        executable: false,
+                        rent_epoch: 0,
+                    },
+                    true,
+                ),
+            ),
+            (
+                missing,
+                GetAccountResult::FoundAccount(
+                    missing,
+                    Account {
+                        lamports: 2,
+                        data: vec![2],
+                        owner: Pubkey::new_unique(),
+                        executable: false,
+                        rent_epoch: 0,
+                    },
+                    true,
+                ),
+            ),
+        ]);
+
+        let resolved = locker
+            .resolve_accounts_after_fetch(&[locally_written, missing], fetched_accounts)
+            .unwrap()
+            .inner;
+        assert_eq!(resolved[0].clone().map_account().unwrap(), local_account);
+        assert_eq!(resolved[1].clone().map_account().unwrap().lamports, 2);
+
+        locker.with_svm_reader(|svm| {
+            assert_eq!(
+                svm.inner.get_account_no_db(&locally_written),
+                Some(local_account)
+            );
+            assert_eq!(
+                svm.inner
+                    .get_account_no_db(&missing)
+                    .expect("missing account should be hydrated")
+                    .lamports,
+                2
+            );
+        });
     }
 
     #[test]

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -220,30 +220,51 @@ impl Display for SignatureSubscriptionType {
     }
 }
 
-type DoUpdateSvm = bool;
+/// Identifies where an account result was read from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AccountSource {
+    /// The account is already present in the live LiteSVM state.
+    Svm,
+    /// The account was read from the configured database and is not yet in LiteSVM.
+    Database,
+    /// The account was fetched from the remote RPC.
+    Remote,
+    /// The account was created locally by a default factory or mutation path.
+    Generated,
+}
+
+/// The kind of secondary account returned with a coupled account result.
+#[derive(Clone, Debug)]
+pub enum CoupledAccount {
+    /// Upgradeable programs may be returned with their program-data account.
+    ProgramData(Pubkey, Option<Account>),
+    /// Token accounts may be returned with their mint account.
+    Mint(Pubkey, Option<Account>),
+}
 
 #[derive(Clone, Debug)]
-/// Represents the result of a get_account operation.
+/// Represents the result of a `get_account` operation.
+///
+/// The result records provenance, while the caller chooses how that result may
+/// affect the SVM through [svm::AccountUpdatePolicy]. In particular,
+/// provenance does not imply authoritative replacement. See the policy
+/// documentation for the complete result-by-policy decision table.
 pub enum GetAccountResult {
     /// Represents that the account was not found.
     None(Pubkey),
-    /// Represents that the account was found.
-    /// The `DoUpdateSvm` flag indicates whether the SVM should be updated after this account is found.
-    /// This is useful for cases where the account was fetched from a remote source and needs to be
-    /// updated in the SVM to reflect the latest state. However, when the account is found locally,
-    /// it likely does not need to be updated in the SVM.
-    FoundAccount(Pubkey, Account, DoUpdateSvm),
-    FoundProgramAccount((Pubkey, Account), (Pubkey, Option<Account>)),
-    FoundTokenAccount((Pubkey, Account), (Pubkey, Option<Account>)),
+    /// Represents an account found in one of the account stores.
+    FoundAccount(Pubkey, Account, AccountSource),
+    /// Represents an account coupled to a program-data or mint account.
+    FoundCoupledAccount((Pubkey, Account), CoupledAccount, AccountSource),
 }
 
 impl GetAccountResult {
     pub fn expected_data(&self) -> &Vec<u8> {
         match &self {
             Self::None(_) => unreachable!(),
-            Self::FoundAccount(_, account, _)
-            | Self::FoundProgramAccount((_, account), _)
-            | Self::FoundTokenAccount((_, account), _) => &account.data,
+            Self::FoundAccount(_, account, _) | Self::FoundCoupledAccount((_, account), _, _) => {
+                &account.data
+            }
         }
     }
 
@@ -253,15 +274,15 @@ impl GetAccountResult {
     {
         match self {
             Self::None(_) => unreachable!(),
-            Self::FoundAccount(_, account, do_update_account) => {
+            Self::FoundAccount(_, account, source) => {
                 update(account)?;
-                *do_update_account = true;
+                // Applying an override turns a read result into an explicit
+                // local mutation, regardless of where the original account came from.
+                *source = AccountSource::Generated;
             }
-            Self::FoundProgramAccount((_, account), _) => {
+            Self::FoundCoupledAccount((_, account), _, source) => {
                 update(account)?;
-            }
-            Self::FoundTokenAccount((_, account), _) => {
-                update(account)?;
+                *source = AccountSource::Generated;
             }
         }
         Ok(())
@@ -270,9 +291,9 @@ impl GetAccountResult {
     pub fn map_account(self) -> SurfpoolResult<Account> {
         match self {
             Self::None(pubkey) => Err(SurfpoolError::account_not_found(pubkey)),
-            Self::FoundAccount(_, account, _)
-            | Self::FoundProgramAccount((_, account), _)
-            | Self::FoundTokenAccount((_, account), _) => Ok(account),
+            Self::FoundAccount(_, account, _) | Self::FoundCoupledAccount((_, account), _, _) => {
+                Ok(account)
+            }
         }
     }
 
@@ -283,10 +304,12 @@ impl GetAccountResult {
         match self {
             Self::None(_) => None,
             Self::FoundAccount(pubkey, account, _) => Some(((pubkey, account), None)),
-            Self::FoundProgramAccount((pubkey, account), _) => Some(((pubkey, account), None)),
-            Self::FoundTokenAccount((pubkey, account), token_data) => {
-                Some(((pubkey, account), Some(token_data)))
-            }
+            Self::FoundCoupledAccount((pubkey, account), coupled, _) => match coupled {
+                CoupledAccount::ProgramData(_, _) => Some(((pubkey, account), None)),
+                CoupledAccount::Mint(coupled_pubkey, coupled_account) => {
+                    Some(((pubkey, account), Some((coupled_pubkey, coupled_account))))
+                }
+            },
         }
     }
 
@@ -294,12 +317,12 @@ impl GetAccountResult {
         matches!(self, Self::None(_))
     }
 
-    pub const fn requires_update(&self) -> bool {
+    pub const fn source(&self) -> Option<AccountSource> {
         match self {
-            Self::None(_) => false,
-            Self::FoundAccount(_, _, do_update) => *do_update,
-            Self::FoundProgramAccount(_, _) => true,
-            Self::FoundTokenAccount(_, _) => true,
+            Self::None(_) => None,
+            Self::FoundAccount(_, _, source) | Self::FoundCoupledAccount(_, _, source) => {
+                Some(*source)
+            }
         }
     }
 }

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -38,7 +38,9 @@ use super::GetTransactionResult;
 use crate::{
     error::{SurfpoolError, SurfpoolResult},
     rpc::utils::is_method_not_supported_error,
-    surfnet::{GetAccountResult, locker::is_supported_token_program},
+    surfnet::{
+        AccountSource, CoupledAccount, GetAccountResult, locker::is_supported_token_program,
+    },
     types::{RemoteRpcResult, TokenAccount},
 };
 
@@ -216,9 +218,10 @@ impl SurfnetRemoteClient {
                             .await
                             .map_err(|e| SurfpoolError::get_account(*pubkey, e))?;
 
-                        result = Some(GetAccountResult::FoundTokenAccount(
+                        result = Some(GetAccountResult::FoundCoupledAccount(
                             (*pubkey, account.clone()),
-                            (token_account.mint(), mint.value),
+                            CoupledAccount::Mint(token_account.mint(), mint.value),
+                            AccountSource::Remote,
                         ));
                     };
                 } else if account.executable {
@@ -230,16 +233,17 @@ impl SurfnetRemoteClient {
                         .await
                         .map_err(|e| SurfpoolError::get_account(*pubkey, e))?;
 
-                    result = Some(GetAccountResult::FoundProgramAccount(
+                    result = Some(GetAccountResult::FoundCoupledAccount(
                         (*pubkey, account.clone()),
-                        (program_data_address, program_data.value),
+                        CoupledAccount::ProgramData(program_data_address, program_data.value),
+                        AccountSource::Remote,
                     ));
                 }
 
                 result.unwrap_or(GetAccountResult::FoundAccount(
-                    *pubkey, account,
-                    // Mark this account as needing to be updated in the SVM, since we fetched it
-                    true,
+                    *pubkey,
+                    account,
+                    AccountSource::Remote,
                 ))
             }
             None => GetAccountResult::None(*pubkey),
@@ -291,8 +295,7 @@ impl SurfnetRemoteClient {
                             GetAccountResult::FoundAccount(
                                 *pubkey,
                                 remote_account,
-                                // Mark this account as needing to be updated in the SVM, since we fetched it
-                                true,
+                                AccountSource::Remote,
                             ),
                         );
                     }
@@ -305,8 +308,7 @@ impl SurfnetRemoteClient {
                         GetAccountResult::FoundAccount(
                             *pubkey,
                             remote_account,
-                            // Mark this account as needing to be updated in the SVM, since we fetched it
-                            true,
+                            AccountSource::Remote,
                         ),
                     );
                 }
@@ -357,17 +359,22 @@ impl SurfnetRemoteClient {
                     // mint accounts to be inserted
                     results_map.insert(
                         account_buffer[index].0,
-                        GetAccountResult::FoundTokenAccount(
+                        GetAccountResult::FoundCoupledAccount(
                             (account_buffer[index].0, account_buffer[index].1.clone()),
-                            (account_buffer[index].2, remote_account.clone()),
+                            CoupledAccount::Mint(account_buffer[index].2, remote_account.clone()),
+                            AccountSource::Remote,
                         ),
                     );
                 } else {
                     results_map.insert(
                         account_buffer[index].0,
-                        GetAccountResult::FoundProgramAccount(
+                        GetAccountResult::FoundCoupledAccount(
                             (account_buffer[index].0, account_buffer[index].1.clone()),
-                            (account_buffer[index].2, remote_account.clone()),
+                            CoupledAccount::ProgramData(
+                                account_buffer[index].2,
+                                remote_account.clone(),
+                            ),
+                            AccountSource::Remote,
                         ),
                     );
                 }

--- a/crates/core/src/surfnet/surfnet_lite_svm.rs
+++ b/crates/core/src/surfnet/surfnet_lite_svm.rs
@@ -19,7 +19,9 @@ use solana_transaction::versioned::VersionedTransaction;
 use crate::{
     error::{SurfpoolError, SurfpoolResult},
     storage::{OverlayStorage, Storage, StorageBackend},
-    surfnet::{GetAccountResult, locker::is_supported_token_program},
+    surfnet::{
+        AccountSource, CoupledAccount, GetAccountResult, locker::is_supported_token_program,
+    },
 };
 
 pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
@@ -191,9 +193,9 @@ impl SurfnetLiteSvm {
     pub fn get_account_result(&self, pubkey: &Pubkey) -> SurfpoolResult<GetAccountResult> {
         if let Some(account) = self.svm.get_account(pubkey) {
             return Ok(GetAccountResult::FoundAccount(
-                *pubkey, account,
-                // mark as not an account that should be updated in the SVM, since this is a local read and it already exists
-                false,
+                *pubkey,
+                account,
+                AccountSource::Svm,
             ));
         } else if let Some(db) = &self.db {
             let mut result = None;
@@ -202,9 +204,10 @@ impl SurfnetLiteSvm {
                     if let Ok(token_account) = crate::types::TokenAccount::unpack(&account.data) {
                         let mint = db.get(&token_account.mint().to_string())?.map(Into::into);
 
-                        result = Some(GetAccountResult::FoundTokenAccount(
+                        result = Some(GetAccountResult::FoundCoupledAccount(
                             (*pubkey, account.clone()),
-                            (token_account.mint(), mint),
+                            CoupledAccount::Mint(token_account.mint(), mint),
+                            AccountSource::Database,
                         ));
                     };
                 } else if account.executable {
@@ -212,16 +215,17 @@ impl SurfnetLiteSvm {
 
                     let program_data = db.get(&program_data_address.to_string())?.map(Into::into);
 
-                    result = Some(GetAccountResult::FoundProgramAccount(
+                    result = Some(GetAccountResult::FoundCoupledAccount(
                         (*pubkey, account.clone()),
-                        (program_data_address, program_data),
+                        CoupledAccount::ProgramData(program_data_address, program_data),
+                        AccountSource::Database,
                     ));
                 }
 
                 return Ok(result.unwrap_or(GetAccountResult::FoundAccount(
-                    *pubkey, account,
-                    // Mark this account as needing to be updated in the SVM, since we pulled it from the db
-                    true,
+                    *pubkey,
+                    account,
+                    AccountSource::Database,
                 )));
             }
         }

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -76,10 +76,10 @@ use txtx_addon_network_svm_types::idl::{
 use uuid::Uuid;
 
 use super::{
-    AccountSubscriptionData, BlockHeader, BlockIdentifier, FINALIZATION_SLOT_THRESHOLD,
-    GetAccountResult, GeyserBlockMetadata, GeyserEntryInfo, GeyserEvent, GeyserSlotStatus,
-    ProgramSubscriptionData, SignatureSubscriptionData, SignatureSubscriptionType,
-    SlotsUpdatesSubscriptionData, remote::SurfnetRemoteClient,
+    AccountSource, AccountSubscriptionData, BlockHeader, BlockIdentifier, CoupledAccount,
+    FINALIZATION_SLOT_THRESHOLD, GetAccountResult, GeyserBlockMetadata, GeyserEntryInfo,
+    GeyserEvent, GeyserSlotStatus, ProgramSubscriptionData, SignatureSubscriptionData,
+    SignatureSubscriptionType, SlotsUpdatesSubscriptionData, remote::SurfnetRemoteClient,
 };
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
@@ -117,8 +117,19 @@ lazy_static::lazy_static! {
     };
 }
 
-/// Determines whether an account result is an authoritative state change or
-/// a best-effort cache hydration.
+/// Determines how an account result may change the SVM.
+///
+/// The result's [`AccountSource`] describes where the data came from; this
+/// policy describes what the current operation is allowed to do with it.
+///
+/// | Result | Source | `Authoritative` | `HydrateIfAbsent` |
+/// | --- | --- | --- | --- |
+/// | `None` | Any | No-op | No-op |
+/// | `FoundAccount` | `Svm` | No-op; it is already live | No-op |
+/// | `FoundAccount` | `Database` or `Remote` | Replace when explicitly applied | Insert only when absent; preserve live state |
+/// | `FoundAccount` | `Generated` | Replace when explicitly applied | No-op; generated state is already an explicit mutation |
+/// | `FoundCoupledAccount::ProgramData` | `Database` or `Remote` | Apply program-data before program | Hydrate each missing component, preserving live state |
+/// | `FoundCoupledAccount::Mint` | `Database` or `Remote` | Apply mint before token account when present | Hydrate each missing component, preserving live state |
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum AccountUpdatePolicy {
     /// Replace local state with the supplied account update.
@@ -126,6 +137,17 @@ pub(crate) enum AccountUpdatePolicy {
     /// Keep any live LiteSVM state and rehydrate database-only state instead
     /// of replacing it with a fetched result.
     HydrateIfAbsent,
+}
+
+impl AccountUpdatePolicy {
+    /// Converts account provenance into the non-authoritative policy used when
+    /// a result needs to be materialized in LiteSVM.
+    pub(crate) const fn for_source(source: AccountSource) -> Option<Self> {
+        match source {
+            AccountSource::Database | AccountSource::Remote => Some(Self::HydrateIfAbsent),
+            AccountSource::Svm | AccountSource::Generated => None,
+        }
+    }
 }
 
 /// Helper function to apply an override to a decoded account value using dot notation
@@ -2257,29 +2279,42 @@ impl SurfnetSvm {
         let account_update = self.account_update_for_policy(account_update, policy)?;
 
         match account_update {
-            GetAccountResult::FoundAccount(pubkey, account, true) => {
-                self.apply_synthetic_programdata(&account)?;
-                self.apply_account_component(pubkey, account, policy)?;
+            GetAccountResult::None(_) => {}
+            GetAccountResult::FoundAccount(pubkey, account, source) => {
+                if source != AccountSource::Svm {
+                    self.apply_synthetic_programdata(&account)?;
+                    self.apply_account_component(pubkey, account, policy)?;
+                }
             }
-            GetAccountResult::FoundAccount(_, _, false) | GetAccountResult::None(_) => {}
-            GetAccountResult::FoundProgramAccount((pubkey, account), (_, None)) => {
-                self.apply_synthetic_programdata(&account)?;
-                self.apply_account_component(pubkey, account, policy)?;
-            }
-            GetAccountResult::FoundTokenAccount((pubkey, account), (_, None)) => {
-                self.apply_account_component(pubkey, account, policy)?;
-            }
-            GetAccountResult::FoundProgramAccount(
+            GetAccountResult::FoundCoupledAccount(
                 (pubkey, account),
-                (coupled_pubkey, Some(coupled_account)),
-            )
-            | GetAccountResult::FoundTokenAccount(
-                (pubkey, account),
-                (coupled_pubkey, Some(coupled_account)),
+                CoupledAccount::ProgramData(_, None),
+                _,
             ) => {
-                // Programdata and mint accounts must be available before their
-                // dependent program or token accounts.
+                self.apply_synthetic_programdata(&account)?;
+                self.apply_account_component(pubkey, account, policy)?;
+            }
+            GetAccountResult::FoundCoupledAccount(
+                (pubkey, account),
+                CoupledAccount::ProgramData(coupled_pubkey, Some(coupled_account)),
+                _,
+            ) => {
                 self.apply_account_component(coupled_pubkey, coupled_account, policy)?;
+                self.apply_account_component(pubkey, account, policy)?;
+            }
+            GetAccountResult::FoundCoupledAccount(
+                (pubkey, account),
+                CoupledAccount::Mint(coupled_pubkey, Some(coupled_account)),
+                _,
+            ) => {
+                self.apply_account_component(coupled_pubkey, coupled_account, policy)?;
+                self.apply_account_component(pubkey, account, policy)?;
+            }
+            GetAccountResult::FoundCoupledAccount(
+                (pubkey, account),
+                CoupledAccount::Mint(_, None),
+                _,
+            ) => {
                 self.apply_account_component(pubkey, account, policy)?;
             }
         }
@@ -2298,8 +2333,7 @@ impl SurfnetSvm {
 
         let pubkey = match &account_update {
             GetAccountResult::None(pubkey) | GetAccountResult::FoundAccount(pubkey, ..) => *pubkey,
-            GetAccountResult::FoundProgramAccount((pubkey, _), _)
-            | GetAccountResult::FoundTokenAccount((pubkey, _), _) => *pubkey,
+            GetAccountResult::FoundCoupledAccount((pubkey, _), _, _) => *pubkey,
         };
         let local = self.inner.get_account_result(&pubkey)?;
 
@@ -2309,7 +2343,11 @@ impl SurfnetSvm {
         // result stale: do not install its coupled mint or programdata before
         // skipping the primary, or the live account could observe mismatched
         // dependency state.
-        if local.requires_update() {
+        if local
+            .source()
+            .and_then(AccountUpdatePolicy::for_source)
+            .is_some()
+        {
             Ok(local)
         } else if local.is_none() {
             Ok(account_update)
@@ -2327,7 +2365,14 @@ impl SurfnetSvm {
         let account = if policy == AccountUpdatePolicy::HydrateIfAbsent {
             match self.inner.get_account_result(&pubkey)? {
                 GetAccountResult::None(_) => account,
-                local if local.requires_update() => local.map_account()?,
+                local
+                    if local
+                        .source()
+                        .and_then(AccountUpdatePolicy::for_source)
+                        .is_some() =>
+                {
+                    local.map_account()?
+                }
                 _ => return Ok(()),
             }
         } else {
@@ -4529,9 +4574,10 @@ mod tests {
         svm.set_account(&token_primary, local_primary.clone())
             .unwrap();
         svm.apply_account_update(
-            GetAccountResult::FoundTokenAccount(
+            GetAccountResult::FoundCoupledAccount(
                 (token_primary, fetched_primary.clone()),
-                (token_mint, Some(fetched_primary.clone())),
+                CoupledAccount::Mint(token_mint, Some(fetched_primary.clone())),
+                AccountSource::Remote,
             ),
             AccountUpdatePolicy::HydrateIfAbsent,
         )
@@ -4547,9 +4593,10 @@ mod tests {
         svm.set_account(&program_primary, local_primary.clone())
             .unwrap();
         svm.apply_account_update(
-            GetAccountResult::FoundProgramAccount(
+            GetAccountResult::FoundCoupledAccount(
                 (program_primary, fetched_primary.clone()),
-                (programdata, Some(fetched_primary)),
+                CoupledAccount::ProgramData(programdata, Some(fetched_primary)),
+                AccountSource::Remote,
             ),
             AccountUpdatePolicy::HydrateIfAbsent,
         )
@@ -4586,19 +4633,21 @@ mod tests {
             assert_eq!(svm.get_all_accounts().unwrap(), index_before);
         }
 
-        // GetAccountResult::FoundAccount with `DoUpdateSvm` flag to false should be a noop
+        // An account already present in LiteSVM is not materialized again.
         {
             let index_before = svm.get_all_accounts().unwrap();
-            let found_update = GetAccountResult::FoundAccount(pubkey, account.clone(), false);
+            let found_update =
+                GetAccountResult::FoundAccount(pubkey, account.clone(), AccountSource::Svm);
             svm.apply_account_update(found_update, AccountUpdatePolicy::Authoritative)
                 .unwrap();
             assert_eq!(svm.get_all_accounts().unwrap(), index_before);
         }
 
-        // GetAccountResult::FoundAccount with `DoUpdateSvm` flag to true should update the account
+        // A generated account is explicitly materialized by the caller.
         {
             let index_before = svm.get_all_accounts().unwrap();
-            let found_update = GetAccountResult::FoundAccount(pubkey, account.clone(), true);
+            let found_update =
+                GetAccountResult::FoundAccount(pubkey, account.clone(), AccountSource::Generated);
             svm.apply_account_update(found_update, AccountUpdatePolicy::Authoritative)
                 .unwrap();
             assert_eq!(
@@ -4634,7 +4683,11 @@ mod tests {
                 .unwrap();
 
             svm.apply_account_update(
-                GetAccountResult::FoundAccount(policy_pubkey, fetched_account.clone(), true),
+                GetAccountResult::FoundAccount(
+                    policy_pubkey,
+                    fetched_account.clone(),
+                    AccountSource::Remote,
+                ),
                 AccountUpdatePolicy::HydrateIfAbsent,
             )
             .unwrap();
@@ -4644,7 +4697,11 @@ mod tests {
             );
 
             svm.apply_account_update(
-                GetAccountResult::FoundAccount(policy_pubkey, fetched_account.clone(), true),
+                GetAccountResult::FoundAccount(
+                    policy_pubkey,
+                    fetched_account.clone(),
+                    AccountSource::Remote,
+                ),
                 AccountUpdatePolicy::Authoritative,
             )
             .unwrap();
@@ -4656,7 +4713,7 @@ mod tests {
             while events_rx.try_recv().is_ok() {}
         }
 
-        // GetAccountResult::FoundProgramAccount with no program account inserts a default programdata account
+        // A coupled program result with no program-data account inserts a default programdata account.
         {
             let (program_address, program_account, program_data_address, _) =
                 create_program_accounts();
@@ -4681,9 +4738,10 @@ mod tests {
             };
 
             let index_before = svm.get_all_accounts().unwrap();
-            let found_program_account_update = GetAccountResult::FoundProgramAccount(
+            let found_program_account_update = GetAccountResult::FoundCoupledAccount(
                 (program_address, program_account.clone()),
-                (program_data_address, None),
+                CoupledAccount::ProgramData(program_data_address, None),
+                AccountSource::Remote,
             );
             svm.apply_account_update(
                 found_program_account_update,
@@ -4704,7 +4762,7 @@ mod tests {
 
             if !expect_account_update_event(&events_rx, &svm, &program_address, &program_account) {
                 panic!(
-                    "Expected account update event not received after GetAccountResult::FoundProgramAccount update for program pubkey"
+                    "Expected account update event not received after coupled program update for program pubkey"
                 );
             }
             assert_eq!(
@@ -4713,15 +4771,19 @@ mod tests {
             );
         }
 
-        // GetAccountResult::FoundProgramAccount with program account + program data account inserts two accounts
+        // A coupled program result with program data inserts both accounts.
         {
             let (program_address, program_account, program_data_address, program_data_account) =
                 create_program_accounts();
 
             let index_before = svm.get_all_accounts().unwrap();
-            let found_program_account_update = GetAccountResult::FoundProgramAccount(
+            let found_program_account_update = GetAccountResult::FoundCoupledAccount(
                 (program_address, program_account.clone()),
-                (program_data_address, Some(program_data_account.clone())),
+                CoupledAccount::ProgramData(
+                    program_data_address,
+                    Some(program_data_account.clone()),
+                ),
+                AccountSource::Remote,
             );
             svm.apply_account_update(
                 found_program_account_update,
@@ -4739,18 +4801,18 @@ mod tests {
                 &program_data_account,
             ) {
                 panic!(
-                    "Expected account update event not received after GetAccountResult::FoundProgramAccount update for program data pubkey"
+                    "Expected account update event not received after coupled program update for program data pubkey"
                 );
             }
 
             if !expect_account_update_event(&events_rx, &svm, &program_address, &program_account) {
                 panic!(
-                    "Expected account update event not received after GetAccountResult::FoundProgramAccount update for program pubkey"
+                    "Expected account update event not received after coupled program update for program pubkey"
                 );
             }
         }
 
-        // If we insert the program data account ahead of time, then have a GetAccountResult::FoundProgramAccount with just the program data account,
+        // If we insert the program data account ahead of time, then apply a coupled program result,
         // we should get one insert
         {
             let (program_address, program_account, program_data_address, program_data_account) =
@@ -4760,7 +4822,7 @@ mod tests {
             let found_update = GetAccountResult::FoundAccount(
                 program_data_address,
                 program_data_account.clone(),
-                true,
+                AccountSource::Remote,
             );
             svm.apply_account_update(found_update, AccountUpdatePolicy::Authoritative)
                 .unwrap();
@@ -4780,9 +4842,10 @@ mod tests {
             }
 
             let index_before = svm.get_all_accounts().unwrap();
-            let program_account_found_update = GetAccountResult::FoundProgramAccount(
+            let program_account_found_update = GetAccountResult::FoundCoupledAccount(
                 (program_address, program_account.clone()),
-                (program_data_address, None),
+                CoupledAccount::ProgramData(program_data_address, None),
+                AccountSource::Remote,
             );
             svm.apply_account_update(
                 program_account_found_update,

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -117,6 +117,17 @@ lazy_static::lazy_static! {
     };
 }
 
+/// Determines whether an account result is an authoritative state change or
+/// a best-effort cache hydration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AccountUpdatePolicy {
+    /// Replace local state with the supplied account update.
+    Authoritative,
+    /// Keep any live LiteSVM state and rehydrate database-only state instead
+    /// of replacing it with a fetched result.
+    HydrateIfAbsent,
+}
+
 /// Helper function to apply an override to a decoded account value using dot notation
 pub fn apply_override_to_decoded_account(
     decoded_value: &mut Value,
@@ -2235,98 +2246,28 @@ impl SurfnetSvm {
         Ok(())
     }
 
-    /// Writes account updates to the SVM state based on the provided account update result.
-    ///
-    /// # Arguments
-    /// * `account_update` - The account update result to process.
-    pub fn write_account_update(&mut self, account_update: GetAccountResult) {
-        let init_programdata_account = |program_account: &Account| {
-            if !program_account.executable {
-                return None;
-            }
-            if !program_account
-                .owner
-                .eq(&solana_sdk_ids::bpf_loader_upgradeable::id())
-            {
-                return None;
-            }
-            let Ok(UpgradeableLoaderState::Program {
-                programdata_address,
-            }) = bincode::deserialize::<UpgradeableLoaderState>(&program_account.data)
-            else {
-                return None;
-            };
+    /// Materializes an account lookup result into the SVM according to its
+    /// source policy. This is the sole insertion path for `GetAccountResult`;
+    /// callers must state whether the result is authoritative or cache-only.
+    pub(crate) fn apply_account_update(
+        &mut self,
+        account_update: GetAccountResult,
+        policy: AccountUpdatePolicy,
+    ) -> SurfpoolResult<()> {
+        let account_update = self.account_update_for_policy(account_update, policy)?;
 
-            let programdata_state = UpgradeableLoaderState::ProgramData {
-                upgrade_authority_address: Some(system_program::id()),
-                slot: self.get_latest_absolute_slot(),
-            };
-            let mut data = bincode::serialize(&programdata_state).unwrap();
-
-            data.extend_from_slice(crate::surfnet::noop_program::NOOP_PROGRAM_ELF);
-            let lamports = self.inner.minimum_balance_for_rent_exemption(data.len());
-            Some((
-                programdata_address,
-                Account {
-                    lamports,
-                    data,
-                    owner: solana_sdk_ids::bpf_loader_upgradeable::id(),
-                    executable: false,
-                    rent_epoch: 0,
-                },
-            ))
-        };
         match account_update {
-            GetAccountResult::FoundAccount(pubkey, account, do_update_account) => {
-                if do_update_account {
-                    if let Some((programdata_address, programdata_account)) =
-                        init_programdata_account(&account)
-                    {
-                        match self.get_account(&programdata_address) {
-                            Ok(None) => {
-                                if let Err(e) =
-                                    self.set_account(&programdata_address, programdata_account)
-                                {
-                                    let _ = self.simnet_events_tx.error(e.to_string());
-                                }
-                            }
-                            Ok(Some(_)) => {}
-                            Err(e) => {
-                                let _ = self.simnet_events_tx.error(e.to_string());
-                            }
-                        }
-                    }
-                    if let Err(e) = self.set_account(&pubkey, account.clone()) {
-                        let _ = self.simnet_events_tx.error(e.to_string());
-                    }
-                }
+            GetAccountResult::FoundAccount(pubkey, account, true) => {
+                self.apply_synthetic_programdata(&account)?;
+                self.apply_account_component(pubkey, account, policy)?;
             }
+            GetAccountResult::FoundAccount(_, _, false) | GetAccountResult::None(_) => {}
             GetAccountResult::FoundProgramAccount((pubkey, account), (_, None)) => {
-                if let Some((programdata_address, programdata_account)) =
-                    init_programdata_account(&account)
-                {
-                    match self.get_account(&programdata_address) {
-                        Ok(None) => {
-                            if let Err(e) =
-                                self.set_account(&programdata_address, programdata_account)
-                            {
-                                let _ = self.simnet_events_tx.error(e.to_string());
-                            }
-                        }
-                        Ok(Some(_)) => {}
-                        Err(e) => {
-                            let _ = self.simnet_events_tx.error(e.to_string());
-                        }
-                    }
-                }
-                if let Err(e) = self.set_account(&pubkey, account.clone()) {
-                    let _ = self.simnet_events_tx.error(e.to_string());
-                }
+                self.apply_synthetic_programdata(&account)?;
+                self.apply_account_component(pubkey, account, policy)?;
             }
             GetAccountResult::FoundTokenAccount((pubkey, account), (_, None)) => {
-                if let Err(e) = self.set_account(&pubkey, account.clone()) {
-                    let _ = self.simnet_events_tx.error(e.to_string());
-                }
+                self.apply_account_component(pubkey, account, policy)?;
             }
             GetAccountResult::FoundProgramAccount(
                 (pubkey, account),
@@ -2336,16 +2277,103 @@ impl SurfnetSvm {
                 (pubkey, account),
                 (coupled_pubkey, Some(coupled_account)),
             ) => {
-                // The data account _must_ be set first, as the program account depends on it.
-                if let Err(e) = self.set_account(&coupled_pubkey, coupled_account.clone()) {
-                    let _ = self.simnet_events_tx.error(e.to_string());
-                }
-                if let Err(e) = self.set_account(&pubkey, account.clone()) {
-                    let _ = self.simnet_events_tx.error(e.to_string());
-                }
+                // Programdata and mint accounts must be available before their
+                // dependent program or token accounts.
+                self.apply_account_component(coupled_pubkey, coupled_account, policy)?;
+                self.apply_account_component(pubkey, account, policy)?;
             }
-            GetAccountResult::None(_) => {}
         }
+
+        Ok(())
+    }
+
+    fn account_update_for_policy(
+        &self,
+        account_update: GetAccountResult,
+        policy: AccountUpdatePolicy,
+    ) -> SurfpoolResult<GetAccountResult> {
+        if policy != AccountUpdatePolicy::HydrateIfAbsent {
+            return Ok(account_update);
+        }
+
+        let pubkey = match &account_update {
+            GetAccountResult::None(pubkey) | GetAccountResult::FoundAccount(pubkey, ..) => *pubkey,
+            GetAccountResult::FoundProgramAccount((pubkey, _), _)
+            | GetAccountResult::FoundTokenAccount((pubkey, _), _) => *pubkey,
+        };
+        let local = self.inner.get_account_result(&pubkey)?;
+
+        // A database result includes its own associated programdata or mint
+        // account. Prefer that complete local representation to a stale
+        // fetched result, while still allowing each component to preserve a
+        // newer LiteSVM value below.
+        if local.requires_update() {
+            Ok(local)
+        } else {
+            Ok(account_update)
+        }
+    }
+
+    fn apply_account_component(
+        &mut self,
+        pubkey: Pubkey,
+        account: Account,
+        policy: AccountUpdatePolicy,
+    ) -> SurfpoolResult<()> {
+        let account = if policy == AccountUpdatePolicy::HydrateIfAbsent {
+            match self.inner.get_account_result(&pubkey)? {
+                GetAccountResult::None(_) => account,
+                local if local.requires_update() => local.map_account()?,
+                _ => return Ok(()),
+            }
+        } else {
+            account
+        };
+
+        // Preserve the established behavior for fetched data: an account that
+        // LiteSVM rejects (such as an incomplete program upload) is still
+        // returned to the caller, with the insertion failure emitted as an
+        // event for observability.
+        if let Err(error) = self.set_account(&pubkey, account) {
+            let _ = self.simnet_events_tx.error(error.to_string());
+        }
+        Ok(())
+    }
+
+    fn apply_synthetic_programdata(&mut self, program_account: &Account) -> SurfpoolResult<()> {
+        if !program_account.executable
+            || program_account.owner != solana_sdk_ids::bpf_loader_upgradeable::id()
+        {
+            return Ok(());
+        }
+        let Ok(UpgradeableLoaderState::Program {
+            programdata_address,
+        }) = bincode::deserialize::<UpgradeableLoaderState>(&program_account.data)
+        else {
+            return Ok(());
+        };
+
+        let programdata_state = UpgradeableLoaderState::ProgramData {
+            upgrade_authority_address: Some(system_program::id()),
+            slot: self.get_latest_absolute_slot(),
+        };
+        let mut data = bincode::serialize(&programdata_state).unwrap();
+        data.extend_from_slice(crate::surfnet::noop_program::NOOP_PROGRAM_ELF);
+        let lamports = self.inner.minimum_balance_for_rent_exemption(data.len());
+
+        // A synthesized fallback is never authoritative: retain any real
+        // programdata already held in memory or in the configured database.
+        self.apply_account_component(
+            programdata_address,
+            Account {
+                lamports,
+                data,
+                owner: solana_sdk_ids::bpf_loader_upgradeable::id(),
+                executable: false,
+                rent_epoch: 0,
+            },
+            AccountUpdatePolicy::HydrateIfAbsent,
+        )
     }
 
     pub fn confirm_current_block(&mut self) -> SurfpoolResult<()> {
@@ -4490,11 +4518,12 @@ mod tests {
             rent_epoch: 0,
         };
 
-        // GetAccountResult::None should be a noop when writing account updates
+        // GetAccountResult::None should be a noop when materializing account updates.
         {
             let index_before = svm.get_all_accounts().unwrap();
             let empty_update = GetAccountResult::None(pubkey);
-            svm.write_account_update(empty_update);
+            svm.apply_account_update(empty_update, AccountUpdatePolicy::Authoritative)
+                .unwrap();
             assert_eq!(svm.get_all_accounts().unwrap(), index_before);
         }
 
@@ -4502,7 +4531,8 @@ mod tests {
         {
             let index_before = svm.get_all_accounts().unwrap();
             let found_update = GetAccountResult::FoundAccount(pubkey, account.clone(), false);
-            svm.write_account_update(found_update);
+            svm.apply_account_update(found_update, AccountUpdatePolicy::Authoritative)
+                .unwrap();
             assert_eq!(svm.get_all_accounts().unwrap(), index_before);
         }
 
@@ -4510,7 +4540,8 @@ mod tests {
         {
             let index_before = svm.get_all_accounts().unwrap();
             let found_update = GetAccountResult::FoundAccount(pubkey, account.clone(), true);
-            svm.write_account_update(found_update);
+            svm.apply_account_update(found_update, AccountUpdatePolicy::Authoritative)
+                .unwrap();
             assert_eq!(
                 svm.get_all_accounts().unwrap().len(),
                 index_before.len() + 1
@@ -4520,6 +4551,50 @@ mod tests {
                     "Expected account update event not received after GetAccountResult::FoundAccount update"
                 );
             }
+        }
+
+        // Hydration preserves live LiteSVM state, while an authoritative
+        // update explicitly replaces it.
+        {
+            let policy_pubkey = Pubkey::new_unique();
+            let local_account = Account {
+                lamports: 1,
+                data: vec![1],
+                owner: Pubkey::new_unique(),
+                executable: false,
+                rent_epoch: 0,
+            };
+            let fetched_account = Account {
+                lamports: 2,
+                data: vec![2],
+                owner: Pubkey::new_unique(),
+                executable: false,
+                rent_epoch: 0,
+            };
+            svm.set_account(&policy_pubkey, local_account.clone())
+                .unwrap();
+
+            svm.apply_account_update(
+                GetAccountResult::FoundAccount(policy_pubkey, fetched_account.clone(), true),
+                AccountUpdatePolicy::HydrateIfAbsent,
+            )
+            .unwrap();
+            assert_eq!(
+                svm.get_account(&policy_pubkey).unwrap(),
+                Some(local_account)
+            );
+
+            svm.apply_account_update(
+                GetAccountResult::FoundAccount(policy_pubkey, fetched_account.clone(), true),
+                AccountUpdatePolicy::Authoritative,
+            )
+            .unwrap();
+            assert_eq!(
+                svm.get_account(&policy_pubkey).unwrap(),
+                Some(fetched_account)
+            );
+
+            while events_rx.try_recv().is_ok() {}
         }
 
         // GetAccountResult::FoundProgramAccount with no program account inserts a default programdata account
@@ -4551,7 +4626,11 @@ mod tests {
                 (program_address, program_account.clone()),
                 (program_data_address, None),
             );
-            svm.write_account_update(found_program_account_update);
+            svm.apply_account_update(
+                found_program_account_update,
+                AccountUpdatePolicy::Authoritative,
+            )
+            .unwrap();
 
             if !expect_account_update_event(
                 &events_rx,
@@ -4585,7 +4664,11 @@ mod tests {
                 (program_address, program_account.clone()),
                 (program_data_address, Some(program_data_account.clone())),
             );
-            svm.write_account_update(found_program_account_update);
+            svm.apply_account_update(
+                found_program_account_update,
+                AccountUpdatePolicy::Authoritative,
+            )
+            .unwrap();
             assert_eq!(
                 svm.get_all_accounts().unwrap().len(),
                 index_before.len() + 2
@@ -4620,7 +4703,8 @@ mod tests {
                 program_data_account.clone(),
                 true,
             );
-            svm.write_account_update(found_update);
+            svm.apply_account_update(found_update, AccountUpdatePolicy::Authoritative)
+                .unwrap();
             assert_eq!(
                 svm.get_all_accounts().unwrap().len(),
                 index_before.len() + 1
@@ -4641,7 +4725,11 @@ mod tests {
                 (program_address, program_account.clone()),
                 (program_data_address, None),
             );
-            svm.write_account_update(program_account_found_update);
+            svm.apply_account_update(
+                program_account_found_update,
+                AccountUpdatePolicy::Authoritative,
+            )
+            .unwrap();
             assert_eq!(
                 svm.get_all_accounts().unwrap().len(),
                 index_before.len() + 1

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -2305,12 +2305,16 @@ impl SurfnetSvm {
 
         // A database result includes its own associated programdata or mint
         // account. Prefer that complete local representation to a stale
-        // fetched result, while still allowing each component to preserve a
-        // newer LiteSVM value below.
+        // fetched result. Conversely, a live primary makes the entire fetched
+        // result stale: do not install its coupled mint or programdata before
+        // skipping the primary, or the live account could observe mismatched
+        // dependency state.
         if local.requires_update() {
             Ok(local)
-        } else {
+        } else if local.is_none() {
             Ok(account_update)
+        } else {
+            Ok(GetAccountResult::None(pubkey))
         }
     }
 
@@ -4500,6 +4504,61 @@ mod tests {
             program_data_address,
             program_data_account,
         )
+    }
+
+    #[test]
+    fn hydrate_if_absent_skips_coupled_dependencies_when_primary_is_live() {
+        let (mut svm, _events_rx, _geyser_rx) = SurfnetSvm::default();
+        let local_primary = Account {
+            lamports: 1,
+            data: vec![1],
+            owner: Pubkey::new_unique(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        let fetched_primary = Account {
+            lamports: 2,
+            data: vec![2],
+            owner: Pubkey::new_unique(),
+            executable: false,
+            rent_epoch: 0,
+        };
+
+        let token_primary = Pubkey::new_unique();
+        let token_mint = Pubkey::new_unique();
+        svm.set_account(&token_primary, local_primary.clone())
+            .unwrap();
+        svm.apply_account_update(
+            GetAccountResult::FoundTokenAccount(
+                (token_primary, fetched_primary.clone()),
+                (token_mint, Some(fetched_primary.clone())),
+            ),
+            AccountUpdatePolicy::HydrateIfAbsent,
+        )
+        .unwrap();
+        assert_eq!(
+            svm.get_account(&token_primary).unwrap(),
+            Some(local_primary.clone())
+        );
+        assert!(svm.inner.get_account_no_db(&token_mint).is_none());
+
+        let program_primary = Pubkey::new_unique();
+        let programdata = Pubkey::new_unique();
+        svm.set_account(&program_primary, local_primary.clone())
+            .unwrap();
+        svm.apply_account_update(
+            GetAccountResult::FoundProgramAccount(
+                (program_primary, fetched_primary.clone()),
+                (programdata, Some(fetched_primary)),
+            ),
+            AccountUpdatePolicy::HydrateIfAbsent,
+        )
+        .unwrap();
+        assert_eq!(
+            svm.get_account(&program_primary).unwrap(),
+            Some(local_primary)
+        );
+        assert!(svm.inner.get_account_no_db(&programdata).is_none());
     }
 
     #[test_case(TestType::sqlite(); "with on-disk sqlite db")]


### PR DESCRIPTION
- Introduced AccountUpdatePolicy enum to manage authoritative vs. cache hydration updates.
- Replaced direct calls to write_account_update with apply_account_update across multiple modules.
- Updated logic in SurfnetSvm to handle account updates based on the new policy, ensuring local state is preserved when appropriate.
- Enhanced tests to validate behavior of local vs. remote account updates, ensuring local writes are not overwritten by stale remote data.
- Removed deprecated write_multiple_account_updates method and consolidated account update logic for clarity and maintainability.


Thank you @Arrowana for identifying this bug! Replaces #738