### PR TITLE
chore(sdk-node): bump @solana/kit to v8 and kit plugins to 0.18

### DIFF
--- a/.github/workflows/release_sdk_node_npm.yml
+++ b/.github/workflows/release_sdk_node_npm.yml
@@ -159,7 +159,7 @@ jobs:
           node -e "require('@solana/surfpool'); console.log('require @solana/surfpool OK');"
           # The kit peers are optional and not auto-installed; installing them
           # here validates the documented opt-in flow for the ./kit entry.
-          npm install --no-audit --no-fund "@solana/kit@^7.0.0" "@solana/kit-plugin-rpc@^0.15.0" "@solana/kit-plugin-signer@^0.13.0"
+          npm install --no-audit --no-fund "@solana/kit@^8.0.0" "@solana/kit-plugin-rpc@^0.18.0" "@solana/kit-plugin-signer@^0.18.0"
           node -e "
             const kit = require('@solana/surfpool/kit');
             if (typeof kit.surfpool !== 'function') { throw new Error('missing surfpool export'); }

--- a/.github/workflows/sdk_node.yml
+++ b/.github/workflows/sdk_node.yml
@@ -192,7 +192,7 @@ jobs:
           npm install "./$(basename "${{ steps.pack.outputs.root_pack }}")"
           # The kit peers are optional and not auto-installed; installing them
           # here validates the documented opt-in flow.
-          npm install "@solana/kit@^7.0.0" "@solana/kit-plugin-rpc@^0.15.0" "@solana/kit-plugin-signer@^0.13.0"
+          npm install "@solana/kit@^8.0.0" "@solana/kit-plugin-rpc@^0.18.0" "@solana/kit-plugin-signer@^0.18.0"
           node - <<'EOF'
           const assert = require("node:assert/strict");
           const { createClient } = require("@solana/kit");

--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -10,9 +10,9 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
-        "@solana/kit": "^7.0.0",
-        "@solana/kit-plugin-rpc": "^0.15.0",
-        "@solana/kit-plugin-signer": "^0.13.0",
+        "@solana/kit": "^8.0.0",
+        "@solana/kit-plugin-rpc": "^0.18.0",
+        "@solana/kit-plugin-signer": "^0.18.0",
         "typescript": "^5.7.0"
       },
       "engines": {
@@ -24,9 +24,9 @@
         "@solana/surfpool-linux-x64-gnu": "1.5.0"
       },
       "peerDependencies": {
-        "@solana/kit": "^7.0.0",
-        "@solana/kit-plugin-rpc": "^0.15.0",
-        "@solana/kit-plugin-signer": "^0.13.0"
+        "@solana/kit": "^8.0.0",
+        "@solana/kit-plugin-rpc": "^0.18.0",
+        "@solana/kit-plugin-signer": "^0.18.0"
       },
       "peerDependenciesMeta": {
         "@solana/kit": {
@@ -58,18 +58,18 @@
       }
     },
     "node_modules/@solana/accounts": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-7.0.0.tgz",
-      "integrity": "sha512-RfbinkhuWxcObxZIdjeWEn/mzLqRp/h2hAk/ZQCUxPdDBW8h4XxEybK9GBItGOAcrUz5HuusXTD+cXXnlIxWcg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-8.0.0.tgz",
+      "integrity": "sha512-+uqFCoI/P9oo0FGR3t3TJJxi0aoAdaEvFXzZCfNoLH5txZLTiw6/d/9QCSE/FXpbNZfk0VPGWcGN+QAXp/yrRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/rpc-spec": "7.0.0",
-        "@solana/rpc-types": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/rpc-spec": "8.0.0",
+        "@solana/rpc-types": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -84,17 +84,17 @@
       }
     },
     "node_modules/@solana/addresses": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-7.0.0.tgz",
-      "integrity": "sha512-E7sJtV5d3bXrmw3I30rcKY+xoqM++6KIVJCi+q8ZaSMyP04UMfEENPHIJ+TkyS1RUgjzPT91ka/oWrtTh6EfkQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.0.0.tgz",
+      "integrity": "sha512-hPtZOGxeMVEVoXleEsYcOj1mhxtvUTeEivE3iqCT7HJGGnYZFaV0/MduoqsEMiaBM+2ggjpVh9V7QoXPJIhbhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/assertions": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/nominal-types": "7.0.0"
+        "@solana/assertions": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/nominal-types": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -109,13 +109,13 @@
       }
     },
     "node_modules/@solana/assertions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-7.0.0.tgz",
-      "integrity": "sha512-CShOQLPezI0tbrih+L88fzt8FMHDyJoWkmulk4wfRp3HhpQL2yNlH/SWLH033qysnvkmE7TxBFUtcnbnf7jz1g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.0.0.tgz",
+      "integrity": "sha512-qvS9Jicl3ZKc4QkRhz6ZT32E/hmPMR3CkGaQccG8JhMVbOSJBK6+18IO2T03K1kNGnP335FDDL6H/Yzw0IhQ7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0"
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -130,18 +130,18 @@
       }
     },
     "node_modules/@solana/codecs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-7.0.0.tgz",
-      "integrity": "sha512-xT1IbwKkPZ544u/eqhb9SZ0fNYJidWgIUzKNQMbvLCwduayAkQp+czlGdvLQ6CVlqtCewtH3gW8biGU7YuBdEw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-8.0.0.tgz",
+      "integrity": "sha512-Pk33P602YQSYHJka2IH4LhTg9vcVskYQb/XfOCqXyXDsgJS2x3au7kpXB7Q6M5yiw8VBw8ZNu/a0iGBX44v7tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-data-structures": "7.0.0",
-        "@solana/codecs-numbers": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/fixed-points": "7.0.0",
-        "@solana/options": "7.0.0"
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-data-structures": "8.0.0",
+        "@solana/codecs-numbers": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/fixed-points": "8.0.0",
+        "@solana/options": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -156,13 +156,13 @@
       }
     },
     "node_modules/@solana/codecs-core": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-7.0.0.tgz",
-      "integrity": "sha512-6HtEisZEtFb6okARUgYqmKdDbn2aHRrSCDgB1/GEwr0s6fK5XNYpafaSjorbs2MEyZV3tCUFTj2j6fk/4nNcLg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.0.0.tgz",
+      "integrity": "sha512-WU/W1IEssIae1rKfJHAwuxvbnhwFH9+WCjD+l4oK2TiKgRDIdO3ndF58ABl5hFqgISCthHxeiFqBtd8C8EhzWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0"
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -177,15 +177,15 @@
       }
     },
     "node_modules/@solana/codecs-data-structures": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-7.0.0.tgz",
-      "integrity": "sha512-P0Ys1mB4lYlz3MMTCaJSysE3OYrq8WvsveU1ta8U/yG1qChXFGCOxPVh06swjaRxwPrEakb9VUESS5vNtp1rRA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-8.0.0.tgz",
+      "integrity": "sha512-iCwbuANIuUbr7f69wx8E7tzT5tHcrJpKq8Ni06Y7H8aKhzJUlTeNQnpCbQr/e2bhvM6VI65yaXLUNEXfM7OS6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-numbers": "7.0.0",
-        "@solana/errors": "7.0.0"
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-numbers": "8.0.0",
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -200,14 +200,14 @@
       }
     },
     "node_modules/@solana/codecs-numbers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-7.0.0.tgz",
-      "integrity": "sha512-XL0jnmnXr3ceoX4tusT+XkBVR2iGKEJecTIXbIV7ILi9xObg3fNXafNbTmbIOvKc0ByTyjo8EWZ9jQKSRWgsgA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.0.0.tgz",
+      "integrity": "sha512-Islv8gZPQhVA1DvCk3KspTTw9r0z/qL6EWwN5/vvA9LYWe11RmNarJ+C0qxg1vPh2lQh8W6t/GcpZS/TJbHI0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "7.0.0",
-        "@solana/errors": "7.0.0"
+        "@solana/codecs-core": "8.0.0",
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -222,15 +222,15 @@
       }
     },
     "node_modules/@solana/codecs-strings": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-7.0.0.tgz",
-      "integrity": "sha512-zXE1PE9HkVk6phZ6aqHTXvLZ0qIl5bJNIvG9eMB7LuFO1XBVQywJUtjKS8fE3/xmRCWSMilFSrEXGA+SpOyLrQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.0.0.tgz",
+      "integrity": "sha512-4l8XCWIFt9DYX/zH22Jygmu+DRjKpFjFE1CNqnin24+LZ6WQu6Zk3cU+nftV3OrLns2Yi+o4cSlv/eVUsxA3qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-numbers": "7.0.0",
-        "@solana/errors": "7.0.0"
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-numbers": "8.0.0",
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@solana/errors": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-7.0.0.tgz",
-      "integrity": "sha512-94r+LLSzZ0XVp+LOogwxWGXeo138uvwqtqRW9Tjl1DIXrFgh8euXnJSXZyydu1UXJs7ItOSm0QreJviSGw3TGQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.0.0.tgz",
+      "integrity": "sha512-S7vuD1EWVkp2OX9J7fQW7j7nGP3e+iuscDktheMDxpM/5d9GwfjjNiFDTOQB/SwEKuFd9PnZ5Wq5MmMBJxVSrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -274,9 +274,9 @@
       }
     },
     "node_modules/@solana/fast-stable-stringify": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-7.0.0.tgz",
-      "integrity": "sha512-i/b5ZJMqMJXa6etjypANa2/ErPZfNG9/EVIYl7HpWooyCRgZ8hZJmJ2Cgrp0r4EMXCLeWn4aEG2HOBTzOJ4F7Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-8.0.0.tgz",
+      "integrity": "sha512-2cg1e6ytDOtID8AnoqdIC0vzmEo5J2N96RtON6+nuyYjaOKH+i8T5nLmUAmVpcozcdntp899MfGGrUcxHJ/7Sw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -292,14 +292,14 @@
       }
     },
     "node_modules/@solana/fixed-points": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-7.0.0.tgz",
-      "integrity": "sha512-Y3gcyHTponi5kXpWVEJIhuZ7yT84N+8He4dbjXWqwMBJnzKM+4tqFCbzy6y+6+Jxt44RT1lDmbpxmZopFRXU8Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-8.0.0.tgz",
+      "integrity": "sha512-KA7ZA3xUIGNqDlagrTpzUtXsVSZn+vZC4odBDT3iXoRQysqV9t5g191HFH1OiTM68+7H8Rrte1Z0pTZSrQceTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "7.0.0",
-        "@solana/errors": "7.0.0"
+        "@solana/codecs-core": "8.0.0",
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/@solana/functional": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-7.0.0.tgz",
-      "integrity": "sha512-ix9fzYhc2hCLiYf+hGI00mzzayANKDExEBxbwrtMj/BdQkwgUIvIlOssqHeSqDChL3UZhq9lR24Nz4JwYX8Jbw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-8.0.0.tgz",
+      "integrity": "sha512-w5GZeeLJQyIBc21PRWPzOs7M+7aKJdbklA5cqzSx7u5cNjJQ9VDs7/JkPTtgTzrhNIqa7jqZRNf97ecx7dQVvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -332,18 +332,18 @@
       }
     },
     "node_modules/@solana/instruction-plans": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-7.0.0.tgz",
-      "integrity": "sha512-uzXHztc8hLoT5TNWFsBX2DIETyp/Lr2l36O330s3YCgpRmfI4IRbBrjjq7TxDYFm/QY8+DD4CRG8p7wZSqG8dQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-8.0.0.tgz",
+      "integrity": "sha512-sD9W72Pn59UT1swV5wwR7uFpBdAUAc+o2Am3fEFZbm24HWQVhcV5rOmCZqzu/dlU10puFFra28AEVq20o5crAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0",
-        "@solana/instructions": "7.0.0",
-        "@solana/keys": "7.0.0",
-        "@solana/promises": "7.0.0",
-        "@solana/transaction-messages": "7.0.0",
-        "@solana/transactions": "7.0.0"
+        "@solana/errors": "8.0.0",
+        "@solana/instructions": "8.0.0",
+        "@solana/keys": "8.0.0",
+        "@solana/promises": "8.0.0",
+        "@solana/transaction-messages": "8.0.0",
+        "@solana/transactions": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -358,14 +358,14 @@
       }
     },
     "node_modules/@solana/instructions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-7.0.0.tgz",
-      "integrity": "sha512-ZN0gKAtCOKDuIaStcvLZDf5H20fkk7jr4dZE0Rk7z0kslf6mrRam9Y23N6AzeHp/b5ZeVKyfaTf4M35mOktLNg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-8.0.0.tgz",
+      "integrity": "sha512-xcToa7n5IBnjaKfOBwHwj2UU+wmE7Rvh8jLFHRrSeAXzqZkABDviMrrKAPdcgD+/lhnofyuz1cYLH6cuc5hdnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "7.0.0",
-        "@solana/errors": "7.0.0"
+        "@solana/codecs-core": "8.0.0",
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -380,18 +380,18 @@
       }
     },
     "node_modules/@solana/keys": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-7.0.0.tgz",
-      "integrity": "sha512-JsdYR/YN3AGHZN2aZoeE5cymHYkNoBLnqgXoRncW/VyD7fMcR350aHU1hCMYd0b5BtITLsGmvvtvrgVkzK83Eg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-8.0.0.tgz",
+      "integrity": "sha512-nUg748MurpMmfVoWYwshpxrWsJZIcJ31mYf9xm1Z7NV0fySWyZYhgQbrEtONpMW6TPt2kpgBYDVKWs/wAyPokw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/assertions": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/nominal-types": "7.0.0",
-        "@solana/promises": "7.0.0"
+        "@solana/assertions": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/nominal-types": "8.0.0",
+        "@solana/promises": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -406,39 +406,39 @@
       }
     },
     "node_modules/@solana/kit": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-7.0.0.tgz",
-      "integrity": "sha512-ZCeai4LRJQooUmJXvpgMEGFTrCdJnV1ODbDJ8oqFZ+Y4t/9x1baQsFFpruqsdRyeGv2Rr+X6jV7cldVD+hyzRA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-8.0.0.tgz",
+      "integrity": "sha512-HAruLcW5OPVJu/T/NeMHFTPC8c6De1TjXsOGF8ZablZV14ytlyx2CwyIkOJeU2WTRq1WNM933RI/XuOBUCPrtA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@solana/accounts": "7.0.0",
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/functional": "7.0.0",
-        "@solana/instruction-plans": "7.0.0",
-        "@solana/instructions": "7.0.0",
-        "@solana/keys": "7.0.0",
-        "@solana/offchain-messages": "7.0.0",
-        "@solana/plugin-core": "7.0.0",
-        "@solana/plugin-interfaces": "7.0.0",
-        "@solana/program-client-core": "7.0.0",
-        "@solana/programs": "7.0.0",
-        "@solana/rpc": "7.0.0",
-        "@solana/rpc-api": "7.0.0",
-        "@solana/rpc-parsed-types": "7.0.0",
-        "@solana/rpc-spec-types": "7.0.0",
-        "@solana/rpc-subscriptions": "7.0.0",
-        "@solana/rpc-types": "7.0.0",
-        "@solana/signers": "7.0.0",
-        "@solana/subscribable": "7.0.0",
-        "@solana/sysvars": "7.0.0",
-        "@solana/transaction-confirmation": "7.0.0",
-        "@solana/transaction-introspection": "7.0.0",
-        "@solana/transaction-messages": "7.0.0",
-        "@solana/transactions": "7.0.0"
+        "@solana/accounts": "8.0.0",
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/functional": "8.0.0",
+        "@solana/instruction-plans": "8.0.0",
+        "@solana/instructions": "8.0.0",
+        "@solana/keys": "8.0.0",
+        "@solana/offchain-messages": "8.0.0",
+        "@solana/plugin-core": "8.0.0",
+        "@solana/plugin-interfaces": "8.0.0",
+        "@solana/program-client-core": "8.0.0",
+        "@solana/programs": "8.0.0",
+        "@solana/promises": "8.0.0",
+        "@solana/rpc": "8.0.0",
+        "@solana/rpc-api": "8.0.0",
+        "@solana/rpc-parsed-types": "8.0.0",
+        "@solana/rpc-spec-types": "8.0.0",
+        "@solana/rpc-subscriptions": "8.0.0",
+        "@solana/rpc-types": "8.0.0",
+        "@solana/signers": "8.0.0",
+        "@solana/subscribable": "8.0.0",
+        "@solana/sysvars": "8.0.0",
+        "@solana/transaction-confirmation": "8.0.0",
+        "@solana/transaction-introspection": "8.0.0",
+        "@solana/transaction-messages": "8.0.0",
+        "@solana/transactions": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -453,42 +453,42 @@
       }
     },
     "node_modules/@solana/kit-plugin-instruction-plan": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@solana/kit-plugin-instruction-plan/-/kit-plugin-instruction-plan-0.13.0.tgz",
-      "integrity": "sha512-9RA94e0LLtVLN+bvGclpu8l0lAXGOGS72DxPIQ1VyGZs7vK/WTwPOqKnWhjJs2Cv/SDJ2xsCAhYkXr0UltVrOg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit-plugin-instruction-plan/-/kit-plugin-instruction-plan-0.18.0.tgz",
+      "integrity": "sha512-GVhSf/QFtowshm4zhwqOrFI5oMpeOgRDCv5WMmYER0xZqE8+aSDxHsbEyI3dS/s4YilA296EHpQpzTAdlpj/bw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@solana/kit": "^7.0.0"
+        "@solana/kit": "^8.0.0"
       }
     },
     "node_modules/@solana/kit-plugin-rpc": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@solana/kit-plugin-rpc/-/kit-plugin-rpc-0.15.0.tgz",
-      "integrity": "sha512-Abymr7WLP9yQ6ixCCv+tKzjoWpAkxJ90JWzL+pfkTAFGTpVk9N0myhMcO2ohl6yztJRMOxsw1CXWjcVecxxUlg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit-plugin-rpc/-/kit-plugin-rpc-0.18.0.tgz",
+      "integrity": "sha512-R6q1MfdxTvcqouPV4PtDB8cXV/Ye9Mal7WZVEMFPZ/sdXbe35K92/7P3YjpQ6I1eqEv8lnBbu7/KCWExvofKVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/kit-plugin-instruction-plan": "0.13.0"
+        "@solana/kit-plugin-instruction-plan": "0.18.0"
       },
       "peerDependencies": {
-        "@solana/kit": "^7.0.0"
+        "@solana/kit": "^8.0.0"
       }
     },
     "node_modules/@solana/kit-plugin-signer": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@solana/kit-plugin-signer/-/kit-plugin-signer-0.13.0.tgz",
-      "integrity": "sha512-Vtlyt2Td8WfeQvC30yOU7a+CFo4+loMCSQKUFwvSQvbpKG39S6UyQc1euhcvtwCbJRZR3m5nAZvHayQ1rxeUkA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit-plugin-signer/-/kit-plugin-signer-0.18.0.tgz",
+      "integrity": "sha512-/CkyDE0HArqH503UUdsiiknBYpM0gAbe/QhlQ37hCRwP+WcnQkqQNdqhx999vMZaKii68ffSD8+xsvOZcSvC+w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@solana/kit": "^7.0.0"
+        "@solana/kit": "^8.0.0"
       }
     },
     "node_modules/@solana/nominal-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-7.0.0.tgz",
-      "integrity": "sha512-ff21hmKKMckDkGWah9tRXsEyFCtSnkugH+EMLGJOn7tiXdtFljOXW5Q12IXyeil87EE8aWb1MS6p8v5+hi71Vg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.0.0.tgz",
+      "integrity": "sha512-aCvkLVfJLy7q0xSbzJXLMZkLEDtxbQZtJKJJAsdi7u40KwkK4ZLITLYc7wbIVKCpxLJcs1XspwJKLZGlcFGwSQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -504,20 +504,20 @@
       }
     },
     "node_modules/@solana/offchain-messages": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-7.0.0.tgz",
-      "integrity": "sha512-fGrzxmqVStweGHRlXVAPKACdDboFCwXq5m8C+aD9Nupax6Q9rnvjICzYRLypwqB9X90XIZazh0ys+0KGLMpIJQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-8.0.0.tgz",
+      "integrity": "sha512-wynBOsq3bwwqDG+KIUK9/5hNlo/tpRjmUf+VcFWUdD0LgSRr9NtF8QL2/Modj/m+Xj1iFkjfP+p8f94iGUF56g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-data-structures": "7.0.0",
-        "@solana/codecs-numbers": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/keys": "7.0.0",
-        "@solana/nominal-types": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-data-structures": "8.0.0",
+        "@solana/codecs-numbers": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/keys": "8.0.0",
+        "@solana/nominal-types": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -532,17 +532,17 @@
       }
     },
     "node_modules/@solana/options": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-7.0.0.tgz",
-      "integrity": "sha512-6DhvMqRcL3mG0R5JejYIW5PDTDr7HcLX2R9iCs6OPN1HdsyXmE2rX2EldnuA0rYz1buOodeWYsu4N1lpDcEpaQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-8.0.0.tgz",
+      "integrity": "sha512-OOrtPfPOuJY2+jNUUUgm6d9pQewhs+fTaR6R6nRAGJOl2IVgmTOMQ6+mpj2nfH36bLXRNuXmJR7SCG64mMi8Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-data-structures": "7.0.0",
-        "@solana/codecs-numbers": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0"
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-data-structures": "8.0.0",
+        "@solana/codecs-numbers": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -557,9 +557,9 @@
       }
     },
     "node_modules/@solana/plugin-core": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-7.0.0.tgz",
-      "integrity": "sha512-EwTUfOGoQQ3aXooRlQFVbk+sJW7NqJl1K+bmSLiJUjaBTSqtbr3GtMu7aoybJqzZQKjOGSG4Hn0BzK24SvWy3A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-8.0.0.tgz",
+      "integrity": "sha512-8ciqi0mT7TocVt/ZjW0rzch8jgmaYbZeW6J2EFM2Oxe1vG2QloK+voikRxkYtsHMxGtSLfiTZDnklX24xBSa9Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -575,19 +575,21 @@
       }
     },
     "node_modules/@solana/plugin-interfaces": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-7.0.0.tgz",
-      "integrity": "sha512-fz/HknZLGnVIjhjXrMzW3Qm1x80oeEMSOk4RzMwjcyAEyfzhHtGNW74NsU5W+uFpYz6UBbV5mB1jpuAdJdnj9A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-8.0.0.tgz",
+      "integrity": "sha512-xi8co+87aAT51XBt0GJDntww172Rke+Bb+hjxPHMoNHd4C1WdMf9VQHwpGhh/km3DYYGx75JBxwpNwPZIbzNxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/instruction-plans": "7.0.0",
-        "@solana/keys": "7.0.0",
-        "@solana/rpc-spec": "7.0.0",
-        "@solana/rpc-subscriptions-spec": "7.0.0",
-        "@solana/rpc-types": "7.0.0",
-        "@solana/signers": "7.0.0"
+        "@solana/accounts": "8.0.0",
+        "@solana/addresses": "8.0.0",
+        "@solana/instruction-plans": "8.0.0",
+        "@solana/keys": "8.0.0",
+        "@solana/rpc-spec": "8.0.0",
+        "@solana/rpc-subscriptions-spec": "8.0.0",
+        "@solana/rpc-types": "8.0.0",
+        "@solana/signers": "8.0.0",
+        "@solana/transactions": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -602,21 +604,21 @@
       }
     },
     "node_modules/@solana/program-client-core": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-7.0.0.tgz",
-      "integrity": "sha512-+N8HImlR3MTbbvhOShsLelQXGZKbi6KhPhyy+4ZkDLbnRs4QikTamIChXZmoCyxB51S8/9cNRAKyQhbeF5Y8Qg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-8.0.0.tgz",
+      "integrity": "sha512-LS2cgz6imea+PLCQ9J3wKbacR127YpO8aKo/gl1x60GoBasdT1km5Dw63gsv7HEkmEF0iQZGjA9TBwYZNAOXFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/accounts": "7.0.0",
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/instruction-plans": "7.0.0",
-        "@solana/instructions": "7.0.0",
-        "@solana/plugin-interfaces": "7.0.0",
-        "@solana/rpc-api": "7.0.0",
-        "@solana/signers": "7.0.0"
+        "@solana/accounts": "8.0.0",
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/instruction-plans": "8.0.0",
+        "@solana/instructions": "8.0.0",
+        "@solana/plugin-interfaces": "8.0.0",
+        "@solana/rpc-api": "8.0.0",
+        "@solana/signers": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -631,14 +633,14 @@
       }
     },
     "node_modules/@solana/programs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-7.0.0.tgz",
-      "integrity": "sha512-a1HNgzr9YiiZ8vK4VaKHEXjnZmKX7W5ab2ghuseIalEw/+PJLFcTRTOw8n3efRu677b/bG2Icmb3MBBEXmvbPg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-8.0.0.tgz",
+      "integrity": "sha512-7n40XqVlTntQWYGwSiFyY4pQSOmCdLmI13oXWbHeSh/e1f4hJvPrVIpKe/h/liT630mSdjgxy1Je+2c7cV24Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/errors": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -653,9 +655,9 @@
       }
     },
     "node_modules/@solana/promises": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-7.0.0.tgz",
-      "integrity": "sha512-rjoHnaR4zeEIHqIzfgotxRrLKqY4Goj0G5duZOnjHm8ZC+7eDkH5/mXj1bDJ4ROM70dVM+y1Xkrjg7IL6k6StA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-8.0.0.tgz",
+      "integrity": "sha512-KYjpZeKOkW4eAserk48349BlWjPorhjP2dkGjYMG0ZRWg67tpby708Yizu1g3S4CAwOAH40EFFYTW6NXaZqcpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -671,21 +673,21 @@
       }
     },
     "node_modules/@solana/rpc": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-7.0.0.tgz",
-      "integrity": "sha512-hCf4XEhspsNb8TnQ+E961+rBuJcTyrmwNr4LDfVHEeO/VTqaN+yVwAI1wpxcnzwc+T4OoXcyujNiQWhVZPOhiA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-8.0.0.tgz",
+      "integrity": "sha512-wzo+xjw0oTVOf8jX1dfowegVv8kjpSE7AMoAcBWRiTOOzrLViYiVEPSHvJAow27TTgLoI8ujkfCl+emXFFrA9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0",
-        "@solana/fast-stable-stringify": "7.0.0",
-        "@solana/functional": "7.0.0",
-        "@solana/rpc-api": "7.0.0",
-        "@solana/rpc-spec": "7.0.0",
-        "@solana/rpc-spec-types": "7.0.0",
-        "@solana/rpc-transformers": "7.0.0",
-        "@solana/rpc-transport-http": "7.0.0",
-        "@solana/rpc-types": "7.0.0"
+        "@solana/errors": "8.0.0",
+        "@solana/fast-stable-stringify": "8.0.0",
+        "@solana/functional": "8.0.0",
+        "@solana/rpc-api": "8.0.0",
+        "@solana/rpc-spec": "8.0.0",
+        "@solana/rpc-spec-types": "8.0.0",
+        "@solana/rpc-transformers": "8.0.0",
+        "@solana/rpc-transport-http": "8.0.0",
+        "@solana/rpc-types": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -700,23 +702,23 @@
       }
     },
     "node_modules/@solana/rpc-api": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-7.0.0.tgz",
-      "integrity": "sha512-MTtBO883st83CjWpo8B4g8EKzXaeoBX5N7+sv4vcvsn2q1NpY4SG3XejdX1FrKeTe9Xjbv0/FzFtykstbKe1UA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-8.0.0.tgz",
+      "integrity": "sha512-NT2fBS9wivcMuNAwFiiiVpQ1EIR29mTzq0j7fnq9T5D4EBrl/OmA7xZXN+Z6TzUPpNLAaLADzPceXHrqqeaRSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/keys": "7.0.0",
-        "@solana/rpc-parsed-types": "7.0.0",
-        "@solana/rpc-spec": "7.0.0",
-        "@solana/rpc-transformers": "7.0.0",
-        "@solana/rpc-types": "7.0.0",
-        "@solana/transaction-messages": "7.0.0",
-        "@solana/transactions": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/keys": "8.0.0",
+        "@solana/rpc-parsed-types": "8.0.0",
+        "@solana/rpc-spec": "8.0.0",
+        "@solana/rpc-transformers": "8.0.0",
+        "@solana/rpc-types": "8.0.0",
+        "@solana/transaction-messages": "8.0.0",
+        "@solana/transactions": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -731,9 +733,9 @@
       }
     },
     "node_modules/@solana/rpc-parsed-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-7.0.0.tgz",
-      "integrity": "sha512-80VjPbB/TZ/Hy5qdRF7onPfMPHk5cwBVbtNUGbilrmFuqRzSvzSOY1ynNXXODPZBytNmPq7u7oJfSCsQ5MA9Ig==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-8.0.0.tgz",
+      "integrity": "sha512-UEzab+gqgWZ84e1SwMoofInmu5Q0a8+DB7YYC+YnzfJJjbEL/qyFPdNpIvKX3DFyHJ+Hg5rjE9iVUVOP6Pqk2w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -749,15 +751,15 @@
       }
     },
     "node_modules/@solana/rpc-spec": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-7.0.0.tgz",
-      "integrity": "sha512-GRGlXpLgap9yVh3qmCl4huuKAoLMp/p82/9Q9ONj6lmFH+RqJE4Q+16V+HxHI5ZakmwZYoVZU4GEKjumse9SCg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-8.0.0.tgz",
+      "integrity": "sha512-8Mji0374hnloSXSMgLQSCj+E/c2A8qMCa9IOm1xbdHtDu91q/1fB7v88j9jT/lHmSBbShVJLyGCI9OKzxT1Tiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0",
-        "@solana/rpc-spec-types": "7.0.0",
-        "@solana/subscribable": "7.0.0"
+        "@solana/errors": "8.0.0",
+        "@solana/rpc-spec-types": "8.0.0",
+        "@solana/subscribable": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -772,13 +774,13 @@
       }
     },
     "node_modules/@solana/rpc-spec-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-7.0.0.tgz",
-      "integrity": "sha512-V4Hp2//fW8eYq1zcGgHPu7FXKHyIWERBQd4+NRaKn2m8rPiVAm3pVRwPzSvVE0+8Nyf5qzdcfcMf7NQdhl6j7Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.0.0.tgz",
+      "integrity": "sha512-o9/NGXsY2fBOMsJxt/exjDyV+zPsDDUl0szspDdLuh2w/YUb3U9D2ZvsCmxjtWotgbmIqFn6uKKf1/0pL/Wtdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0"
+        "@solana/errors": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -793,23 +795,23 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-7.0.0.tgz",
-      "integrity": "sha512-jLNjUCGBbCIfABqqHopNJIeAkhd4GzhbodgCH4x2X+S0ycBaERX393+k+fG8JPJpGujkmeQFBCeIKO3lK+PoYg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-8.0.0.tgz",
+      "integrity": "sha512-Ar2UgTHqx6W1xFJ8JmkZiY2xvcSzrW7FrXF2cg7AiBw89PIeMcpQOUHokaZtI8bN2CHp3f5VT1d4CcKFe0UIJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0",
-        "@solana/fast-stable-stringify": "7.0.0",
-        "@solana/functional": "7.0.0",
-        "@solana/promises": "7.0.0",
-        "@solana/rpc-spec-types": "7.0.0",
-        "@solana/rpc-subscriptions-api": "7.0.0",
-        "@solana/rpc-subscriptions-channel-websocket": "7.0.0",
-        "@solana/rpc-subscriptions-spec": "7.0.0",
-        "@solana/rpc-transformers": "7.0.0",
-        "@solana/rpc-types": "7.0.0",
-        "@solana/subscribable": "7.0.0"
+        "@solana/errors": "8.0.0",
+        "@solana/fast-stable-stringify": "8.0.0",
+        "@solana/functional": "8.0.0",
+        "@solana/promises": "8.0.0",
+        "@solana/rpc-spec-types": "8.0.0",
+        "@solana/rpc-subscriptions-api": "8.0.0",
+        "@solana/rpc-subscriptions-channel-websocket": "8.0.0",
+        "@solana/rpc-subscriptions-spec": "8.0.0",
+        "@solana/rpc-transformers": "8.0.0",
+        "@solana/rpc-types": "8.0.0",
+        "@solana/subscribable": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -824,19 +826,19 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions-api": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-7.0.0.tgz",
-      "integrity": "sha512-o2PZDeNC/kg3VO3ry4R0JySJ1xMHLchZwmzVwamxGidlLe9uvzm6CHlCqv/JCq4/zHLo7qbLqnmOckZ6vlDqaw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-8.0.0.tgz",
+      "integrity": "sha512-ILmWLSRMs0cmes78FDln79OCVpRn5WwVg8aIgkH+phR6qsybg9ZA6JmVKPsNjRJzWhnvKw3cnY3YscRNk/uW2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/keys": "7.0.0",
-        "@solana/rpc-subscriptions-spec": "7.0.0",
-        "@solana/rpc-transformers": "7.0.0",
-        "@solana/rpc-types": "7.0.0",
-        "@solana/transaction-messages": "7.0.0",
-        "@solana/transactions": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/keys": "8.0.0",
+        "@solana/rpc-subscriptions-spec": "8.0.0",
+        "@solana/rpc-transformers": "8.0.0",
+        "@solana/rpc-types": "8.0.0",
+        "@solana/transaction-messages": "8.0.0",
+        "@solana/transactions": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -851,16 +853,16 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-7.0.0.tgz",
-      "integrity": "sha512-79ecXBCT2pG+vXNBZim80vUz+B04L1mEduXobBIXM55VvxsHYT+4H4V+/ZHoFJUK6Lhbt+6zhpconx8Wa3H+JA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-8.0.0.tgz",
+      "integrity": "sha512-5gOIiaA+UsDGTuVIszwUzwlGI0AKOxsStXg5abk9BdWsx8B0iEqRZ0FTXeZxHOs6t4k25yhLFkAeam7i18qKeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0",
-        "@solana/functional": "7.0.0",
-        "@solana/rpc-subscriptions-spec": "7.0.0",
-        "@solana/subscribable": "7.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/functional": "8.0.0",
+        "@solana/rpc-subscriptions-spec": "8.0.0",
+        "@solana/subscribable": "8.0.0",
         "ws": "^8.21.0"
       },
       "engines": {
@@ -876,16 +878,16 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions-spec": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-7.0.0.tgz",
-      "integrity": "sha512-Oips5ciWqPGO5Cx7hcEQ/czbcrUjPf+4cTam0UMrK3BnvHPcEAWkPYlIgabQiqa60/pjOOz7B936oMXA5XwL+g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-8.0.0.tgz",
+      "integrity": "sha512-RdKaVmuC1ATsCiiFzb8Fd5uJIouS32TvF+eVCRx/fmqHmbW7J7testCqi/gjITJGjr8JE/7qPJIoUU1dccWzLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0",
-        "@solana/promises": "7.0.0",
-        "@solana/rpc-spec-types": "7.0.0",
-        "@solana/subscribable": "7.0.0"
+        "@solana/errors": "8.0.0",
+        "@solana/promises": "8.0.0",
+        "@solana/rpc-spec-types": "8.0.0",
+        "@solana/subscribable": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -900,17 +902,17 @@
       }
     },
     "node_modules/@solana/rpc-transformers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-7.0.0.tgz",
-      "integrity": "sha512-NHkTKC2J4oaMMzyOtIEDOLCGtzg1Y8vlPoBmUeA82o+DNjBSiZLR2Ariy7n7chmwKchCZ8aGirBxjLCSRc6b/g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-8.0.0.tgz",
+      "integrity": "sha512-OA4wEcLte+WJirlYfZcsFcX6Sn5/deWaJ+G1x1VbfDYXwGEzo39JBk7A23VZ9T9MOmDfpgfds7lCjCix9lFZJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0",
-        "@solana/functional": "7.0.0",
-        "@solana/nominal-types": "7.0.0",
-        "@solana/rpc-spec-types": "7.0.0",
-        "@solana/rpc-types": "7.0.0"
+        "@solana/errors": "8.0.0",
+        "@solana/functional": "8.0.0",
+        "@solana/nominal-types": "8.0.0",
+        "@solana/rpc-spec-types": "8.0.0",
+        "@solana/rpc-types": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -925,16 +927,16 @@
       }
     },
     "node_modules/@solana/rpc-transport-http": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-7.0.0.tgz",
-      "integrity": "sha512-W0G15BN0xljXzRRo/ZwepJNiOjKhRImF5SxhjZauh2yVBoUjfd6NSCmYcdWu0tj9lypKKrB1ReS4oPmb4yCHbA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-8.0.0.tgz",
+      "integrity": "sha512-fGk4ym3zApquQnKI2vyO+wdEwfKEKsRQfUunLVgjAMLYSd2dxV4rQ2rFErxzJpJE0gMWE3vBH9JTPm9NXHgiuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0",
-        "@solana/rpc-spec": "7.0.0",
-        "@solana/rpc-spec-types": "7.0.0",
-        "undici-types": "^8.5.0"
+        "@solana/errors": "8.0.0",
+        "@solana/rpc-spec": "8.0.0",
+        "@solana/rpc-spec-types": "8.0.0",
+        "undici-types": "^8.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -949,19 +951,19 @@
       }
     },
     "node_modules/@solana/rpc-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-7.0.0.tgz",
-      "integrity": "sha512-Lf2csFSWHwN/8EL03uWfS7n1J19vWLK4DBGkQ5jebRhoJ3dD+xPcJtS+epI2281t5aghJvoV7D+RIM0NextZJg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.0.0.tgz",
+      "integrity": "sha512-OvuMUHeeuK7cySRGs8pMd/qXvYyUiAAeTI6NRgQCR0moRbegQ9DqtQycnS1y9wkpywv8bEjpoJoi8QZfMpx/WQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-numbers": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/fixed-points": "7.0.0",
-        "@solana/nominal-types": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-numbers": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/fixed-points": "8.0.0",
+        "@solana/nominal-types": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -976,21 +978,21 @@
       }
     },
     "node_modules/@solana/signers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-7.0.0.tgz",
-      "integrity": "sha512-4E3xYQ0b9OZCTLghqfeHh66lfipy3jV1REdFJLk9WqPBaXVa/wSgGGIqZVa744ATSd9AeEfL/I5n/LrMNQOhoA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-8.0.0.tgz",
+      "integrity": "sha512-yKqD54Hh8a+BBgjdcyRDYukKRG9d2Zj9aLAOuXapIcj1fWG1bWGIf3LEdVAjdoNJPTa2NEb787ouM6QOA+DAMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/instructions": "7.0.0",
-        "@solana/keys": "7.0.0",
-        "@solana/nominal-types": "7.0.0",
-        "@solana/offchain-messages": "7.0.0",
-        "@solana/transaction-messages": "7.0.0",
-        "@solana/transactions": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/instructions": "8.0.0",
+        "@solana/keys": "8.0.0",
+        "@solana/nominal-types": "8.0.0",
+        "@solana/offchain-messages": "8.0.0",
+        "@solana/transaction-messages": "8.0.0",
+        "@solana/transactions": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -1005,14 +1007,14 @@
       }
     },
     "node_modules/@solana/subscribable": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-7.0.0.tgz",
-      "integrity": "sha512-dJQA5AxDv/7YxuNe7GXIkaOUNhXczFaL3/SNOvXe7k77bC4dx4HPkySfcVDfEWBOePe3+8iyVbT8DZ3aOcp8Ng==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-8.0.0.tgz",
+      "integrity": "sha512-/vu8j2WeAklP5h7xBgbrM4zG9/W+lju0HN50f0qMRqcmo1VhQejHFb42MVaHFb3iRUvsuvC2M627DGUFb8CMZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "7.0.0",
-        "@solana/promises": "7.0.0"
+        "@solana/errors": "8.0.0",
+        "@solana/promises": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -1075,18 +1077,18 @@
       }
     },
     "node_modules/@solana/sysvars": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-7.0.0.tgz",
-      "integrity": "sha512-GKND6hCcBcrak3/VAtx6aEoAi9wQjJQzU2Fcu6JYmnTjGe5MHf21FqbjGl0aQ0C2HlJQQJmA07wgsuOiYDTDog==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-8.0.0.tgz",
+      "integrity": "sha512-z8bZDr/RfvEeQr5t2UVtdG/qzS5yjBnTpcuVvpQcoWqkfzMISb5+dMTc1qiYtnwGz2176QZROgZ7+OQogfDbnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/accounts": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-data-structures": "7.0.0",
-        "@solana/codecs-numbers": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/rpc-types": "7.0.0"
+        "@solana/accounts": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-data-structures": "8.0.0",
+        "@solana/codecs-numbers": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/rpc-types": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -1101,22 +1103,22 @@
       }
     },
     "node_modules/@solana/transaction-confirmation": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-7.0.0.tgz",
-      "integrity": "sha512-SaU2CY9ZDJGK47DtQ7xwKFmbgzDGqIN/Ug89ZSUzDPD9QdMRXhtxgH8KZgb0gSgpyel85sSt0QH9wkWzhp69ow==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-8.0.0.tgz",
+      "integrity": "sha512-vz72wtWChtoqzCXmYpQwD0ZRtA1qM10FGg+hwtmUeoxvoq014MAJ5JEJ4PN5X3D5ST/qdmv3TmmFyfdyJ8kfCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/keys": "7.0.0",
-        "@solana/promises": "7.0.0",
-        "@solana/rpc": "7.0.0",
-        "@solana/rpc-subscriptions": "7.0.0",
-        "@solana/rpc-types": "7.0.0",
-        "@solana/transaction-messages": "7.0.0",
-        "@solana/transactions": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/keys": "8.0.0",
+        "@solana/promises": "8.0.0",
+        "@solana/rpc": "8.0.0",
+        "@solana/rpc-subscriptions": "8.0.0",
+        "@solana/rpc-types": "8.0.0",
+        "@solana/transaction-messages": "8.0.0",
+        "@solana/transactions": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -1131,20 +1133,20 @@
       }
     },
     "node_modules/@solana/transaction-introspection": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-introspection/-/transaction-introspection-7.0.0.tgz",
-      "integrity": "sha512-aO+5ewxGaziXYcXJZ6F3doq/KI1L3WU2z5eCjs4DBO0kRQBHp4bH6ZKygVX2JIxOZrd1rB9SxP/CCCX2wRm8Xw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-introspection/-/transaction-introspection-8.0.0.tgz",
+      "integrity": "sha512-GkmR+SXN70Amh1f+MvzEGUiqr3/YL/FyEqeT6oCAMTR2AidXfyZIKNkoTB4+1jABeXFFMaYiCfPhKD6+BznnXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/instructions": "7.0.0",
-        "@solana/rpc-api": "7.0.0",
-        "@solana/transaction-messages": "7.0.0",
-        "@solana/transactions": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/instructions": "8.0.0",
+        "@solana/rpc-types": "8.0.0",
+        "@solana/transaction-messages": "8.0.0",
+        "@solana/transactions": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -1159,21 +1161,21 @@
       }
     },
     "node_modules/@solana/transaction-messages": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-7.0.0.tgz",
-      "integrity": "sha512-qCBYR3QQvykcI36vnqwI5090hGXS3mmCe72b/f/n9kBsBaA2oowdBXZupB1wwKe8+6x8o8VkhKQaK9oTKKbWTg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-8.0.0.tgz",
+      "integrity": "sha512-/3QXUWIPLDicPLOt2aVczgTRJrWih59mHndLOwCD3i7/phGFnH66cjoyYy7+ootJJJwDlsgMoOmgdGJJHnqyFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-data-structures": "7.0.0",
-        "@solana/codecs-numbers": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/functional": "7.0.0",
-        "@solana/instructions": "7.0.0",
-        "@solana/nominal-types": "7.0.0",
-        "@solana/rpc-types": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-data-structures": "8.0.0",
+        "@solana/codecs-numbers": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/functional": "8.0.0",
+        "@solana/instructions": "8.0.0",
+        "@solana/nominal-types": "8.0.0",
+        "@solana/rpc-types": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -1188,24 +1190,24 @@
       }
     },
     "node_modules/@solana/transactions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-7.0.0.tgz",
-      "integrity": "sha512-y5nayd2Ozld/4Bxefz50e/E6qxyZteuZCZ7suh7z96KY6QUJlZDR+eCG1v/lA7Azt3GSOevJuYFX/ept/mqZkw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-8.0.0.tgz",
+      "integrity": "sha512-8HQmyVN9qv0v1ylTqOR38T8834oQ+sPLSRpPueTd5yfwiv60CtUwndHg1M+y5n7Q4DP1jJZ0M5YReJ5BpnD2Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "7.0.0",
-        "@solana/codecs-core": "7.0.0",
-        "@solana/codecs-data-structures": "7.0.0",
-        "@solana/codecs-numbers": "7.0.0",
-        "@solana/codecs-strings": "7.0.0",
-        "@solana/errors": "7.0.0",
-        "@solana/functional": "7.0.0",
-        "@solana/instructions": "7.0.0",
-        "@solana/keys": "7.0.0",
-        "@solana/nominal-types": "7.0.0",
-        "@solana/rpc-types": "7.0.0",
-        "@solana/transaction-messages": "7.0.0"
+        "@solana/addresses": "8.0.0",
+        "@solana/codecs-core": "8.0.0",
+        "@solana/codecs-data-structures": "8.0.0",
+        "@solana/codecs-numbers": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
+        "@solana/errors": "8.0.0",
+        "@solana/functional": "8.0.0",
+        "@solana/instructions": "8.0.0",
+        "@solana/keys": "8.0.0",
+        "@solana/nominal-types": "8.0.0",
+        "@solana/rpc-types": "8.0.0",
+        "@solana/transaction-messages": "8.0.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -1248,7 +1250,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1258,16 +1259,16 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
-      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.10.0.tgz",
+      "integrity": "sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/crates/sdk-node/package.json
+++ b/crates/sdk-node/package.json
@@ -71,15 +71,15 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
-    "@solana/kit": "^7.0.0",
-    "@solana/kit-plugin-rpc": "^0.15.0",
-    "@solana/kit-plugin-signer": "^0.13.0",
+    "@solana/kit": "^8.0.0",
+    "@solana/kit-plugin-rpc": "^0.18.0",
+    "@solana/kit-plugin-signer": "^0.18.0",
     "typescript": "^5.7.0"
   },
   "peerDependencies": {
-    "@solana/kit": "^7.0.0",
-    "@solana/kit-plugin-rpc": "^0.15.0",
-    "@solana/kit-plugin-signer": "^0.13.0"
+    "@solana/kit": "^8.0.0",
+    "@solana/kit-plugin-rpc": "^0.18.0",
+    "@solana/kit-plugin-signer": "^0.18.0"
   },
   "peerDependenciesMeta": {
     "@solana/kit": {


### PR DESCRIPTION
## Summary
- Bump `@solana/kit` to v8 and `@solana/kit-plugin-rpc`/`@solana/kit-plugin-signer` to 0.18 in both dev and peer deps.
- No source changes needed — the kit surface the SDK uses is unchanged across v7 → v8.
- Consumers of `@solana/surfpool/kit` now need kit v8; the peer range no longer accepts v7.

## Test Plan
- `npm run build:ts` and `npm test` in `crates/sdk-node` (20/20 pass, includes `typecheck:kit`).

Refs TOO-650
