### PR TITLE
fix(core): report Geyser indices and serialize bundle commits

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -84,10 +84,10 @@ impl From<solana_client::client_error::ClientError> for SurfpoolError {
 }
 
 impl SurfpoolError {
-    pub fn stale_bundle_sandbox_slot(sandbox_slot: Slot, live_slot: Slot) -> Self {
-        let mut error = Error::invalid_request();
+    pub(crate) fn bundle_sandbox_slot_mismatch(sandbox_slot: Slot, live_slot: Slot) -> Self {
+        let mut error = Error::internal_error();
         error.data = Some(json!(format!(
-            "Bundle sandbox executed at slot {sandbox_slot}, but the live Surfnet advanced to slot {live_slot} before commit"
+            "Bundle sandbox slot {sandbox_slot} does not match live slot {live_slot}"
         )));
         Self(error)
     }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -84,6 +84,14 @@ impl From<solana_client::client_error::ClientError> for SurfpoolError {
 }
 
 impl SurfpoolError {
+    pub fn stale_bundle_sandbox_slot(sandbox_slot: Slot, live_slot: Slot) -> Self {
+        let mut error = Error::invalid_request();
+        error.data = Some(json!(format!(
+            "Bundle sandbox executed at slot {sandbox_slot}, but the live Surfnet advanced to slot {live_slot} before commit"
+        )));
+        Self(error)
+    }
+
     pub fn from_try_send_error<T>(e: TrySendError<T>) -> Self {
         let mut error = Error::internal_error();
         error.data = Some(json!(format!(

--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -308,12 +308,12 @@ impl Jito for SurfpoolJitoRpc {
             }
 
             // -- Phase A: Sandbox execution -------------------------------------------------
-            // Take a brief read lock on the original VM to construct a sandbox whose storages
-            // are overlay-wrapped, whose subscription registries are empty (no live WS leak),
-            // and whose event channels buffer into receivers we hold here.
-            let bundle_sandbox = ctx
-                .svm_locker
-                .with_svm_reader(|svm_reader| svm_reader.clone_for_bundle_sandbox());
+            // Keep the original VM exclusively locked from sandbox creation through commit.
+            // The sandbox owns independent state, so processing below never re-enters this
+            // lock. This prevents clock ticks and RPC transactions from invalidating the
+            // sandbox's slot or account-state snapshot before the atomic commit.
+            let mut original_svm = ctx.svm_locker.0.write().await;
+            let bundle_sandbox = original_svm.clone_for_bundle_sandbox();
 
             let BundleSandbox {
                 svm: sandbox_svm,
@@ -397,7 +397,8 @@ impl Jito for SurfpoolJitoRpc {
             // -- Phase B: Atomic commit -----------------------------------------------------
             // All bundle transactions succeeded on the sandbox. Extract the sandbox SVM (the
             // only remaining Arc reference is the local `sandbox_locker`), reassemble the
-            // BundleSandbox and call commit_sandbox under the original VM's writer lock.
+            // BundleSandbox and commit it while retaining the writer guard acquired before
+            // sandbox creation.
             let sandbox_svm = match Arc::try_unwrap(sandbox_locker.0) {
                 Ok(rwlock) => rwlock.into_inner(),
                 Err(_) => {
@@ -419,15 +420,14 @@ impl Jito for SurfpoolJitoRpc {
             // silently.
             let (bundle_status_tx, _bundle_status_rx) = crossbeam_channel::unbounded();
 
-            ctx.svm_locker
-                .with_svm_writer(move |original| {
-                    original.commit_sandbox(reassembled, bundle_status_tx)
-                })
+            original_svm
+                .commit_sandbox(reassembled, bundle_status_tx)
                 .map_err(|e| {
                     Error::invalid_params(format!(
                         "Jito bundle commit failed after successful sandbox execution: {e}"
                     ))
                 })?;
+            drop(original_svm);
 
             // Calculate bundle ID by hashing comma-separated signatures (Jito-compatible)
             // https://github.com/jito-foundation/jito-solana/blob/master/sdk/src/bundle/mod.rs#L21

--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -307,20 +307,15 @@ impl Jito for SurfpoolJitoRpc {
                 decoded_txs.push(tx);
             }
 
-            // -- Phase A: Sandbox execution -------------------------------------------------
-            // Keep the original VM exclusively locked from sandbox creation through commit.
-            // The sandbox owns independent state, so processing below never re-enters this
-            // lock. This prevents clock ticks and RPC transactions from invalidating the
-            // sandbox's slot or account-state snapshot before the atomic commit.
-            let mut original_svm = ctx.svm_locker.0.write().await;
-            let bundle_sandbox = original_svm.clone_for_bundle_sandbox();
+            // Keep the live VM stable while the bundle executes and commits.
+            let mut live_svm_guard = ctx.svm_locker.0.write().await;
+            let bundle_sandbox = live_svm_guard.clone_for_bundle_sandbox();
 
             let BundleSandbox {
                 svm: sandbox_svm,
                 geyser_rx,
                 simnet_rx,
                 confirmation_queue_base_len,
-                finalization_queue_base_len,
             } = bundle_sandbox;
 
             let sandbox_locker = SurfnetSvmLocker::new(sandbox_svm);
@@ -394,11 +389,8 @@ impl Jito for SurfpoolJitoRpc {
                 }
             }
 
-            // -- Phase B: Atomic commit -----------------------------------------------------
             // All bundle transactions succeeded on the sandbox. Extract the sandbox SVM (the
-            // only remaining Arc reference is the local `sandbox_locker`), reassemble the
-            // BundleSandbox and commit it while retaining the writer guard acquired before
-            // sandbox creation.
+            // only remaining Arc reference is the local `sandbox_locker`) and commit it.
             let sandbox_svm = match Arc::try_unwrap(sandbox_locker.0) {
                 Ok(rwlock) => rwlock.into_inner(),
                 Err(_) => {
@@ -412,7 +404,6 @@ impl Jito for SurfpoolJitoRpc {
                 geyser_rx,
                 simnet_rx,
                 confirmation_queue_base_len,
-                finalization_queue_base_len,
             };
 
             // Use a discardable status channel for the bundle. The runloop will use it to
@@ -420,14 +411,12 @@ impl Jito for SurfpoolJitoRpc {
             // silently.
             let (bundle_status_tx, _bundle_status_rx) = crossbeam_channel::unbounded();
 
-            original_svm
+            live_svm_guard
                 .commit_sandbox(reassembled, bundle_status_tx)
-                .map_err(|e| {
-                    Error::invalid_params(format!(
-                        "Jito bundle commit failed after successful sandbox execution: {e}"
-                    ))
-                })?;
-            drop(original_svm);
+                .map_err(Error::from)?;
+
+            // store_bundle reacquires the same lock.
+            drop(live_svm_guard);
 
             // Calculate bundle ID by hashing comma-separated signatures (Jito-compatible)
             // https://github.com/jito-foundation/jito-solana/blob/master/sdk/src/bundle/mod.rs#L21
@@ -1429,6 +1418,104 @@ mod tests {
             bundle_id, expected_bundle_id,
             "Bundle ID should match SHA-256 of comma-separated signatures"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_send_bundle_keeps_slot_stable_through_commit() {
+        let payer = Keypair::new();
+        let setup = TestSetup::new(SurfpoolJitoRpc);
+        let recent_blockhash = setup
+            .context
+            .svm_locker
+            .with_svm_reader(|svm| svm.latest_blockhash());
+        let initial_slot = setup
+            .context
+            .svm_locker
+            .with_svm_reader(|svm| svm.get_latest_absolute_slot());
+
+        setup
+            .context
+            .svm_locker
+            .0
+            .write()
+            .await
+            .airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL)
+            .expect("airdrop should complete")
+            .expect("airdrop should succeed");
+
+        let transactions = (0..MAX_BUNDLE_SIZE)
+            .map(|_| {
+                build_v0_transaction(
+                    &payer.pubkey(),
+                    &[&payer],
+                    &[system_instruction::transfer(
+                        &payer.pubkey(),
+                        &Pubkey::new_unique(),
+                        LAMPORTS_PER_SOL,
+                    )],
+                    &recent_blockhash,
+                )
+            })
+            .collect::<Vec<_>>();
+        let signatures = transactions
+            .iter()
+            .map(|transaction| transaction.signatures[0])
+            .collect::<Vec<_>>();
+        let encoded_transactions = transactions
+            .iter()
+            .map(|transaction| bs58::encode(bincode::serialize(transaction).unwrap()).into_string())
+            .collect::<Vec<_>>();
+
+        let bundle_context = setup.context.clone();
+        let bundle_task = tokio::spawn(async move {
+            SurfpoolJitoRpc
+                .send_bundle(Some(bundle_context), encoded_transactions, None)
+                .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match setup.context.svm_locker.0.try_write() {
+                    Ok(guard) => drop(guard),
+                    Err(_) => break,
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("sendBundle should lock the live SVM");
+
+        let slot_locker = setup.context.svm_locker.clone();
+        let slot_task = tokio::spawn(async move {
+            slot_locker
+                .0
+                .write()
+                .await
+                .confirm_current_block()
+                .expect("slot advance should succeed");
+        });
+
+        let (bundle_result, slot_result) = tokio::join!(bundle_task, slot_task);
+        bundle_result
+            .expect("sendBundle task should complete")
+            .expect("bundle should commit");
+        slot_result.expect("slot task should complete");
+
+        let transaction_slots = setup.context.svm_locker.with_svm_reader(|svm| {
+            signatures
+                .iter()
+                .map(|signature| {
+                    svm.transactions
+                        .get(&signature.to_string())
+                        .expect("transaction lookup should succeed")
+                        .expect("bundle transaction should be stored")
+                        .expect_processed()
+                        .0
+                        .slot
+                })
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(transaction_slots, vec![initial_slot; MAX_BUNDLE_SIZE]);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -319,6 +319,8 @@ impl Jito for SurfpoolJitoRpc {
                 svm: sandbox_svm,
                 geyser_rx,
                 simnet_rx,
+                confirmation_queue_base_len,
+                finalization_queue_base_len,
             } = bundle_sandbox;
 
             let sandbox_locker = SurfnetSvmLocker::new(sandbox_svm);
@@ -408,6 +410,8 @@ impl Jito for SurfpoolJitoRpc {
                 svm: sandbox_svm,
                 geyser_rx,
                 simnet_rx,
+                confirmation_queue_base_len,
+                finalization_queue_base_len,
             };
 
             // Use a discardable status channel for the bundle. The runloop will use it to
@@ -708,6 +712,7 @@ impl Jito for SurfpoolJitoRpc {
                 svm: sandbox_svm,
                 geyser_rx: _geyser_rx, // discarded on drop
                 simnet_rx: _simnet_rx, // discarded on drop
+                ..
             } = bundle_sandbox;
             let sandbox_locker = SurfnetSvmLocker::new(sandbox_svm);
 

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -734,13 +734,13 @@ fn start_geyser_runloop(
                     Err(e) => {
                         break format!("Failed to read new transaction to send to Geyser plugin: {e}");
                     },
-                    Ok(GeyserEvent::NotifyTransaction(transaction_with_status_meta, versioned_transaction, transaction_index)) => {
+                    Ok(GeyserEvent::NotifyTransaction(event)) => {
 
                         if !indexing_enabled {
                             continue;
                         }
 
-                        let transaction = match versioned_transaction {
+                        let transaction = match event.versioned_transaction {
                             Some(tx) => tx,
                             None => {
                                 log_warn("Unable to index sanitized transaction".to_string());
@@ -752,13 +752,13 @@ fn start_geyser_runloop(
                             signature: &transaction.signatures[0],
                             is_vote: false,
                             transaction: &transaction,
-                            transaction_status_meta: &transaction_with_status_meta.meta,
-                            index: transaction_index,
+                            transaction_status_meta: &event.transaction_with_status_meta.meta,
+                            index: event.index,
                             message_hash: &transaction.message.hash(),
                         };
 
                         for plugin in managed_plugins.iter().map(|p| &*p.plugin) {
-                            if let Err(e) = plugin.notify_transaction(ReplicaTransactionInfoVersions::V0_0_3(&transaction_replica), transaction_with_status_meta.slot) {
+                            if let Err(e) = plugin.notify_transaction(ReplicaTransactionInfoVersions::V0_0_3(&transaction_replica), event.transaction_with_status_meta.slot) {
                                 log_error(format!("Failed to notify Geyser plugin of new transaction: {:?}", e))
                             };
                         }

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -734,7 +734,7 @@ fn start_geyser_runloop(
                     Err(e) => {
                         break format!("Failed to read new transaction to send to Geyser plugin: {e}");
                     },
-                    Ok(GeyserEvent::NotifyTransaction(transaction_with_status_meta, versioned_transaction)) => {
+                    Ok(GeyserEvent::NotifyTransaction(transaction_with_status_meta, versioned_transaction, transaction_index)) => {
 
                         if !indexing_enabled {
                             continue;
@@ -753,7 +753,7 @@ fn start_geyser_runloop(
                             is_vote: false,
                             transaction: &transaction,
                             transaction_status_meta: &transaction_with_status_meta.meta,
-                            index: 0,
+                            index: transaction_index,
                             message_hash: &transaction.message.hash(),
                         };
 

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -2234,6 +2234,7 @@ impl SurfnetSvmLocker {
             )));
 
             self.with_svm_writer(|svm_writer| {
+                let transaction_index = svm_writer.transactions_queued_for_confirmation.len();
                 let transaction_with_status_meta = TransactionWithStatusMeta::from_failure(
                     simulated_slot,
                     transaction.clone(),
@@ -2261,6 +2262,7 @@ impl SurfnetSvmLocker {
                     .send(GeyserEvent::NotifyTransaction(
                         transaction_with_status_meta,
                         Some(transaction.clone()),
+                        transaction_index,
                     ));
 
                 svm_writer.transactions_queued_for_confirmation.push_back((
@@ -2423,6 +2425,7 @@ impl SurfnetSvmLocker {
                 .collect::<Result<Vec<_>, SurfpoolError>>()?;
 
             if do_propagate {
+                let transaction_index = svm_writer.transactions_queued_for_confirmation.len();
                 let transaction_meta =
                     convert_transaction_metadata_from_canonical(&transaction_metadata);
                 let transaction_with_status_meta = TransactionWithStatusMeta::new(
@@ -2455,6 +2458,7 @@ impl SurfnetSvmLocker {
                     .send(GeyserEvent::NotifyTransaction(
                         transaction_with_status_meta,
                         versioned_transaction,
+                        transaction_index,
                     ));
 
                 svm_writer.transactions_queued_for_confirmation.push_back((
@@ -5545,7 +5549,7 @@ mod tests {
                 Ok(crate::surfnet::GeyserEvent::UpdateAccount(update)) => {
                     account_updates.push(update);
                 }
-                Ok(crate::surfnet::GeyserEvent::NotifyTransaction(_, _)) => {
+                Ok(crate::surfnet::GeyserEvent::NotifyTransaction(_, _, _)) => {
                     got_transaction_notify = true;
                 }
                 Ok(_) => {}
@@ -5580,6 +5584,82 @@ mod tests {
                 "Account update should carry transaction signature"
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn same_slot_transactions_emit_ordered_geyser_indices() {
+        use std::time::Duration;
+
+        use crossbeam_channel::{RecvTimeoutError, unbounded};
+        use solana_keypair::Keypair;
+        use solana_message::{Message, VersionedMessage};
+        use solana_signer::Signer;
+        use solana_system_interface::instruction as system_instruction;
+        use solana_transaction::versioned::VersionedTransaction;
+
+        let (svm, _events_rx, geyser_rx) = SurfnetSvm::default();
+        let locker = SurfnetSvmLocker::new(svm);
+        let payer = Keypair::new();
+        let payer_pubkey = payer.pubkey();
+
+        let _ = locker
+            .airdrop(&payer_pubkey, 1_000_000_000)
+            .expect("airdrop should succeed");
+
+        let first_transaction_index =
+            locker.with_svm_reader(|svm| svm.transactions_queued_for_confirmation.len());
+        let blockhash = locker.latest_absolute_blockhash();
+        let mut expected_signatures = Vec::new();
+
+        for amount in [1_000_000, 2_000_000_000] {
+            let message = Message::new_with_blockhash(
+                &[system_instruction::transfer(
+                    &payer_pubkey,
+                    &Pubkey::new_unique(),
+                    amount,
+                )],
+                Some(&payer_pubkey),
+                &blockhash,
+            );
+            let transaction = VersionedTransaction::try_new(
+                VersionedMessage::Legacy(message),
+                &[payer.insecure_clone()],
+            )
+            .expect("transaction should sign");
+            expected_signatures.push(transaction.signatures[0]);
+
+            let (status_tx, _status_rx) = unbounded();
+            locker
+                .process_transaction(&None, transaction, status_tx, true, true)
+                .await
+                .expect("transaction processing should succeed");
+        }
+
+        let mut notifications = Vec::new();
+        for _ in 0..64 {
+            match geyser_rx.recv_timeout(Duration::from_millis(50)) {
+                Ok(crate::surfnet::GeyserEvent::NotifyTransaction(transaction, _, index)) => {
+                    notifications.push((
+                        transaction.transaction.signatures[0],
+                        index,
+                        transaction.meta.status.is_ok(),
+                    ));
+                    if notifications.len() == expected_signatures.len() {
+                        break;
+                    }
+                }
+                Ok(_) => {}
+                Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        assert_eq!(
+            notifications,
+            vec![
+                (expected_signatures[0], first_transaction_index, true),
+                (expected_signatures[1], first_transaction_index + 1, false),
+            ]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -5663,6 +5663,131 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn bundle_transaction_indices_rebase_against_live_queue_on_commit() {
+        use std::time::Duration;
+
+        use crossbeam_channel::{RecvTimeoutError, unbounded};
+        use solana_keypair::Keypair;
+        use solana_message::{Message, VersionedMessage};
+        use solana_signer::Signer;
+        use solana_system_interface::instruction as system_instruction;
+        use solana_transaction::versioned::VersionedTransaction;
+
+        use crate::surfnet::svm::BundleSandbox;
+
+        let (svm, _events_rx, geyser_rx) = SurfnetSvm::default();
+        let live_locker = SurfnetSvmLocker::new(svm);
+        let bundle_payer = Keypair::new();
+        let live_payer = Keypair::new();
+
+        for payer in [&bundle_payer, &live_payer] {
+            let _ = live_locker
+                .airdrop(&payer.pubkey(), 1_000_000_000)
+                .expect("airdrop should succeed");
+        }
+
+        let bundle_sandbox = live_locker.with_svm_reader(|svm| svm.clone_for_bundle_sandbox());
+        let BundleSandbox {
+            svm: sandbox_svm,
+            geyser_rx: sandbox_geyser_rx,
+            simnet_rx: sandbox_simnet_rx,
+            confirmation_queue_base_len,
+            finalization_queue_base_len,
+        } = bundle_sandbox;
+        let sandbox_locker = SurfnetSvmLocker::new(sandbox_svm);
+
+        let blockhash = live_locker.latest_absolute_blockhash();
+        let build_transaction = |payer: &Keypair| {
+            let message = Message::new_with_blockhash(
+                &[system_instruction::transfer(
+                    &payer.pubkey(),
+                    &Pubkey::new_unique(),
+                    1_000_000,
+                )],
+                Some(&payer.pubkey()),
+                &blockhash,
+            );
+            VersionedTransaction::try_new(
+                VersionedMessage::Legacy(message),
+                &[payer.insecure_clone()],
+            )
+            .expect("transaction should sign")
+        };
+        let bundle_transaction = build_transaction(&bundle_payer);
+        let bundle_signature = bundle_transaction.signatures[0];
+        let live_transaction = build_transaction(&live_payer);
+        let live_signature = live_transaction.signatures[0];
+
+        let (sandbox_status_tx, _sandbox_status_rx) = unbounded();
+        sandbox_locker
+            .process_transaction(&None, bundle_transaction, sandbox_status_tx, true, true)
+            .await
+            .expect("bundle transaction should succeed in sandbox");
+
+        let (live_status_tx, _live_status_rx) = unbounded();
+        live_locker
+            .process_transaction(&None, live_transaction, live_status_tx, true, true)
+            .await
+            .expect("intervening live transaction should succeed");
+
+        let committed_bundle_index =
+            live_locker.with_svm_reader(|svm| svm.transactions_queued_for_confirmation.len());
+        let sandbox_svm = match Arc::try_unwrap(sandbox_locker.0) {
+            Ok(rwlock) => rwlock.into_inner(),
+            Err(_) => panic!("sandbox locker should have one owner"),
+        };
+        let reassembled = BundleSandbox {
+            svm: sandbox_svm,
+            geyser_rx: sandbox_geyser_rx,
+            simnet_rx: sandbox_simnet_rx,
+            confirmation_queue_base_len,
+            finalization_queue_base_len,
+        };
+        let (bundle_status_tx, _bundle_status_rx) = unbounded();
+        live_locker
+            .with_svm_writer(move |svm| svm.commit_sandbox(reassembled, bundle_status_tx))
+            .expect("bundle commit should succeed");
+
+        let queued_signatures = live_locker.with_svm_reader(|svm| {
+            svm.transactions_queued_for_confirmation
+                .iter()
+                .map(|(transaction, _, _)| transaction.signatures[0])
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(queued_signatures.len(), committed_bundle_index + 1);
+        assert_eq!(
+            &queued_signatures[committed_bundle_index - 1..],
+            &[live_signature, bundle_signature]
+        );
+
+        let mut notification_indices = HashMap::new();
+        for _ in 0..64 {
+            match geyser_rx.recv_timeout(Duration::from_millis(50)) {
+                Ok(crate::surfnet::GeyserEvent::NotifyTransaction(transaction, _, index)) => {
+                    let signature = transaction.transaction.signatures[0];
+                    if signature == live_signature || signature == bundle_signature {
+                        notification_indices.insert(signature, index);
+                    }
+                    if notification_indices.len() == 2 {
+                        break;
+                    }
+                }
+                Ok(_) => {}
+                Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        assert_eq!(
+            notification_indices.get(&live_signature),
+            Some(&(committed_bundle_index - 1))
+        );
+        assert_eq!(
+            notification_indices.get(&bundle_signature),
+            Some(&committed_bundle_index)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_transaction_fee_includes_priority_fee() {
         use crossbeam_channel::unbounded;
         use solana_compute_budget_interface::ComputeBudgetInstruction;

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -65,8 +65,8 @@ use uuid::Uuid;
 
 use super::{
     AccountFactory, AccountSource, CoupledAccount, GetAccountResult, GetTransactionResult,
-    GeyserEvent, LocalSignatureStatusOrSubscription, SignatureSubscriptionType, SurfnetSvm,
-    remote::SurfnetRemoteClient, svm::AccountUpdatePolicy,
+    GeyserEvent, GeyserTransactionEvent, LocalSignatureStatusOrSubscription,
+    SignatureSubscriptionType, SurfnetSvm, remote::SurfnetRemoteClient, svm::AccountUpdatePolicy,
 };
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
@@ -87,12 +87,6 @@ use crate::{
         TimeTravelConfig, TokenAccount, TransactionLoadedAddresses, TransactionWithStatusMeta,
     },
 };
-
-enum ProcessTransactionResult {
-    Success(TransactionMetadata),
-    SimulationFailure(FailedTransactionMetadata),
-    ExecutionFailure(FailedTransactionMetadata),
-}
 
 pub struct SvmAccessContext<T> {
     pub slot: Slot,
@@ -2165,10 +2159,9 @@ impl SurfnetSvmLocker {
 
     #[allow(clippy::too_many_arguments)]
     fn handle_execution_failure(
-        &self,
+        svm_writer: &mut SurfnetSvm,
         failed_transaction_metadata: FailedTransactionMetadata,
         transaction: VersionedTransaction,
-        simulated_slot: Slot,
         pubkeys_from_message: &[Pubkey],
         accounts_before: &[Option<Account>],
         token_accounts_before: &[(usize, TokenAccount)],
@@ -2187,7 +2180,7 @@ impl SurfnetSvmLocker {
 
         let accounts_after = pubkeys_from_message
             .iter()
-            .map(|p| self.with_svm_reader(|svm_reader| svm_reader.inner.get_account(p)))
+            .map(|p| svm_writer.inner.get_account(p))
             .collect::<SurfpoolResult<Vec<Option<Account>>>>()?;
 
         for (pubkey, (before, after)) in pubkeys_from_message
@@ -2195,99 +2188,93 @@ impl SurfnetSvmLocker {
             .zip(accounts_before.iter().zip(accounts_after.iter()))
         {
             if before.ne(&after) {
-                self.with_svm_writer(|svm_writer| {
-                    if let Some(after) = &after {
-                        let _ = svm_writer.update_account_registries(pubkey, after);
-                        svm_writer.notify_account_subscribers(pubkey, &after);
-                        svm_writer.notify_program_subscribers(pubkey, &after);
-                    } else {
-                        svm_writer.notify_account_subscribers(pubkey, &Account::default());
-                        svm_writer.notify_program_subscribers(pubkey, &Account::default());
-                    }
-                });
+                if let Some(after) = &after {
+                    let _ = svm_writer.update_account_registries(pubkey, after);
+                    svm_writer.notify_account_subscribers(pubkey, after);
+                    svm_writer.notify_program_subscribers(pubkey, after);
+                } else {
+                    svm_writer.notify_account_subscribers(pubkey, &Account::default());
+                    svm_writer.notify_program_subscribers(pubkey, &Account::default());
+                }
             }
         }
 
-        let token_mints = self
-            .with_svm_reader(|svm_reader| {
-                token_accounts_before
-                    .iter()
-                    .map(|(_, a)| {
-                        svm_reader
-                            .token_mints
-                            .get(&a.mint().to_string())
-                            .ok()
-                            .flatten()
-                            .ok_or(SurfpoolError::token_mint_not_found(a.mint()))
-                    })
-                    .collect::<Result<Vec<_>, SurfpoolError>>()
+        let token_mints = token_accounts_before
+            .iter()
+            .map(|(_, a)| {
+                svm_writer
+                    .token_mints
+                    .get(&a.mint().to_string())
+                    .ok()
+                    .flatten()
+                    .ok_or(SurfpoolError::token_mint_not_found(a.mint()))
             })
+            .collect::<Result<Vec<_>, SurfpoolError>>()
             .unwrap_or_default();
 
         if do_propagate {
             let meta_canonical = convert_transaction_metadata_from_canonical(&meta);
-            let simnet_events_tx = self.simnet_events_tx();
-            simnet_events_tx.error(format!("Transaction execution failed: {}", err));
+            svm_writer
+                .simnet_events_tx
+                .error(format!("Transaction execution failed: {}", err));
             let _ = status_tx.try_send(TransactionStatusEvent::ExecutionFailure((
                 err.clone(),
                 meta_canonical.clone(),
             )));
 
-            self.with_svm_writer(|svm_writer| {
-                let transaction_index = svm_writer.transactions_queued_for_confirmation.len();
-                let transaction_with_status_meta = TransactionWithStatusMeta::from_failure(
-                    simulated_slot,
-                    transaction.clone(),
-                    &FailedTransactionMetadata {
-                        err: err.clone(),
-                        meta: meta.clone(),
-                    },
-                    accounts_before,
-                    &accounts_after,
-                    token_accounts_before,
-                    token_mints,
-                    token_programs,
-                    loaded_addresses.clone().unwrap_or_default(),
-                );
-                svm_writer.transactions.store(
-                    signature.to_string(),
-                    SurfnetTransactionStatus::processed(
-                        transaction_with_status_meta.clone(),
-                        HashSet::new(),
-                    ),
-                )?;
+            let slot = svm_writer.get_latest_absolute_slot();
+            let transaction_index = svm_writer.transactions_queued_for_confirmation.len();
+            let transaction_with_status_meta = TransactionWithStatusMeta::from_failure(
+                slot,
+                transaction.clone(),
+                &FailedTransactionMetadata {
+                    err: err.clone(),
+                    meta: meta.clone(),
+                },
+                accounts_before,
+                &accounts_after,
+                token_accounts_before,
+                token_mints,
+                token_programs,
+                loaded_addresses.clone().unwrap_or_default(),
+            );
+            svm_writer.transactions.store(
+                signature.to_string(),
+                SurfnetTransactionStatus::processed(
+                    transaction_with_status_meta.clone(),
+                    HashSet::new(),
+                ),
+            )?;
 
-                let _ = svm_writer
-                    .geyser_events_tx
-                    .send(GeyserEvent::NotifyTransaction(
-                        transaction_with_status_meta,
-                        Some(transaction.clone()),
-                        transaction_index,
-                    ));
+            let _ = svm_writer
+                .geyser_events_tx
+                .send(GeyserEvent::NotifyTransaction(GeyserTransactionEvent {
+                    transaction_with_status_meta,
+                    versioned_transaction: Some(transaction.clone()),
+                    index: transaction_index,
+                }));
 
-                svm_writer.transactions_queued_for_confirmation.push_back((
-                    transaction.clone(),
-                    status_tx.clone(),
-                    Some(err.clone()),
-                ));
+            svm_writer.transactions_queued_for_confirmation.push_back((
+                transaction.clone(),
+                status_tx.clone(),
+                Some(err.clone()),
+            ));
 
-                svm_writer.notify_signature_subscribers(
-                    SignatureSubscriptionType::processed(),
-                    &signature,
-                    simulated_slot,
-                    Some(err.clone()),
-                );
-                svm_writer.notify_logs_subscribers(
-                    &signature,
-                    Some(err.clone()),
-                    log_messages.clone(),
-                    CommitmentLevel::Processed,
-                );
-                svm_writer
-                    .simnet_events_tx
-                    .transaction_processed(meta_canonical, Some(err));
-                Ok::<(), SurfpoolError>(())
-            })?;
+            svm_writer.notify_signature_subscribers(
+                SignatureSubscriptionType::processed(),
+                &signature,
+                slot,
+                Some(err.clone()),
+            );
+            svm_writer.notify_logs_subscribers(
+                &signature,
+                Some(err.clone()),
+                log_messages.clone(),
+                CommitmentLevel::Processed,
+            );
+            svm_writer
+                .simnet_events_tx
+                .transaction_processed(meta_canonical, Some(err));
         }
         Ok(ProfileResult::new(
             pre_execution_capture,
@@ -2300,10 +2287,9 @@ impl SurfnetSvmLocker {
 
     #[allow(clippy::too_many_arguments)]
     fn handle_execution_success(
-        &self,
+        svm_writer: &mut SurfnetSvm,
         transaction_metadata: TransactionMetadata,
         transaction: VersionedTransaction,
-        simulated_slot: Slot,
         pubkeys_from_message: &[Pubkey],
         loaded_addresses: &Option<LoadedAddresses>,
         accounts_before: &[Option<Account>],
@@ -2317,7 +2303,7 @@ impl SurfnetSvmLocker {
         let logs = transaction_metadata.logs.clone();
         let signature = transaction.signatures[0];
 
-        let post_execution_capture = self.with_svm_writer(|svm_writer| {
+        let post_execution_capture = {
             let accounts_after = pubkeys_from_message
                 .iter()
                 .map(|p| svm_writer.inner.get_account_no_db(p))
@@ -2425,11 +2411,12 @@ impl SurfnetSvmLocker {
                 .collect::<Result<Vec<_>, SurfpoolError>>()?;
 
             if do_propagate {
+                let slot = svm_writer.get_latest_absolute_slot();
                 let transaction_index = svm_writer.transactions_queued_for_confirmation.len();
                 let transaction_meta =
                     convert_transaction_metadata_from_canonical(&transaction_metadata);
                 let transaction_with_status_meta = TransactionWithStatusMeta::new(
-                    svm_writer.get_latest_absolute_slot(),
+                    slot,
                     transaction.clone(),
                     transaction_metadata,
                     accounts_before,
@@ -2455,11 +2442,11 @@ impl SurfnetSvmLocker {
 
                 let _ = svm_writer
                     .geyser_events_tx
-                    .send(GeyserEvent::NotifyTransaction(
+                    .send(GeyserEvent::NotifyTransaction(GeyserTransactionEvent {
                         transaction_with_status_meta,
                         versioned_transaction,
-                        transaction_index,
-                    ));
+                        index: transaction_index,
+                    }));
 
                 svm_writer.transactions_queued_for_confirmation.push_back((
                     transaction.clone(),
@@ -2470,7 +2457,7 @@ impl SurfnetSvmLocker {
                 svm_writer.notify_signature_subscribers(
                     SignatureSubscriptionType::processed(),
                     &signature,
-                    simulated_slot,
+                    slot,
                     None,
                 );
                 svm_writer.notify_logs_subscribers(
@@ -2485,7 +2472,7 @@ impl SurfnetSvmLocker {
             }
 
             Ok::<ExecutionCapture, SurfpoolError>(post_execution_capture)
-        })?;
+        }?;
 
         Ok(ProfileResult::new(
             pre_execution_capture,
@@ -2511,78 +2498,56 @@ impl SurfnetSvmLocker {
         status_tx: &Sender<TransactionStatusEvent>,
         do_propagate: bool,
     ) -> SurfpoolResult<ProfileResult> {
-        let res = match self
-            .do_process_transaction_internal(transaction.clone(), skip_preflight, sigverify)
-            .await
-        {
-            ProcessTransactionResult::Success(transaction_metadata) => self
-                .handle_execution_success(
-                    transaction_metadata,
-                    transaction,
-                    self.get_latest_absolute_slot(),
-                    transaction_accounts,
-                    loaded_addresses,
-                    accounts_before,
-                    token_accounts_before,
-                    token_programs,
-                    pre_execution_capture,
-                    status_tx,
-                    do_propagate,
-                )?,
-            ProcessTransactionResult::SimulationFailure(failed_transaction_metadata) => self
-                .handle_simulation_failure(
+        if !skip_preflight {
+            if let Err(failed) = self.with_svm_reader(|svm_reader| {
+                svm_reader.simulate_transaction(transaction.clone(), sigverify)
+            }) {
+                return Ok(self.handle_simulation_failure(
                     transaction.signatures[0],
-                    failed_transaction_metadata,
+                    failed,
                     pre_execution_capture,
                     self.get_latest_absolute_slot(),
                     status_tx.clone(),
                     do_propagate,
-                ),
-            ProcessTransactionResult::ExecutionFailure(failed) => self.handle_execution_failure(
-                failed,
-                transaction,
-                self.get_latest_absolute_slot(),
-                transaction_accounts,
-                accounts_before,
-                token_accounts_before,
-                token_programs,
-                loaded_addresses,
-                pre_execution_capture,
-                status_tx.clone(),
-                do_propagate,
-            )?,
-        };
-        Ok(res)
-    }
-
-    async fn do_process_transaction_internal(
-        &self,
-        transaction: VersionedTransaction,
-        skip_preflight: bool,
-        sigverify: bool,
-    ) -> ProcessTransactionResult {
-        // if not skipping preflight, simulate the transaction
-        if !skip_preflight {
-            if let Err(e) = self.with_svm_reader(|svm_reader| {
-                svm_reader
-                    .simulate_transaction(transaction.clone(), sigverify)
-                    .map_err(ProcessTransactionResult::SimulationFailure)
-            }) {
-                return e;
+                ));
             }
         }
 
-        match self.with_svm_writer(|svm_writer| {
-            svm_writer
-                .send_transaction(transaction, false /* cu_analysis_enabled */, sigverify)
-                .map_err(|e| {
-                    debug!("Transaction execution failure: {:?}", e.meta);
-                    ProcessTransactionResult::ExecutionFailure(e)
-                })
-                .map(ProcessTransactionResult::Success)
-        }) {
-            Ok(res) => res,
-            Err(res) => res,
+        let mut svm_writer = self.0.write().await;
+        match svm_writer.send_transaction(
+            transaction.clone(),
+            false, /* cu_analysis_enabled */
+            sigverify,
+        ) {
+            Ok(transaction_metadata) => Self::handle_execution_success(
+                &mut svm_writer,
+                transaction_metadata,
+                transaction,
+                transaction_accounts,
+                loaded_addresses,
+                accounts_before,
+                token_accounts_before,
+                token_programs,
+                pre_execution_capture,
+                status_tx,
+                do_propagate,
+            ),
+            Err(failed) => {
+                debug!("Transaction execution failure: {:?}", failed.meta);
+                Self::handle_execution_failure(
+                    &mut svm_writer,
+                    failed,
+                    transaction,
+                    transaction_accounts,
+                    accounts_before,
+                    token_accounts_before,
+                    token_programs,
+                    loaded_addresses,
+                    pre_execution_capture,
+                    status_tx.clone(),
+                    do_propagate,
+                )
+            }
         }
     }
 }
@@ -5549,7 +5514,7 @@ mod tests {
                 Ok(crate::surfnet::GeyserEvent::UpdateAccount(update)) => {
                     account_updates.push(update);
                 }
-                Ok(crate::surfnet::GeyserEvent::NotifyTransaction(_, _, _)) => {
+                Ok(crate::surfnet::GeyserEvent::NotifyTransaction(_)) => {
                     got_transaction_notify = true;
                 }
                 Ok(_) => {}
@@ -5588,9 +5553,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn same_slot_transactions_emit_ordered_geyser_indices() {
-        use std::time::Duration;
-
-        use crossbeam_channel::{RecvTimeoutError, unbounded};
+        use crossbeam_channel::unbounded;
         use solana_keypair::Keypair;
         use solana_message::{Message, VersionedMessage};
         use solana_signer::Signer;
@@ -5602,12 +5565,18 @@ mod tests {
         let payer = Keypair::new();
         let payer_pubkey = payer.pubkey();
 
-        let _ = locker
-            .airdrop(&payer_pubkey, 1_000_000_000)
-            .expect("airdrop should succeed");
-
-        let first_transaction_index =
-            locker.with_svm_reader(|svm| svm.transactions_queued_for_confirmation.len());
+        locker
+            .with_svm_writer(|svm| {
+                svm.set_account(
+                    &payer_pubkey,
+                    Account {
+                        lamports: 1_000_000_000,
+                        owner: solana_system_interface::program::id(),
+                        ..Account::default()
+                    },
+                )
+            })
+            .expect("payer funding should succeed");
         let blockhash = locker.latest_absolute_blockhash();
         let mut expected_signatures = Vec::new();
 
@@ -5632,158 +5601,27 @@ mod tests {
             locker
                 .process_transaction(&None, transaction, status_tx, true, true)
                 .await
-                .expect("transaction processing should succeed");
+                .expect("transaction processing should complete");
         }
 
-        let mut notifications = Vec::new();
-        for _ in 0..64 {
-            match geyser_rx.recv_timeout(Duration::from_millis(50)) {
-                Ok(crate::surfnet::GeyserEvent::NotifyTransaction(transaction, _, index)) => {
-                    notifications.push((
-                        transaction.transaction.signatures[0],
-                        index,
-                        transaction.meta.status.is_ok(),
-                    ));
-                    if notifications.len() == expected_signatures.len() {
-                        break;
-                    }
-                }
-                Ok(_) => {}
-                Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => break,
-            }
-        }
+        let notifications = geyser_rx
+            .try_iter()
+            .filter_map(|event| match event {
+                crate::surfnet::GeyserEvent::NotifyTransaction(event) => Some((
+                    event.transaction_with_status_meta.transaction.signatures[0],
+                    event.index,
+                    event.transaction_with_status_meta.meta.status.is_ok(),
+                )),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
 
         assert_eq!(
             notifications,
             vec![
-                (expected_signatures[0], first_transaction_index, true),
-                (expected_signatures[1], first_transaction_index + 1, false),
+                (expected_signatures[0], 0, true),
+                (expected_signatures[1], 1, false),
             ]
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn bundle_transaction_indices_rebase_against_live_queue_on_commit() {
-        use std::time::Duration;
-
-        use crossbeam_channel::{RecvTimeoutError, unbounded};
-        use solana_keypair::Keypair;
-        use solana_message::{Message, VersionedMessage};
-        use solana_signer::Signer;
-        use solana_system_interface::instruction as system_instruction;
-        use solana_transaction::versioned::VersionedTransaction;
-
-        use crate::surfnet::svm::BundleSandbox;
-
-        let (svm, _events_rx, geyser_rx) = SurfnetSvm::default();
-        let live_locker = SurfnetSvmLocker::new(svm);
-        let bundle_payer = Keypair::new();
-        let live_payer = Keypair::new();
-
-        for payer in [&bundle_payer, &live_payer] {
-            let _ = live_locker
-                .airdrop(&payer.pubkey(), 1_000_000_000)
-                .expect("airdrop should succeed");
-        }
-
-        let bundle_sandbox = live_locker.with_svm_reader(|svm| svm.clone_for_bundle_sandbox());
-        let BundleSandbox {
-            svm: sandbox_svm,
-            geyser_rx: sandbox_geyser_rx,
-            simnet_rx: sandbox_simnet_rx,
-            confirmation_queue_base_len,
-            finalization_queue_base_len,
-        } = bundle_sandbox;
-        let sandbox_locker = SurfnetSvmLocker::new(sandbox_svm);
-
-        let blockhash = live_locker.latest_absolute_blockhash();
-        let build_transaction = |payer: &Keypair| {
-            let message = Message::new_with_blockhash(
-                &[system_instruction::transfer(
-                    &payer.pubkey(),
-                    &Pubkey::new_unique(),
-                    1_000_000,
-                )],
-                Some(&payer.pubkey()),
-                &blockhash,
-            );
-            VersionedTransaction::try_new(
-                VersionedMessage::Legacy(message),
-                &[payer.insecure_clone()],
-            )
-            .expect("transaction should sign")
-        };
-        let bundle_transaction = build_transaction(&bundle_payer);
-        let bundle_signature = bundle_transaction.signatures[0];
-        let live_transaction = build_transaction(&live_payer);
-        let live_signature = live_transaction.signatures[0];
-
-        let (sandbox_status_tx, _sandbox_status_rx) = unbounded();
-        sandbox_locker
-            .process_transaction(&None, bundle_transaction, sandbox_status_tx, true, true)
-            .await
-            .expect("bundle transaction should succeed in sandbox");
-
-        let (live_status_tx, _live_status_rx) = unbounded();
-        live_locker
-            .process_transaction(&None, live_transaction, live_status_tx, true, true)
-            .await
-            .expect("intervening live transaction should succeed");
-
-        let committed_bundle_index =
-            live_locker.with_svm_reader(|svm| svm.transactions_queued_for_confirmation.len());
-        let sandbox_svm = match Arc::try_unwrap(sandbox_locker.0) {
-            Ok(rwlock) => rwlock.into_inner(),
-            Err(_) => panic!("sandbox locker should have one owner"),
-        };
-        let reassembled = BundleSandbox {
-            svm: sandbox_svm,
-            geyser_rx: sandbox_geyser_rx,
-            simnet_rx: sandbox_simnet_rx,
-            confirmation_queue_base_len,
-            finalization_queue_base_len,
-        };
-        let (bundle_status_tx, _bundle_status_rx) = unbounded();
-        live_locker
-            .with_svm_writer(move |svm| svm.commit_sandbox(reassembled, bundle_status_tx))
-            .expect("bundle commit should succeed");
-
-        let queued_signatures = live_locker.with_svm_reader(|svm| {
-            svm.transactions_queued_for_confirmation
-                .iter()
-                .map(|(transaction, _, _)| transaction.signatures[0])
-                .collect::<Vec<_>>()
-        });
-        assert_eq!(queued_signatures.len(), committed_bundle_index + 1);
-        assert_eq!(
-            &queued_signatures[committed_bundle_index - 1..],
-            &[live_signature, bundle_signature]
-        );
-
-        let mut notification_indices = HashMap::new();
-        for _ in 0..64 {
-            match geyser_rx.recv_timeout(Duration::from_millis(50)) {
-                Ok(crate::surfnet::GeyserEvent::NotifyTransaction(transaction, _, index)) => {
-                    let signature = transaction.transaction.signatures[0];
-                    if signature == live_signature || signature == bundle_signature {
-                        notification_indices.insert(signature, index);
-                    }
-                    if notification_indices.len() == 2 {
-                        break;
-                    }
-                }
-                Ok(_) => {}
-                Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => break,
-            }
-        }
-
-        assert_eq!(
-            notification_indices.get(&live_signature),
-            Some(&(committed_bundle_index - 1))
-        );
-        assert_eq!(
-            notification_indices.get(&bundle_signature),
-            Some(&committed_bundle_index)
         );
     }
 

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -77,13 +77,16 @@ pub struct GeyserEntryInfo {
     pub starting_transaction_index: usize,
 }
 
+/// Transaction data forwarded to Geyser plugins.
+pub struct GeyserTransactionEvent {
+    pub transaction_with_status_meta: TransactionWithStatusMeta,
+    pub versioned_transaction: Option<VersionedTransaction>,
+    pub index: usize,
+}
+
 #[allow(clippy::large_enum_variant)]
 pub enum GeyserEvent {
-    NotifyTransaction(
-        TransactionWithStatusMeta,
-        Option<VersionedTransaction>,
-        usize,
-    ),
+    NotifyTransaction(GeyserTransactionEvent),
     UpdateAccount(GeyserAccountUpdate),
     /// Account update sent at startup (before block production begins).
     /// These updates should be sent to geyser plugins with is_startup=true.

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -79,7 +79,11 @@ pub struct GeyserEntryInfo {
 
 #[allow(clippy::large_enum_variant)]
 pub enum GeyserEvent {
-    NotifyTransaction(TransactionWithStatusMeta, Option<VersionedTransaction>),
+    NotifyTransaction(
+        TransactionWithStatusMeta,
+        Option<VersionedTransaction>,
+        usize,
+    ),
     UpdateAccount(GeyserAccountUpdate),
     /// Account update sent at startup (before block production begins).
     /// These updates should be sent to geyser plugins with is_startup=true.

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -431,6 +431,8 @@ pub struct BundleSandbox {
     pub svm: SurfnetSvm,
     pub geyser_rx: Receiver<GeyserEvent>,
     pub simnet_rx: Receiver<SimnetEvent>,
+    pub confirmation_queue_base_len: usize,
+    pub finalization_queue_base_len: usize,
 }
 
 /// Generic helper: drain the overlay state of `sandbox_storage` (which must be an
@@ -665,6 +667,8 @@ impl SurfnetSvm {
     /// buffered event, every overlay write, and the cloned `LiteSVM` state — the original
     /// VM is left byte-identical to its pre-bundle state.
     pub fn clone_for_bundle_sandbox(&self) -> BundleSandbox {
+        let confirmation_queue_base_len = self.transactions_queued_for_confirmation.len();
+        let finalization_queue_base_len = self.transactions_queued_for_finalization.len();
         let mut svm = self.clone_for_profiling();
         let (geyser_tx, geyser_rx) = crossbeam_channel::unbounded();
         let (simnet_tx, simnet_rx) = SimnetEventsTx::unbounded();
@@ -674,6 +678,8 @@ impl SurfnetSvm {
             svm,
             geyser_rx,
             simnet_rx,
+            confirmation_queue_base_len,
+            finalization_queue_base_len,
         }
     }
 
@@ -693,9 +699,10 @@ impl SurfnetSvm {
     ///   3. Drain the sandbox's account-DB overlay (`inner.db`) onto `self.inner.db` so any
     ///      SQLite-backed account persistence reflects the bundle's mutations.
     ///   4. Pull forward counters (`write_version`, `transactions_processed`), per-account
-    ///      update slots, pending confirmation/finalization queues, perf samples, and the
-    ///      recent-blockhash deque from the sandbox.
-    ///   5. Drain the sandbox's buffered geyser events; replay each onto `self.geyser_events_tx`.
+    ///      update slots, perf samples, and the recent-blockhash deque from the sandbox. Append
+    ///      only the bundle's confirmation/finalization queue delta to the live queues.
+    ///   5. Drain the sandbox's buffered geyser events; rebase transaction indices against the
+    ///      live confirmation queue at commit time and replay each onto `self.geyser_events_tx`.
     ///      For each `UpdateAccount` event, also fire `notify_account_subscribers` /
     ///      `notify_program_subscribers` on `self` (the sandbox's registries were emptied,
     ///      so those notifications could not have been delivered during sandbox execution).
@@ -717,6 +724,8 @@ impl SurfnetSvm {
             mut svm,
             geyser_rx,
             simnet_rx,
+            confirmation_queue_base_len,
+            finalization_queue_base_len,
         } = sandbox;
 
         // 1. Drain all overlay storages onto self's real storages.
@@ -786,11 +795,15 @@ impl SurfnetSvm {
         self.perf_samples = svm.perf_samples.clone();
         self.recent_blockhashes = svm.recent_blockhashes.clone();
 
-        // Push sandbox's queued txs onto self's queues, rewriting the per-tx status channel
-        // to the bundle's status channel so the runloop's Confirmed/Finalized promotions
-        // flow through a single channel (the caller drops the receiver).
+        // Append only the queue entries created by the bundle. The sandbox cloned the live
+        // queue at fork time, and that prefix may now be stale because live transactions can
+        // be committed while the bundle executes.
+        let committed_transaction_index_base = self.transactions_queued_for_confirmation.len();
         let mut signatures = Vec::new();
-        for (tx, _sandbox_status_tx, err) in svm.transactions_queued_for_confirmation.drain(..) {
+        for (tx, _sandbox_status_tx, err) in svm
+            .transactions_queued_for_confirmation
+            .drain(confirmation_queue_base_len..)
+        {
             signatures.push(tx.signatures[0]);
             self.transactions_queued_for_confirmation.push_back((
                 tx,
@@ -798,8 +811,9 @@ impl SurfnetSvm {
                 err,
             ));
         }
-        for (slot, tx, _sandbox_status_tx, err) in
-            svm.transactions_queued_for_finalization.drain(..)
+        for (slot, tx, _sandbox_status_tx, err) in svm
+            .transactions_queued_for_finalization
+            .drain(finalization_queue_base_len..)
         {
             self.transactions_queued_for_finalization.push_back((
                 slot,
@@ -811,10 +825,18 @@ impl SurfnetSvm {
 
         // 5. Drain buffered geyser events; replay onto self's real channel; for each
         //    UpdateAccount, also fire account/program subscribers on self's registries.
-        while let Ok(event) = geyser_rx.try_recv() {
-            if let GeyserEvent::UpdateAccount(update) = &event {
-                self.notify_account_subscribers(&update.pubkey, &update.account);
-                self.notify_program_subscribers(&update.pubkey, &update.account);
+        let mut next_transaction_index = committed_transaction_index_base;
+        while let Ok(mut event) = geyser_rx.try_recv() {
+            match &mut event {
+                GeyserEvent::NotifyTransaction(_, _, transaction_index) => {
+                    *transaction_index = next_transaction_index;
+                    next_transaction_index += 1;
+                }
+                GeyserEvent::UpdateAccount(update) => {
+                    self.notify_account_subscribers(&update.pubkey, &update.account);
+                    self.notify_program_subscribers(&update.pubkey, &update.account);
+                }
+                _ => {}
             }
             let _ = self.geyser_events_tx.send(event);
         }

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -687,8 +687,8 @@ impl SurfnetSvm {
     ///
     /// This is the second half of the atomic Jito bundle pipeline. It must be invoked only
     /// after every transaction in the bundle succeeded inside the sandbox. The caller must
-    /// hold an exclusive writer guard on `self`'s `SurfnetSvmLocker` so that no other RPC
-    /// path can observe a half-committed state.
+    /// retain the same exclusive writer guard on `self`'s `SurfnetSvmLocker` from sandbox
+    /// creation through this commit so no live state can diverge from the sandbox base.
     ///
     /// Order of operations is **state mutations first, side-effects second**:
     ///   1. Drain every overlay-wrapped storage field from the sandbox onto `self`'s
@@ -727,6 +727,19 @@ impl SurfnetSvm {
             confirmation_queue_base_len,
             finalization_queue_base_len,
         } = sandbox;
+
+        let sandbox_slot = svm.get_latest_absolute_slot();
+        let live_slot = self.get_latest_absolute_slot();
+        if sandbox_slot != live_slot {
+            warn!(
+                "Rejecting stale bundle sandbox: sandbox_slot={}, live_slot={}",
+                sandbox_slot, live_slot
+            );
+            return Err(SurfpoolError::stale_bundle_sandbox_slot(
+                sandbox_slot,
+                live_slot,
+            ));
+        }
 
         // 1. Drain all overlay storages onto self's real storages.
         commit_overlay_storage(svm.blocks.as_ref(), self.blocks.as_mut())?;
@@ -4258,6 +4271,64 @@ mod tests {
                 .is_err()
         );
         assert!(!startup.has_changed().unwrap());
+    }
+
+    #[test]
+    fn bundle_commit_rejects_sandbox_from_previous_slot_before_side_effects() {
+        let (mut live_svm, _events_rx, live_geyser_rx) = SurfnetSvm::default();
+        let recipient = Pubkey::new_unique();
+        let mut sandbox = live_svm.clone_for_bundle_sandbox();
+
+        let sandbox_slot = sandbox.svm.get_latest_absolute_slot();
+        let _ = sandbox
+            .svm
+            .airdrop(&recipient, 1_000_000)
+            .expect("sandbox airdrop should succeed");
+
+        live_svm
+            .confirm_current_block()
+            .expect("live slot should advance");
+        let live_slot = live_svm.get_latest_absolute_slot();
+        assert_eq!(live_slot, sandbox_slot + 1);
+
+        let expected_chain_tip = live_svm.chain_tip.clone();
+        let expected_transactions_processed = live_svm.transactions_processed;
+        let expected_write_version = live_svm.write_version;
+        let expected_confirmation_queue_len = live_svm.transactions_queued_for_confirmation.len();
+        let (bundle_status_tx, _bundle_status_rx) = unbounded();
+
+        let error = live_svm
+            .commit_sandbox(sandbox, bundle_status_tx)
+            .expect_err("a sandbox from a closed slot must not commit");
+
+        assert!(error.to_string().contains(&format!(
+            "Bundle sandbox executed at slot {sandbox_slot}, but the live Surfnet advanced to slot {live_slot} before commit"
+        )));
+        assert_eq!(live_svm.get_latest_absolute_slot(), live_slot);
+        assert_eq!(live_svm.chain_tip, expected_chain_tip);
+        assert_eq!(
+            live_svm.transactions_processed,
+            expected_transactions_processed
+        );
+        assert_eq!(live_svm.write_version, expected_write_version);
+        assert_eq!(
+            live_svm.transactions_queued_for_confirmation.len(),
+            expected_confirmation_queue_len
+        );
+        assert!(
+            live_svm
+                .get_account(&recipient)
+                .expect("live account lookup should succeed")
+                .is_none(),
+            "stale sandbox account state must not reach the live SVM"
+        );
+        assert!(
+            live_geyser_rx.try_iter().all(|event| !matches!(
+                event,
+                GeyserEvent::UpdateAccount(update) if update.pubkey == recipient
+            )),
+            "stale sandbox events must not reach the live Geyser channel"
+        );
     }
 
     fn build_transfer_transaction(

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -81,9 +81,9 @@ use uuid::Uuid;
 use super::{
     AccountSource, AccountSubscriptionData, BlockHeader, BlockIdentifier, CoupledAccount,
     FINALIZATION_SLOT_THRESHOLD, GetAccountResult, GeyserBlockMetadata, GeyserEntryInfo,
-    GeyserEvent, GeyserSlotStatus, LocalSignatureStatus, LocalSignatureStatusOrSubscription,
-    ProgramSubscriptionData, SignatureSubscriptionData, SignatureSubscriptionType,
-    SlotsUpdatesSubscriptionData, remote::SurfnetRemoteClient,
+    GeyserEvent, GeyserSlotStatus, GeyserTransactionEvent, LocalSignatureStatus,
+    LocalSignatureStatusOrSubscription, ProgramSubscriptionData, SignatureSubscriptionData,
+    SignatureSubscriptionType, SlotsUpdatesSubscriptionData, remote::SurfnetRemoteClient,
 };
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
@@ -427,12 +427,11 @@ fn remove_pubkey_from_index(
 /// can be drained on bundle commit to replay events onto the original VM. Construct via
 /// [`SurfnetSvm::clone_for_bundle_sandbox`] and consume via [`SurfnetSvm::commit_sandbox`] on
 /// success or simply drop on failure to discard all in-progress state.
-pub struct BundleSandbox {
-    pub svm: SurfnetSvm,
-    pub geyser_rx: Receiver<GeyserEvent>,
-    pub simnet_rx: Receiver<SimnetEvent>,
-    pub confirmation_queue_base_len: usize,
-    pub finalization_queue_base_len: usize,
+pub(crate) struct BundleSandbox {
+    pub(crate) svm: SurfnetSvm,
+    pub(crate) geyser_rx: Receiver<GeyserEvent>,
+    pub(crate) simnet_rx: Receiver<SimnetEvent>,
+    pub(crate) confirmation_queue_base_len: usize,
 }
 
 /// Generic helper: drain the overlay state of `sandbox_storage` (which must be an
@@ -666,9 +665,8 @@ impl SurfnetSvm {
     /// On bundle failure, simply dropping the returned [`BundleSandbox`] discards every
     /// buffered event, every overlay write, and the cloned `LiteSVM` state — the original
     /// VM is left byte-identical to its pre-bundle state.
-    pub fn clone_for_bundle_sandbox(&self) -> BundleSandbox {
+    pub(crate) fn clone_for_bundle_sandbox(&self) -> BundleSandbox {
         let confirmation_queue_base_len = self.transactions_queued_for_confirmation.len();
-        let finalization_queue_base_len = self.transactions_queued_for_finalization.len();
         let mut svm = self.clone_for_profiling();
         let (geyser_tx, geyser_rx) = crossbeam_channel::unbounded();
         let (simnet_tx, simnet_rx) = SimnetEventsTx::unbounded();
@@ -679,7 +677,6 @@ impl SurfnetSvm {
             geyser_rx,
             simnet_rx,
             confirmation_queue_base_len,
-            finalization_queue_base_len,
         }
     }
 
@@ -700,9 +697,8 @@ impl SurfnetSvm {
     ///      SQLite-backed account persistence reflects the bundle's mutations.
     ///   4. Pull forward counters (`write_version`, `transactions_processed`), per-account
     ///      update slots, perf samples, and the recent-blockhash deque from the sandbox. Append
-    ///      only the bundle's confirmation/finalization queue delta to the live queues.
-    ///   5. Drain the sandbox's buffered geyser events; rebase transaction indices against the
-    ///      live confirmation queue at commit time and replay each onto `self.geyser_events_tx`.
+    ///      only confirmation entries created in the sandbox.
+    ///   5. Replay the sandbox's buffered Geyser events with their original indices.
     ///      For each `UpdateAccount` event, also fire `notify_account_subscribers` /
     ///      `notify_program_subscribers` on `self` (the sandbox's registries were emptied,
     ///      so those notifications could not have been delivered during sandbox execution).
@@ -715,7 +711,7 @@ impl SurfnetSvm {
     ///      ladder identically to txs submitted via `sendTransaction`).
     ///
     /// Returns the ordered list of signatures committed by the bundle.
-    pub fn commit_sandbox(
+    pub(crate) fn commit_sandbox(
         &mut self,
         sandbox: BundleSandbox,
         bundle_status_tx: Sender<TransactionStatusEvent>,
@@ -725,17 +721,16 @@ impl SurfnetSvm {
             geyser_rx,
             simnet_rx,
             confirmation_queue_base_len,
-            finalization_queue_base_len,
         } = sandbox;
 
         let sandbox_slot = svm.get_latest_absolute_slot();
         let live_slot = self.get_latest_absolute_slot();
         if sandbox_slot != live_slot {
             warn!(
-                "Rejecting stale bundle sandbox: sandbox_slot={}, live_slot={}",
+                "Rejecting bundle sandbox with mismatched slot: sandbox_slot={}, live_slot={}",
                 sandbox_slot, live_slot
             );
-            return Err(SurfpoolError::stale_bundle_sandbox_slot(
+            return Err(SurfpoolError::bundle_sandbox_slot_mismatch(
                 sandbox_slot,
                 live_slot,
             ));
@@ -808,10 +803,7 @@ impl SurfnetSvm {
         self.perf_samples = svm.perf_samples.clone();
         self.recent_blockhashes = svm.recent_blockhashes.clone();
 
-        // Append only the queue entries created by the bundle. The sandbox cloned the live
-        // queue at fork time, and that prefix may now be stale because live transactions can
-        // be committed while the bundle executes.
-        let committed_transaction_index_base = self.transactions_queued_for_confirmation.len();
+        // Append only confirmation entries created in the sandbox.
         let mut signatures = Vec::new();
         for (tx, _sandbox_status_tx, err) in svm
             .transactions_queued_for_confirmation
@@ -824,32 +816,12 @@ impl SurfnetSvm {
                 err,
             ));
         }
-        for (slot, tx, _sandbox_status_tx, err) in svm
-            .transactions_queued_for_finalization
-            .drain(finalization_queue_base_len..)
-        {
-            self.transactions_queued_for_finalization.push_back((
-                slot,
-                tx,
-                bundle_status_tx.clone(),
-                err,
-            ));
-        }
-
         // 5. Drain buffered geyser events; replay onto self's real channel; for each
         //    UpdateAccount, also fire account/program subscribers on self's registries.
-        let mut next_transaction_index = committed_transaction_index_base;
-        while let Ok(mut event) = geyser_rx.try_recv() {
-            match &mut event {
-                GeyserEvent::NotifyTransaction(_, _, transaction_index) => {
-                    *transaction_index = next_transaction_index;
-                    next_transaction_index += 1;
-                }
-                GeyserEvent::UpdateAccount(update) => {
-                    self.notify_account_subscribers(&update.pubkey, &update.account);
-                    self.notify_program_subscribers(&update.pubkey, &update.account);
-                }
-                _ => {}
+        while let Ok(event) = geyser_rx.try_recv() {
+            if let GeyserEvent::UpdateAccount(update) = &event {
+                self.notify_account_subscribers(&update.pubkey, &update.account);
+                self.notify_program_subscribers(&update.pubkey, &update.account);
             }
             let _ = self.geyser_events_tx.send(event);
         }
@@ -1231,39 +1203,48 @@ impl SurfnetSvm {
                 )),
             };
 
+            let transaction_with_status_meta = TransactionWithStatusMeta {
+                slot,
+                transaction: tx.clone(),
+                meta: TransactionStatusMeta {
+                    status: Ok(()),
+                    fee: 5000,
+                    pre_balances: vec![
+                        airdrop_account_before.lamports,
+                        recipient_account_before.lamports,
+                        system_account_before.lamports,
+                    ],
+                    post_balances: vec![
+                        airdrop_account_after.lamports,
+                        recipient_account_after.lamports,
+                        system_account_after.lamports,
+                    ],
+                    inner_instructions: Some(vec![]),
+                    log_messages: Some(tx_result.logs.clone()),
+                    pre_token_balances: Some(vec![]),
+                    post_token_balances: Some(vec![]),
+                    rewards: Some(vec![]),
+                    loaded_addresses: LoadedAddresses::default(),
+                    return_data: Some(tx_result.return_data.clone()),
+                    compute_units_consumed: Some(tx_result.compute_units_consumed),
+                    cost_units: None,
+                },
+            };
             self.transactions.store(
                 tx.get_signature().to_string(),
                 SurfnetTransactionStatus::processed(
-                    TransactionWithStatusMeta {
-                        slot,
-                        transaction: tx.clone(),
-                        meta: TransactionStatusMeta {
-                            status: Ok(()),
-                            fee: 5000,
-                            pre_balances: vec![
-                                airdrop_account_before.lamports,
-                                recipient_account_before.lamports,
-                                system_account_before.lamports,
-                            ],
-                            post_balances: vec![
-                                airdrop_account_after.lamports,
-                                recipient_account_after.lamports,
-                                system_account_after.lamports,
-                            ],
-                            inner_instructions: Some(vec![]),
-                            log_messages: Some(tx_result.logs.clone()),
-                            pre_token_balances: Some(vec![]),
-                            post_token_balances: Some(vec![]),
-                            rewards: Some(vec![]),
-                            loaded_addresses: LoadedAddresses::default(),
-                            return_data: Some(tx_result.return_data.clone()),
-                            compute_units_consumed: Some(tx_result.compute_units_consumed),
-                            cost_units: None,
-                        },
-                    },
+                    transaction_with_status_meta.clone(),
                     HashSet::from([*pubkey]),
                 ),
             )?;
+            let transaction_index = self.transactions_queued_for_confirmation.len();
+            let _ = self.geyser_events_tx.send(GeyserEvent::NotifyTransaction(
+                GeyserTransactionEvent {
+                    transaction_with_status_meta,
+                    versioned_transaction: Some(tx.clone()),
+                    index: transaction_index,
+                },
+            ));
             self.notify_signature_subscribers(
                 SignatureSubscriptionType::processed(),
                 tx.get_signature(),
@@ -4274,16 +4255,42 @@ mod tests {
     }
 
     #[test]
+    fn airdrops_emit_ordered_geyser_transaction_indices() {
+        let (mut svm, _events_rx, geyser_rx) = SurfnetSvm::default();
+        let recipients = [Pubkey::new_unique(), Pubkey::new_unique()];
+        let signatures = recipients.map(|recipient| {
+            svm.airdrop(&recipient, 1_000_000)
+                .expect("airdrop should complete")
+                .expect("airdrop should succeed")
+                .signature
+        });
+
+        let notifications = geyser_rx
+            .try_iter()
+            .filter_map(|event| match event {
+                GeyserEvent::NotifyTransaction(event) => Some((
+                    event.transaction_with_status_meta.transaction.signatures[0],
+                    event.index,
+                )),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(notifications, vec![(signatures[0], 0), (signatures[1], 1)]);
+    }
+
+    #[test]
     fn bundle_commit_rejects_sandbox_from_previous_slot_before_side_effects() {
         let (mut live_svm, _events_rx, live_geyser_rx) = SurfnetSvm::default();
         let recipient = Pubkey::new_unique();
         let mut sandbox = live_svm.clone_for_bundle_sandbox();
 
         let sandbox_slot = sandbox.svm.get_latest_absolute_slot();
-        let _ = sandbox
+        let sandbox_airdrop = sandbox
             .svm
             .airdrop(&recipient, 1_000_000)
-            .expect("sandbox airdrop should succeed");
+            .expect("sandbox airdrop should succeed")
+            .expect("sandbox airdrop should return a transaction");
 
         live_svm
             .confirm_current_block()
@@ -4302,7 +4309,7 @@ mod tests {
             .expect_err("a sandbox from a closed slot must not commit");
 
         assert!(error.to_string().contains(&format!(
-            "Bundle sandbox executed at slot {sandbox_slot}, but the live Surfnet advanced to slot {live_slot} before commit"
+            "Bundle sandbox slot {sandbox_slot} does not match live slot {live_slot}"
         )));
         assert_eq!(live_svm.get_latest_absolute_slot(), live_slot);
         assert_eq!(live_svm.chain_tip, expected_chain_tip);
@@ -4322,13 +4329,14 @@ mod tests {
                 .is_none(),
             "stale sandbox account state must not reach the live SVM"
         );
-        assert!(
-            live_geyser_rx.try_iter().all(|event| !matches!(
+        assert!(live_geyser_rx.try_iter().all(|event| {
+            !matches!(
                 event,
-                GeyserEvent::UpdateAccount(update) if update.pubkey == recipient
-            )),
-            "stale sandbox events must not reach the live Geyser channel"
-        );
+                GeyserEvent::NotifyTransaction(event)
+                    if event.transaction_with_status_meta.transaction.signatures[0]
+                        == sandbox_airdrop.signature
+            )
+        }));
     }
 
     fn build_transfer_transaction(


### PR DESCRIPTION
## Summary

- Populate `ReplicaTransactionInfoV3.index` from each transaction's position in the current slot.
- Keep the live SVM stable while a bundle executes and append only confirmation entries created in its sandbox.
- Emit transaction notifications for synthetic airdrops so visible Geyser indices remain dense.
- Add regression coverage for successful and failed transaction ordering, stale sandbox rejection, and concurrent bundle commits.

## Why

Surfpool currently reports index `0` for every Geyser transaction. Consumers keyed by
`(slot, transaction_index, instruction_index)` can therefore collide distinct transactions
from the same slot.

The confirmation queue defines Surfpool's pending transaction order for the current slot; its
length before enqueueing is the next index. Transaction execution, event publication, and
enqueueing now share one writer guard so the reported slot and index describe the same execution.

`sendBundle` retains the live SVM writer guard through sandbox execution and commit. The commit
appends only sandbox-created confirmation entries and replays their original indices. It rejects
a slot mismatch as an internal invariant failure before applying side effects.

This serializes SVM reads, writes, and slot ticks while a bundle runs.

## API note

`GeyserEvent::NotifyTransaction` now contains a named `GeyserTransactionEvent` payload with an
`index` field. This is a source-breaking change for `surfpool-core` callers that match or construct
the public variant. Bundle sandbox plumbing is crate-private.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p surfpool-core --all-targets`
- `cargo test -p surfpool-core same_slot_transactions_emit_ordered_geyser_indices`
- `cargo test -p surfpool-core airdrops_emit_ordered_geyser_transaction_indices`
- `cargo test -p surfpool-core bundle_commit_rejects_sandbox_from_previous_slot_before_side_effects`
- `cargo test -p surfpool-core test_send_bundle_keeps_slot_stable_through_commit`
- `cargo test -p surfpool-core test_send_transaction_skip_sig_verify_processes_and_updates_state -- --test-threads=1`

The broader core suite still has three pre-existing `test_simulate_add_alt_entries_fetching`
failures caused by remote blockhash/account-data variance; they reproduce serially outside the
sandbox and do not exercise this change.
