### PR TITLE
fix(core): verify datasource TLS certificates by default

### DIFF
--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -284,6 +284,14 @@ pub struct StartNetworkOptions {
         long_help = "Run without a remote RPC datasource. Use this to simulate an offline environment.\n\nExample: surfpool start --offline"
     )]
     pub offline: bool,
+    /// Accept any TLS certificate presented by the datasource RPC.
+    #[clap(
+        long = "allow-insecure-remote-tls",
+        action=ArgAction::SetTrue,
+        default_value = "false",
+        long_help = "Accept any TLS certificate presented by the datasource RPC, including self-signed and expired ones.\n\nAccounts fetched from the datasource are loaded straight into the local SVM, so this lets anyone able to intercept the connection choose the account state and program bytecode your surfnet runs against. Use it only for a datasource you control on a network you trust.\n\nExample: surfpool start --rpc-url https://localhost:8899 --allow-insecure-remote-tls"
+    )]
+    pub allow_insecure_remote_tls: bool,
 }
 
 #[derive(Args, PartialEq, Clone, Debug)]
@@ -678,6 +686,7 @@ impl StartSimnet {
             airdrop_token_amount: self.accounts.airdrop_token_amount,
             expiry: None,
             offline_mode: self.network.offline,
+            allow_insecure_remote_tls: self.network.allow_insecure_remote_tls,
             instruction_profiling_enabled: !self.observability.disable_instruction_profiling,
             max_profiles: self.observability.max_profiles,
             log_bytes_limit: if self.observability.log_bytes_limit == 0 {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -43,7 +43,7 @@ libloading = { workspace = true }
 litesvm = { workspace = true }
 litesvm-token = { workspace = true }
 log = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }                                  # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_json = { workspace = true }

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -186,11 +186,12 @@ pub async fn start_local_surfnet_runloop(
 
     let remote_rpc_client = match simnet.offline_mode {
         true => None,
-        false => SurfnetRemoteClient::new_unsafe(
+        false => SurfnetRemoteClient::new_with_tls_policy(
             simnet
                 .remote_rpc_url
                 .as_ref()
                 .unwrap_or(&DEFAULT_MAINNET_RPC_URL.to_string()),
+            simnet.allow_insecure_remote_tls,
         ),
     };
 
@@ -200,6 +201,14 @@ pub async fn start_local_surfnet_runloop(
         svm_locker
             .simnet_events_tx()
             .connected(remote_client.client.url());
+        // Arming the opt-in is worth saying out loud: from here on, anything
+        // able to intercept the datasource connection picks what lands in the
+        // local bank.
+        if simnet.allow_insecure_remote_tls {
+            svm_locker.simnet_events_tx().warn(
+                "TLS certificate verification is disabled for the datasource (--allow-insecure-remote-tls): fork data is not authenticated",
+            );
+        }
     }
     svm_locker
         .simnet_events_tx()
@@ -567,7 +576,10 @@ pub async fn start_block_production_runloop(
                     SimnetCommand::FetchRemoteAccounts(pubkeys, remote_url) => {
                         // The submitter already marked RemoteAccounts as started;
                         // StartStartupTask precedes this command on the same channel.
-                        let fetch_result = match SurfnetRemoteClient::new_unsafe(&remote_url) {
+                        let fetch_result = match SurfnetRemoteClient::new_with_tls_policy(
+                            &remote_url,
+                            simnet_config.allow_insecure_remote_tls,
+                        ) {
                             Some(remote_client) => match svm_locker
                                 .get_multiple_accounts_with_remote_fallback(
                                     &remote_client,

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr, time::Duration};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use serde_json::json;
@@ -119,13 +119,19 @@ impl SurfpoolRpcClient {
         SurfpoolRpcClient { client }
     }
 
-    /// A variant that accepts invalid TLS certificates, for datasources
-    /// behind self-signed certs.
-    fn new_unsafe<U: ToString>(remote_rpc_url: U) -> Option<Self> {
+    /// A variant that accepts any TLS certificate, for datasources behind
+    /// self-signed certs. Anything the datasource returns is written straight
+    /// into the local bank, so an unverified transport lets an on-path
+    /// attacker choose the account state and program bytecode a surfnet runs
+    /// against: only reach this through the explicit
+    /// `--allow-insecure-remote-tls` opt-in, never by default.
+    fn new_without_tls_verification<U: ToString>(remote_rpc_url: U) -> Option<Self> {
         use reqwest;
 
         // Construction can fail after a fork (the daemonize path), so a
-        // failure logs and surfaces as None rather than a panic.
+        // failure logs and surfaces as None rather than a panic. The built-in
+        // root stores stay off because nothing consults them once every
+        // certificate is accepted, and loading them is what tends to fail here.
         let client = match reqwest::Client::builder()
             .danger_accept_invalid_certs(true)
             .tls_built_in_root_certs(false)
@@ -148,15 +154,15 @@ impl SurfpoolRpcClient {
     }
 }
 
+/// The datasource handle the rest of the surfnet holds.
+///
+/// The client sits behind an [`Arc`] so a clone shares the transport the
+/// original was built with. Rebuilding it from `client.url()` instead would
+/// carry the URL across but not the TLS posture, which is how every clone of a
+/// verified client used to end up unverified.
+#[derive(Clone)]
 pub struct SurfnetRemoteClient {
-    pub client: RpcClient,
-}
-impl Clone for SurfnetRemoteClient {
-    fn clone(&self) -> Self {
-        let remote_rpc_url = self.client.url();
-        SurfnetRemoteClient::new_unsafe(remote_rpc_url)
-            .expect("unable to clone SurfnetRemoteClient")
-    }
+    pub client: Arc<RpcClient>,
 }
 
 pub trait SomeRemoteCtx {
@@ -171,16 +177,42 @@ impl SomeRemoteCtx for Option<SurfnetRemoteClient> {
 }
 
 impl SurfnetRemoteClient {
+    /// A client that verifies the datasource's TLS certificate chain.
     pub fn new<U: ToString>(remote_rpc_url: U) -> Self {
         SurfnetRemoteClient {
-            client: SurfpoolRpcClient::new(remote_rpc_url).client,
+            client: Arc::new(SurfpoolRpcClient::new(remote_rpc_url).client),
         }
     }
 
-    pub fn new_unsafe<U: ToString>(remote_rpc_url: U) -> Option<Self> {
-        SurfpoolRpcClient::new_unsafe(remote_rpc_url).map(|rpc_client| SurfnetRemoteClient {
-            client: rpc_client.client,
+    /// A client that accepts any TLS certificate, for datasources behind
+    /// self-signed certs.
+    ///
+    /// Fetched accounts are written straight into the local bank, so an
+    /// unverified transport lets an on-path attacker choose the account state
+    /// and program bytecode a surfnet runs against. Reach this only through
+    /// the operator's explicit `--allow-insecure-remote-tls` opt-in, which
+    /// [`Self::new_with_tls_policy`] exists to carry.
+    pub fn new_without_tls_verification<U: ToString>(remote_rpc_url: U) -> Option<Self> {
+        SurfpoolRpcClient::new_without_tls_verification(remote_rpc_url).map(|rpc_client| {
+            SurfnetRemoteClient {
+                client: Arc::new(rpc_client.client),
+            }
         })
+    }
+
+    /// Builds a datasource client honouring the surfnet's TLS policy.
+    ///
+    /// `None` means the client could not be built at all, which only the
+    /// unverified path can report; the verified path always succeeds.
+    pub fn new_with_tls_policy<U: ToString>(
+        remote_rpc_url: U,
+        allow_insecure_tls: bool,
+    ) -> Option<Self> {
+        if allow_insecure_tls {
+            Self::new_without_tls_verification(remote_rpc_url)
+        } else {
+            Some(Self::new(remote_rpc_url))
+        }
     }
 
     pub async fn get_epoch_info(&self) -> SurfpoolResult<EpochInfo> {

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -845,6 +845,14 @@ pub enum StartupPlanner {
 pub struct SimnetConfig {
     pub offline_mode: bool,
     pub remote_rpc_url: Option<String>,
+    /// Accept any TLS certificate the datasource presents.
+    ///
+    /// Off unless the operator asks for it: fetched accounts are written
+    /// straight into the local bank, so skipping verification lets an on-path
+    /// attacker pick the account state and program bytecode this surfnet runs
+    /// against. Exists for datasources behind self-signed certs.
+    #[serde(default)]
+    pub allow_insecure_remote_tls: bool,
     pub slot_time: u64,
     pub block_production_mode: BlockProductionMode,
     pub airdrop_addresses: Vec<Pubkey>,
@@ -869,6 +877,7 @@ impl Default for SimnetConfig {
         Self {
             offline_mode: false,
             remote_rpc_url: Some(DEFAULT_MAINNET_RPC_URL.to_string()),
+            allow_insecure_remote_tls: false,
             slot_time: DEFAULT_SLOT_TIME_MS, // Default to 400ms to match CLI default
             block_production_mode: BlockProductionMode::Clock,
             airdrop_addresses: vec![],


### PR DESCRIPTION
The datasource client disabled certificate verification on every connection, including the default public mainnet endpoint. Fetched accounts are written straight into the local bank, so an on-path attacker could impersonate the upstream RPC and choose the account state and program bytecode a surfnet runs against.

Three things kept the unverified path in play:

- `SurfnetRemoteClient::new_unsafe` was hardcoded at both runloop call sites rather than gated behind an opt-in. It is renamed `new_without_tls_verification` and is now reachable only through the operator's explicit choice; its body is unchanged, so anyone who genuinely needs it gets the old behaviour.
- `impl Clone` rebuilt the client from `client.url()`, which carried the URL across but not the TLS posture, so every clone of a verified client came back unverified. The client now sits behind an `Arc` with a derived `Clone`, which makes that structurally impossible rather than a rule to remember, and drops an `expect()` panic with it.
- Both call sites route through `new_with_tls_policy`, fed by the new `--allow-insecure-remote-tls` flag. `SimnetConfig` carries it as `#[serde(default)]` so existing serialized configs still load, and arming it emits a simnet warning rather than being silently true.

`crates/core` also gains an explicit `rustls-tls` feature on reqwest. The workspace dep sets `default-features = false`, and `danger_accept_invalid_certs` is gated behind reqwest's `__tls` cfg, so the crate previously compiled only by borrowing a TLS backend from `crates/cli` or `crates/studio` through feature unification.

Refs solana-foundation/surfpool#757