### PR TITLE
feat(core): make signature subscriptions a lifecycle state machine

### DIFF
--- a/crates/core/src/rpc/ws.rs
+++ b/crates/core/src/rpc/ws.rs
@@ -31,7 +31,7 @@ use crate::{
     rpc::utils::MAX_SUPPORTED_TRANSACTION_VERSION,
     surfnet::{
         GetTransactionResult, SignatureNotification, SignatureSubscribeOutcome,
-        SignatureSubscriptionType,
+        SignatureSubscriptionType, signature_subscriptions::notification_for,
     },
 };
 
@@ -1295,18 +1295,13 @@ impl Rpc for SurfpoolWsRpc {
                         .confirmation_status
                         .is_some_and(|status| subscription_type.is_satisfied_by(status))
                 {
-                    let notification = match subscription_type {
-                        SignatureSubscriptionType::Received => {
-                            SignatureNotification::Received { slot: tx.slot }
-                        }
-                        SignatureSubscriptionType::Commitment(_) => {
-                            SignatureNotification::Processed {
-                                slot: tx.slot,
-                                err: tx.err,
-                            }
-                        }
-                    };
-                    Self::notify_signature_subscriber(&active, &sub_id, notification);
+                    // Satisfaction is judged by the remote's own confirmation status;
+                    // only the payload rule is shared with the registry.
+                    Self::notify_signature_subscriber(
+                        &active,
+                        &sub_id,
+                        notification_for(&subscription_type, tx.slot, tx.err),
+                    );
                     return;
                 }
             }

--- a/crates/core/src/rpc/ws.rs
+++ b/crates/core/src/rpc/ws.rs
@@ -1313,10 +1313,18 @@ impl Rpc for SurfpoolWsRpc {
 
             tokio::select! {
                 notification = rx => {
-                    // An Err here means the SVM-side registry dropped the sender: the waiter
-                    // was swept, so there is nothing left to deliver.
-                    if let Ok(notification) = notification {
-                        Self::notify_signature_subscriber(&active, &sub_id, notification);
+                    match notification {
+                        Ok(notification) => {
+                            Self::notify_signature_subscriber(&active, &sub_id, notification);
+                        }
+                        // The registry dropped the sender (a network reset, or a swept
+                        // waiter): this subscription can no longer resolve, so drop the
+                        // entry rather than let the sink outlive it.
+                        Err(_) => {
+                            if let Ok(mut guard) = active.write() {
+                                guard.remove(&sub_id);
+                            }
+                        }
                     }
                 }
                 // Unsubscribe removed the entry and dropped the cancel sender: end the task.

--- a/crates/core/src/rpc/ws.rs
+++ b/crates/core/src/rpc/ws.rs
@@ -4,7 +4,6 @@ use std::{
     sync::{Arc, RwLock, atomic},
 };
 
-use crossbeam_channel::TryRecvError;
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_pubsub::{
@@ -25,12 +24,14 @@ use solana_pubkey::Pubkey;
 use solana_rpc_client_api::response::{Response as RpcResponse, SlotInfo, SlotUpdate};
 use solana_signature::Signature;
 use solana_transaction_status::UiTransactionEncoding;
+use tokio::sync::oneshot;
 
 use super::{State, SurfnetRpcContext, SurfpoolWebsocketMeta};
 use crate::{
     rpc::utils::MAX_SUPPORTED_TRANSACTION_VERSION,
     surfnet::{
-        GetTransactionResult, LocalSignatureStatusOrSubscription, SignatureSubscriptionType,
+        GetTransactionResult, SignatureNotification, SignatureSubscribeOutcome,
+        SignatureSubscriptionType,
     },
 };
 
@@ -1088,7 +1089,7 @@ pub trait Rpc {
 pub struct SurfpoolWsRpc {
     pub uid: atomic::AtomicUsize,
     pub signature_subscription_map:
-        Arc<RwLock<HashMap<SubscriptionId, Sink<RpcResponse<RpcSignatureResult>>>>>,
+        Arc<RwLock<HashMap<SubscriptionId, SignatureSubscriptionEntry>>>,
     pub account_subscription_map:
         Arc<RwLock<HashMap<SubscriptionId, Sink<RpcResponse<UiAccount>>>>>,
     pub program_subscription_map:
@@ -1102,47 +1103,65 @@ pub struct SurfpoolWsRpc {
     pub tokio_handle: tokio::runtime::Handle,
 }
 
+/// A live signature subscription: the client sink and the cancellation
+/// handle for its delivery task. Removing the entry (delivery or
+/// unsubscribe) drops the cancel sender, which wakes and ends the task;
+/// the task's dropped receiver is then swept from the SVM-side registry
+/// on the next transition or tick.
+pub struct SignatureSubscriptionEntry {
+    sink: Sink<RpcResponse<RpcSignatureResult>>,
+    _cancel: oneshot::Sender<()>,
+}
+
 impl SurfpoolWsRpc {
-    /// Send the one notification a signature subscription is allowed to produce and remove its
-    /// sink from the active subscription map.
+    /// Sends the one notification a signature subscription may produce and removes its entry
+    /// from the active subscription map. The payload variant is carried by the notification,
+    /// so every delivery path renders identically.
     fn notify_signature_subscriber(
-        active: &Arc<RwLock<HashMap<SubscriptionId, Sink<RpcResponse<RpcSignatureResult>>>>>,
+        active: &Arc<RwLock<HashMap<SubscriptionId, SignatureSubscriptionEntry>>>,
         sub_id: &SubscriptionId,
-        subscription_type: &SignatureSubscriptionType,
-        slot: u64,
-        err: Option<solana_transaction_error::TransactionError>,
-        is_received_event: bool,
-    ) -> bool {
+        notification: SignatureNotification,
+    ) {
         let Ok(mut guard) = active.write() else {
             log::error!("Failed to acquire write lock on signature_subscription_map");
-            return false;
+            return;
         };
 
-        let Some(sink) = guard.remove(sub_id) else {
-            return false;
+        let Some(entry) = guard.remove(sub_id) else {
+            return;
         };
 
-        let result = match (subscription_type, is_received_event) {
-            (SignatureSubscriptionType::Received, true) => sink.notify(Ok(RpcResponse {
+        let response = match notification {
+            SignatureNotification::Received { slot } => RpcResponse {
                 context: RpcResponseContext::new(slot),
                 value: RpcSignatureResult::ReceivedSignature(
                     ReceivedSignatureResult::ReceivedSignature,
                 ),
-            })),
-            _ => sink.notify(Ok(RpcResponse {
+            },
+            SignatureNotification::Processed { slot, err } => RpcResponse {
                 context: RpcResponseContext::new(slot),
                 value: RpcSignatureResult::ProcessedSignature(ProcessedSignatureResult {
                     err: err.map(Into::into),
                 }),
-            })),
+            },
         };
 
-        if let Err(error) = result {
+        if let Err(error) = entry.sink.notify(Ok(response)) {
             log::error!("Failed to notify client about signature update: {error}");
-            return false;
         }
+    }
 
-        true
+    /// Fails a signature subscription: removes its entry and forwards the error to the client.
+    fn fail_signature_subscriber(
+        active: &Arc<RwLock<HashMap<SubscriptionId, SignatureSubscriptionEntry>>>,
+        sub_id: &SubscriptionId,
+        error: Error,
+    ) {
+        if let Ok(mut guard) = active.write()
+            && let Some(entry) = guard.remove(sub_id)
+        {
+            let _ = entry.sink.notify(Err(error));
+        }
     }
 }
 
@@ -1217,8 +1236,15 @@ impl Rpc for SurfpoolWsRpc {
         let active = Arc::clone(&self.signature_subscription_map);
         let meta = meta.clone();
         self.tokio_handle.spawn(async move {
+            let (cancel_tx, cancel_rx) = oneshot::channel();
             if let Ok(mut guard) = active.write() {
-                guard.insert(sub_id.clone(), sink);
+                guard.insert(
+                    sub_id.clone(),
+                    SignatureSubscriptionEntry {
+                        sink,
+                        _cancel: cancel_tx,
+                    },
+                );
             } else {
                 log::error!("Failed to acquire write lock on signature_subscription_map");
                 return;
@@ -1231,125 +1257,72 @@ impl Rpc for SurfpoolWsRpc {
                 Ok(res) => res,
                 Err(e) => {
                     log::error!("Failed to get RPC context: {:?}", e);
-                    if let Ok(mut guard) = active.write() {
-                        if let Some(sink) = guard.remove(&sub_id) {
-                            if let Err(e) = sink.notify(Err(e.into())) {
-                                log::error!("Failed to notify client about RPC context error: {e}");
-                            }
-                        }
-                    }
+                    Self::fail_signature_subscriber(&active, &sub_id, e.into());
                     return;
                 }
             };
-            // Check local history first. A remote miss can take arbitrarily long, so it must not
-            // be part of the window between the final local check and receiver registration.
-            let local_tx_result =
-                match svm_locker.get_transaction_local(&signature, &rpc_transaction_config) {
-                    Ok(res) => res,
-                    Err(e) => {
-                        if let Ok(mut guard) = active.write() {
-                            if let Some(sink) = guard.remove(&sub_id) {
-                                let _ = sink.notify(Err(e.into()));
-                            }
-                        }
-                        return;
-                    }
-                };
 
-            // Preserve the historical remote lookup for signatures that were not executed
-            // locally. Its result is intentionally not inserted into the SVM.
-            let tx_result = if local_tx_result.is_none() {
-                match remote_ctx.as_ref() {
-                    Some((remote_client, _)) => {
-                        remote_client
-                            .get_transaction(
-                                signature,
-                                rpc_transaction_config.clone(),
-                                svm_locker.get_latest_absolute_slot(),
-                            )
-                            .await
-                    }
-                    None => local_tx_result,
+            // Resolve against local state or install the waiter, atomically: a transaction
+            // cannot be committed between the status check and the waiter installation.
+            let (rx, known_locally) = match svm_locker
+                .subscribe_signature(&signature, subscription_type.clone())
+            {
+                Ok(SignatureSubscribeOutcome::Now(notification)) => {
+                    Self::notify_signature_subscriber(&active, &sub_id, notification);
+                    return;
                 }
-            } else {
-                local_tx_result
+                Ok(SignatureSubscribeOutcome::Wait { rx, known_locally }) => (rx, known_locally),
+                Err(error) => {
+                    Self::fail_signature_subscriber(&active, &sub_id, error.into());
+                    return;
+                }
             };
 
-            if let GetTransactionResult::FoundTransaction(_, _, tx) = tx_result {
-                if tx
-                    .confirmation_status
-                    .is_some_and(|status| subscription_type.is_satisfied_by(status))
+            // Preserve the historical remote lookup for signatures this surfnet has never
+            // seen. The waiter is already installed, so a transaction landing during the
+            // lookup is delivered through it; the remote result is intentionally not
+            // inserted into the SVM.
+            if !known_locally && let Some((remote_client, _)) = remote_ctx.as_ref() {
+                let tx_result = remote_client
+                    .get_transaction(
+                        signature,
+                        rpc_transaction_config,
+                        svm_locker.get_latest_absolute_slot(),
+                    )
+                    .await;
+                if let GetTransactionResult::FoundTransaction(_, _, tx) = tx_result
+                    && tx
+                        .confirmation_status
+                        .is_some_and(|status| subscription_type.is_satisfied_by(status))
                 {
-                    Self::notify_signature_subscriber(
-                        &active,
-                        &sub_id,
-                        &subscription_type,
-                        tx.slot,
-                        tx.err,
-                        false,
-                    );
+                    let notification = match subscription_type {
+                        SignatureSubscriptionType::Received => {
+                            SignatureNotification::Received { slot: tx.slot }
+                        }
+                        SignatureSubscriptionType::Commitment(_) => {
+                            SignatureNotification::Processed {
+                                slot: tx.slot,
+                                err: tx.err,
+                            }
+                        }
+                    };
+                    Self::notify_signature_subscriber(&active, &sub_id, notification);
                     return;
                 }
             }
 
-            // Check local status and install the receiver while holding one SVM write lock. A
-            // locally committed transaction therefore cannot be missed after a remote miss.
-            let rx = match svm_locker
-                .get_local_signature_status_or_subscribe(&signature, subscription_type.clone())
-            {
-                Ok(LocalSignatureStatusOrSubscription::Status(status)) => {
-                    Self::notify_signature_subscriber(
-                        &active,
-                        &sub_id,
-                        &subscription_type,
-                        status.slot,
-                        status.err,
-                        false,
-                    );
-                    return;
-                }
-                Ok(LocalSignatureStatusOrSubscription::Subscription(rx)) => rx,
-                Err(error) => {
-                    if let Ok(mut guard) = active.write() {
-                        if let Some(sink) = guard.remove(&sub_id) {
-                            let _ = sink.notify(Err(error.into()));
-                        }
+            tokio::select! {
+                notification = rx => {
+                    // An Err here means the SVM-side registry dropped the sender: the waiter
+                    // was swept, so there is nothing left to deliver.
+                    if let Ok(notification) = notification {
+                        Self::notify_signature_subscriber(&active, &sub_id, notification);
                     }
-                    return;
                 }
-            };
-
-            loop {
-                let (slot, some_err) = match rx.try_recv() {
-                    Ok(msg) => msg,
-                    Err(e) => {
-                        match e {
-                            TryRecvError::Empty => {
-                                // no update yet, continue
-                                tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-                                continue;
-                            }
-                            TryRecvError::Disconnected => {
-                                warn!(
-                                    "Signature subscription channel closed for sub id {:?}",
-                                    sub_id
-                                );
-                                // channel closed, exit loop
-                                break;
-                            }
-                        }
-                    }
-                };
-
-                Self::notify_signature_subscriber(
-                    &active,
-                    &sub_id,
-                    &subscription_type,
-                    slot,
-                    some_err,
-                    true,
-                );
-                break;
+                // Unsubscribe removed the entry and dropped the cancel sender: end the task.
+                // The receiver dropped with this task is swept from the registry on the next
+                // transition or tick.
+                _ = cancel_rx => {}
             }
         });
     }

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -473,6 +473,10 @@ pub async fn start_block_production_runloop(
                             svm_writer.latest_epoch_info.slot_index = clock.slot;
                             svm_writer.latest_epoch_info.epoch = clock.epoch;
                             svm_writer.latest_epoch_info.absolute_slot = clock.slot + clock.epoch * svm_writer.latest_epoch_info.slots_in_epoch;
+                            // The warp is a clock advance without a produced block, so run
+                            // the block tick's waiter evaluation here or finalized waiters
+                            // stall until the next block (forever, in Manual mode).
+                            svm_writer.evaluate_signature_waiters();
                             svm_writer.simnet_events_tx.system_clock_updated(clock);
                         });
                     }
@@ -492,6 +496,8 @@ pub async fn start_block_production_runloop(
                             svm_writer.latest_epoch_info.slot_index = clock.slot;
                             svm_writer.latest_epoch_info.epoch = clock.epoch;
                             svm_writer.latest_epoch_info.absolute_slot = clock.slot + clock.epoch * svm_writer.latest_epoch_info.slots_in_epoch;
+                            // Same tick as the fire-and-forget warp above.
+                            svm_writer.evaluate_signature_waiters();
                             svm_writer.simnet_events_tx.system_clock_updated(clock);
                             svm_writer.latest_epoch_info.clone()
                         });

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -83,7 +83,7 @@ use crate::{
         utils::{convert_transaction_metadata_from_canonical, verify_pubkey},
     },
     storage::StorageResult,
-    surfnet::FINALIZATION_SLOT_THRESHOLD,
+    surfnet::{FINALIZATION_SLOT_THRESHOLD, confirmation_status_at},
     types::{
         GeyserAccountUpdate, OfflineAccountConfig, RemoteRpcResult, SurfnetTransactionStatus,
         TimeTravelConfig, TokenAccount, TransactionLoadedAddresses, TransactionWithStatusMeta,
@@ -1262,13 +1262,7 @@ impl SurfnetSvmLocker {
                             meta: tx_with_meta.meta.clone(),
                         });
 
-                        let confirmation_status = match current_slot {
-                            cs if cs == slot => SolanaTransactionConfirmationStatus::Processed,
-                            cs if cs < slot + FINALIZATION_SLOT_THRESHOLD => {
-                                SolanaTransactionConfirmationStatus::Confirmed
-                            }
-                            _ => SolanaTransactionConfirmationStatus::Finalized,
-                        };
+                        let confirmation_status = confirmation_status_at(slot, current_slot);
 
                         Some(Record {
                             signature: sig,
@@ -1438,13 +1432,7 @@ impl SurfnetSvmLocker {
                         }
 
                         // Determine confirmation status
-                        let confirmation_status = match current_slot {
-                            cs if cs == slot => SolanaTransactionConfirmationStatus::Processed,
-                            cs if cs < slot + FINALIZATION_SLOT_THRESHOLD => {
-                                SolanaTransactionConfirmationStatus::Confirmed
-                            }
-                            _ => SolanaTransactionConfirmationStatus::Finalized,
-                        };
+                        let confirmation_status = confirmation_status_at(slot, current_slot);
 
                         // Reconstruct the memo summary the same way a full Agave validator
                         // does, reusing its canonical extractor. `account_keys()` on the

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -65,8 +65,10 @@ use uuid::Uuid;
 
 use super::{
     AccountFactory, AccountSource, CoupledAccount, GetAccountResult, GetTransactionResult,
-    GeyserEvent, LocalSignatureStatusOrSubscription, SignatureSubscriptionType, SurfnetSvm,
-    remote::SurfnetRemoteClient, svm::AccountUpdatePolicy,
+    GeyserEvent, SignatureSubscriptionType, SurfnetSvm,
+    remote::SurfnetRemoteClient,
+    signature_subscriptions::{SignatureSubscribeOutcome, TxStage},
+    svm::AccountUpdatePolicy,
 };
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
@@ -1826,11 +1828,15 @@ impl SurfnetSvmLocker {
 
         let latest_absolute_slot = self.with_svm_writer(|svm_writer| {
             let latest_absolute_slot = svm_writer.get_latest_absolute_slot();
-            svm_writer.notify_signature_subscribers(
-                SignatureSubscriptionType::received(),
+            // Recording the stage (rather than firing a notification at
+            // whoever is registered right now) is what lets a subscriber
+            // arriving after this point, but before the transaction
+            // stores, still resolve its Received target.
+            svm_writer.record_signature_stage(
                 &signature,
-                latest_absolute_slot,
-                None,
+                TxStage::Received {
+                    slot: latest_absolute_slot,
+                },
             );
 
             latest_absolute_slot
@@ -2139,11 +2145,15 @@ impl SurfnetSvmLocker {
             simnet_events_tx.error(format!("Transaction simulation failed: {}", err));
 
             self.with_svm_writer(|svm_writer| {
-                svm_writer.notify_signature_subscribers(
-                    SignatureSubscriptionType::processed(),
+                // Failed, not Executed: this transaction was rejected
+                // before commitment and will never confirm, so only
+                // processed-level waiters may resolve from it.
+                svm_writer.record_signature_stage(
                     &signature,
-                    simulated_slot,
-                    Some(err.clone()),
+                    TxStage::Failed {
+                        slot: simulated_slot,
+                        err: err.clone(),
+                    },
                 );
                 svm_writer.notify_logs_subscribers(
                     &signature,
@@ -2269,11 +2279,12 @@ impl SurfnetSvmLocker {
                     Some(err.clone()),
                 ));
 
-                svm_writer.notify_signature_subscribers(
-                    SignatureSubscriptionType::processed(),
+                svm_writer.record_signature_stage(
                     &signature,
-                    simulated_slot,
-                    Some(err.clone()),
+                    TxStage::Executed {
+                        slot: simulated_slot,
+                        err: Some(err.clone()),
+                    },
                 );
                 svm_writer.notify_logs_subscribers(
                     &signature,
@@ -2463,11 +2474,12 @@ impl SurfnetSvmLocker {
                     None,
                 ));
 
-                svm_writer.notify_signature_subscribers(
-                    SignatureSubscriptionType::processed(),
+                svm_writer.record_signature_stage(
                     &signature,
-                    simulated_slot,
-                    None,
+                    TxStage::Executed {
+                        slot: simulated_slot,
+                        err: None,
+                    },
                 );
                 svm_writer.notify_logs_subscribers(
                     &signature,
@@ -3944,27 +3956,14 @@ impl SurfnetSvmLocker {
         svm_writer.materialize_overrides(remote_ctx).await
     }
 
-    /// Subscribes for signature updates (confirmed/finalized) and returns a receiver of events.
-    pub fn subscribe_for_signature_updates(
+    /// Atomically resolves a signature subscription against local state or registers a
+    /// waiter, under the SVM write lock.
+    pub fn subscribe_signature(
         &self,
         signature: &Signature,
-        subscription_type: SignatureSubscriptionType,
-    ) -> Receiver<(Slot, Option<TransactionError>)> {
-        self.with_svm_writer(|svm_writer| {
-            svm_writer.subscribe_for_signature_updates(signature, subscription_type.clone())
-        })
-    }
-
-    /// Atomically checks whether a local transaction already satisfies a signature
-    /// subscription, otherwise registers its receiver under the SVM write lock.
-    pub fn get_local_signature_status_or_subscribe(
-        &self,
-        signature: &Signature,
-        subscription_type: SignatureSubscriptionType,
-    ) -> SurfpoolResult<LocalSignatureStatusOrSubscription> {
-        self.with_svm_writer(|svm_writer| {
-            svm_writer.get_local_signature_status_or_subscribe(signature, subscription_type)
-        })
+        target: SignatureSubscriptionType,
+    ) -> SurfpoolResult<SignatureSubscribeOutcome> {
+        self.with_svm_writer(|svm_writer| svm_writer.subscribe_signature(signature, target))
     }
 
     /// Subscribes for account updates and returns a receiver of account updates.

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -40,6 +40,23 @@ pub use signature_subscriptions::{SignatureNotification, SignatureSubscribeOutco
 pub const FINALIZATION_SLOT_THRESHOLD: u64 = 31;
 pub const SLOTS_PER_EPOCH: u64 = 432000;
 
+/// The confirmation status a transaction executed at `tx_slot` has
+/// reached by `current_slot`: processed in its execution slot,
+/// confirmed one block later, finalized `FINALIZATION_SLOT_THRESHOLD`
+/// slots after execution. The single home of the slot-distance ladder.
+/// A current slot behind the execution slot reports processed; that
+/// domain is unreachable locally and covers remote transactions ahead
+/// of the local clock.
+pub fn confirmation_status_at(tx_slot: Slot, current_slot: Slot) -> TransactionConfirmationStatus {
+    if current_slot >= tx_slot.saturating_add(FINALIZATION_SLOT_THRESHOLD) {
+        TransactionConfirmationStatus::Finalized
+    } else if current_slot > tx_slot {
+        TransactionConfirmationStatus::Confirmed
+    } else {
+        TransactionConfirmationStatus::Processed
+    }
+}
+
 pub type AccountFactory = Box<dyn Fn(SurfnetSvmLocker) -> GetAccountResult + Send + Sync>;
 
 /// Slot status for geyser plugin notifications.
@@ -392,24 +409,14 @@ impl GetTransactionResult {
         tx: EncodedConfirmedTransactionWithStatusMeta,
         latest_absolute_slot: u64,
     ) -> Self {
-        let is_finalized = latest_absolute_slot >= tx.slot + FINALIZATION_SLOT_THRESHOLD;
-        let is_confirmed = latest_absolute_slot >= tx.slot + 1;
-        let (confirmation_status, confirmations) = if is_finalized {
-            (
-                Some(solana_transaction_status::TransactionConfirmationStatus::Finalized),
-                None,
-            )
-        } else if is_confirmed {
-            (
-                Some(solana_transaction_status::TransactionConfirmationStatus::Confirmed),
-                Some((latest_absolute_slot - tx.slot) as usize),
-            )
-        } else {
-            (
-                Some(solana_transaction_status::TransactionConfirmationStatus::Processed),
-                Some((latest_absolute_slot - tx.slot) as usize),
-            )
+        let confirmation_status = confirmation_status_at(tx.slot, latest_absolute_slot);
+        let confirmations = match confirmation_status {
+            TransactionConfirmationStatus::Finalized => None,
+            // Saturating: a remote transaction ahead of the local clock
+            // reports zero confirmations rather than underflowing.
+            _ => Some(latest_absolute_slot.saturating_sub(tx.slot) as usize),
         };
+        let confirmation_status = Some(confirmation_status);
         let status = TransactionStatus {
             slot: tx.slot,
             confirmations,

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::Sender;
 use jsonrpc_core::Result as RpcError;
 use locker::SurfnetSvmLocker;
 use solana_account::Account;
@@ -17,7 +17,6 @@ use solana_pubkey::Pubkey;
 use solana_rpc_client_api::response::SlotUpdate;
 use solana_signature::Signature;
 use solana_transaction::versioned::VersionedTransaction;
-use solana_transaction_error::TransactionError;
 use solana_transaction_status::{
     EncodedConfirmedTransactionWithStatusMeta, TransactionConfirmationStatus, TransactionStatus,
 };
@@ -32,8 +31,11 @@ use crate::{
 pub mod locker;
 pub mod noop_program;
 pub mod remote;
+pub mod signature_subscriptions;
 pub mod surfnet_lite_svm;
 pub mod svm;
+
+pub use signature_subscriptions::{SignatureNotification, SignatureSubscribeOutcome, TxStage};
 
 pub const FINALIZATION_SLOT_THRESHOLD: u64 = 31;
 pub const SLOTS_PER_EPOCH: u64 = 432000;
@@ -154,27 +156,6 @@ pub struct BlockHeader {
 pub enum SurfnetDataConnection {
     Offline,
     Connected(String, EpochInfo),
-}
-
-pub type SignatureSubscriptionData = (
-    SignatureSubscriptionType,
-    Sender<(Slot, Option<TransactionError>)>,
-);
-
-/// The status returned by an atomic signature lookup.
-///
-/// This deliberately contains only the fields needed to produce a
-/// `signatureNotification`; serializing the transaction is both unnecessary and would make the
-/// registration path needlessly expensive.
-pub struct LocalSignatureStatus {
-    pub slot: Slot,
-    pub err: Option<TransactionError>,
-}
-
-/// The outcome of atomically checking a local signature and registering for updates.
-pub enum LocalSignatureStatusOrSubscription {
-    Status(LocalSignatureStatus),
-    Subscription(Receiver<(Slot, Option<TransactionError>)>),
 }
 
 pub type AccountSubscriptionData =

--- a/crates/core/src/surfnet/signature_subscriptions.rs
+++ b/crates/core/src/surfnet/signature_subscriptions.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashMap;
 
-use solana_clock::Slot;
+use solana_clock::{MAX_PROCESSING_AGE, Slot};
 use solana_commitment_config::CommitmentLevel;
 use solana_signature::Signature;
 use solana_transaction_error::TransactionError;
@@ -107,9 +107,14 @@ struct SignatureLifecycle {
 
 impl SignatureLifecycle {
     /// Whether the entry still carries information: a waiter to
-    /// complete, or a stage the persistent store cannot answer for.
+    /// complete, or a stage the persistent store cannot answer for
+    /// (`Received` and `Failed` are never stored; `Executed` is).
     fn is_live(&self) -> bool {
-        !self.waiters.is_empty() || matches!(self.stage, Some(TxStage::Received { .. }))
+        !self.waiters.is_empty()
+            || matches!(
+                self.stage,
+                Some(TxStage::Received { .. } | TxStage::Failed { .. })
+            )
     }
 }
 
@@ -222,14 +227,21 @@ impl SignatureSubscriptions {
     /// Re-evaluates every waiter against the clock. Called once per
     /// produced block: this is where `Executed` stages cross the
     /// confirmed and finalized boundaries. Also the sweep: waiters
-    /// whose receiver was dropped are removed, and `Received` stages
-    /// old enough that their transaction can no longer land are
+    /// whose receiver was dropped are removed, and `Received` and
+    /// `Failed` stages older than the blockhash validity window are
     /// forgotten.
     pub fn tick(&mut self, current_slot: Slot) {
         self.lifecycles.retain(|_, lifecycle| {
             Self::drain(lifecycle, current_slot);
-            if let Some(TxStage::Received { slot }) = &lifecycle.stage
-                && current_slot >= slot.saturating_add(FINALIZATION_SLOT_THRESHOLD)
+            // 150 slots, per MAX_PROCESSING_AGE: past that, a Received
+            // transaction's blockhash can no longer be current and a
+            // Failed one's error no longer describes anything a client
+            // could still act on. (A durable-nonce transaction can
+            // outlive the window; its late subscriber falls back to the
+            // waiter path, an accepted residual.)
+            if let Some(TxStage::Received { slot } | TxStage::Failed { slot, .. }) =
+                &lifecycle.stage
+                && current_slot >= slot.saturating_add(MAX_PROCESSING_AGE as u64)
             {
                 lifecycle.stage = None;
             }
@@ -252,7 +264,12 @@ impl SignatureSubscriptions {
         target: SignatureSubscriptionType,
     ) -> SignatureSubscribeOutcome {
         let (tx, rx) = oneshot::channel();
-        let known_locally = lifecycle.stage.is_some();
+        // Executed only: a Received or Failed stage cannot answer a
+        // commitment target locally, and the pre-machine flow consulted
+        // the remote for exactly those signatures. Counting them here
+        // would suppress the remote lookup for a signature stuck at
+        // Received locally that exists remotely.
+        let known_locally = matches!(lifecycle.stage, Some(TxStage::Executed { .. }));
         lifecycle.waiters.push(Waiter { target, tx });
         SignatureSubscribeOutcome::Wait { rx, known_locally }
     }
@@ -488,10 +505,63 @@ mod tests {
     fn stale_received_stages_are_forgotten() {
         let mut subs = SignatureSubscriptions::default();
         subs.record(&sig(1), TxStage::Received { slot: 5 }, 5);
-        subs.tick(5 + FINALIZATION_SLOT_THRESHOLD - 1);
+        subs.tick(5 + MAX_PROCESSING_AGE as u64 - 1);
         assert_eq!(subs.lifecycles.len(), 1);
-        subs.tick(5 + FINALIZATION_SLOT_THRESHOLD);
+        subs.tick(5 + MAX_PROCESSING_AGE as u64);
         assert!(subs.lifecycles.is_empty());
+    }
+
+    #[test]
+    fn late_subscriber_is_answered_from_a_retained_failed_stage() {
+        // The persistent store never sees a simulation failure, so the
+        // registry is the only place a late processed-target subscriber
+        // can learn the error from.
+        let mut subs = SignatureSubscriptions::default();
+        let err = TransactionError::BlockhashNotFound;
+        subs.record(
+            &sig(1),
+            TxStage::Failed {
+                slot: 5,
+                err: err.clone(),
+            },
+            5,
+        );
+        let n = expect_now(subs.subscribe(&sig(1), processed(), None, 6));
+        assert_eq!(
+            n,
+            SignatureNotification::Processed {
+                slot: 5,
+                err: Some(err)
+            }
+        );
+        subs.tick(5 + MAX_PROCESSING_AGE as u64);
+        assert!(subs.lifecycles.is_empty());
+    }
+
+    #[test]
+    fn only_executed_stages_count_as_known_locally() {
+        // A Received-stuck signature cannot answer a commitment target
+        // locally; reporting it as known would suppress the remote
+        // lookup the pre-machine flow performed for it.
+        let mut subs = SignatureSubscriptions::default();
+        subs.record(&sig(1), TxStage::Received { slot: 5 }, 5);
+        match subs.subscribe(&sig(1), processed(), None, 5) {
+            SignatureSubscribeOutcome::Wait { known_locally, .. } => {
+                assert!(!known_locally)
+            }
+            SignatureSubscribeOutcome::Now(n) => panic!("expected Wait, got Now({n:?})"),
+        }
+        match subs.subscribe(
+            &sig(2),
+            finalized(),
+            Some(TxStage::Executed { slot: 5, err: None }),
+            5,
+        ) {
+            SignatureSubscribeOutcome::Wait { known_locally, .. } => {
+                assert!(known_locally)
+            }
+            SignatureSubscribeOutcome::Now(n) => panic!("expected Wait, got Now({n:?})"),
+        }
     }
 
     #[test]

--- a/crates/core/src/surfnet/signature_subscriptions.rs
+++ b/crates/core/src/surfnet/signature_subscriptions.rs
@@ -22,9 +22,8 @@ use solana_clock::{MAX_PROCESSING_AGE, Slot};
 use solana_commitment_config::CommitmentLevel;
 use solana_signature::Signature;
 use solana_transaction_error::TransactionError;
-use tokio::sync::oneshot;
-
 use solana_transaction_status::TransactionConfirmationStatus;
+use tokio::sync::oneshot;
 
 use super::{SignatureSubscriptionType, confirmation_status_at};
 

--- a/crates/core/src/surfnet/signature_subscriptions.rs
+++ b/crates/core/src/surfnet/signature_subscriptions.rs
@@ -1,0 +1,509 @@
+//! Signature subscriptions as predicates over a recorded, monotone
+//! per-signature lifecycle.
+//!
+//! A subscription is the predicate "complete me when this signature's
+//! stage first satisfies my target level". Registration and stage
+//! transitions mutate the same entry, so callers that hold the SVM
+//! writer lock get atomicity for free: a subscriber either observes the
+//! stage a transition recorded, or its waiter is present when the
+//! transition drains. Delivery is a `oneshot` completed at the
+//! transition (or a tick), so the notification variant and slot are
+//! computed in exactly one place.
+//!
+//! The registry stores only what the persistent transaction store does
+//! not: `Received` and `Failed` stages, and `Executed` stages that
+//! still have waiters attached. Entries are removed as soon as they
+//! carry neither, so the map is bounded by in-flight work rather than
+//! transaction history.
+
+use std::collections::HashMap;
+
+use solana_clock::Slot;
+use solana_commitment_config::CommitmentLevel;
+use solana_signature::Signature;
+use solana_transaction_error::TransactionError;
+use tokio::sync::oneshot;
+
+use super::{FINALIZATION_SLOT_THRESHOLD, SignatureSubscriptionType};
+
+/// The recorded lifecycle stage of a signature.
+///
+/// Stages are ordered `Received < Failed < Executed` and a recorded
+/// stage never regresses. `Failed` marks a transaction rejected before
+/// commitment (simulation failure): it satisfies the processed level
+/// with its error and never advances with the clock, since the
+/// transaction will not confirm. `Executed` covers committed
+/// transactions, reverted ones included; its commitment level is
+/// derived from clock distance at evaluation time.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TxStage {
+    Received {
+        slot: Slot,
+    },
+    Failed {
+        slot: Slot,
+        err: TransactionError,
+    },
+    Executed {
+        slot: Slot,
+        err: Option<TransactionError>,
+    },
+}
+
+impl TxStage {
+    fn slot(&self) -> Slot {
+        match self {
+            TxStage::Received { slot }
+            | TxStage::Failed { slot, .. }
+            | TxStage::Executed { slot, .. } => *slot,
+        }
+    }
+
+    fn order(&self) -> u8 {
+        match self {
+            TxStage::Received { .. } => 0,
+            TxStage::Failed { .. } => 1,
+            TxStage::Executed { .. } => 2,
+        }
+    }
+}
+
+/// The payload a signature subscription resolves to.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SignatureNotification {
+    Received {
+        slot: Slot,
+    },
+    Processed {
+        slot: Slot,
+        err: Option<TransactionError>,
+    },
+}
+
+/// The outcome of an atomic subscribe: the notification now, or a
+/// receiver completed by a later transition or tick.
+pub enum SignatureSubscribeOutcome {
+    Now(SignatureNotification),
+    /// A waiter was installed. `known_locally` reports whether any
+    /// stage for the signature was on record at registration time, so
+    /// callers can reserve remote lookups for signatures this surfnet
+    /// has never seen.
+    Wait {
+        rx: oneshot::Receiver<SignatureNotification>,
+        known_locally: bool,
+    },
+}
+
+struct Waiter {
+    target: SignatureSubscriptionType,
+    tx: oneshot::Sender<SignatureNotification>,
+}
+
+#[derive(Default)]
+struct SignatureLifecycle {
+    stage: Option<TxStage>,
+    waiters: Vec<Waiter>,
+}
+
+impl SignatureLifecycle {
+    /// Whether the entry still carries information: a waiter to
+    /// complete, or a stage the persistent store cannot answer for.
+    fn is_live(&self) -> bool {
+        !self.waiters.is_empty() || matches!(self.stage, Some(TxStage::Received { .. }))
+    }
+}
+
+/// The per-signature subscription registry. One instance lives on
+/// `SurfnetSvm`, so every method here runs under the SVM writer lock.
+#[derive(Default)]
+pub struct SignatureSubscriptions {
+    lifecycles: HashMap<Signature, SignatureLifecycle>,
+}
+
+/// A cloned registry is empty. SVM clones exist for profiling and
+/// bundle sandboxes, which must not complete live subscribers'
+/// waiters; one-shot delivery cannot be shared between two SVMs.
+impl Clone for SignatureSubscriptions {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+fn commitment_rank(level: CommitmentLevel) -> u8 {
+    match level {
+        CommitmentLevel::Processed => 1,
+        CommitmentLevel::Confirmed => 2,
+        CommitmentLevel::Finalized => 3,
+    }
+}
+
+fn executed_rank(executed_slot: Slot, current_slot: Slot) -> u8 {
+    if current_slot >= executed_slot.saturating_add(FINALIZATION_SLOT_THRESHOLD) {
+        3
+    } else if current_slot > executed_slot {
+        2
+    } else {
+        1
+    }
+}
+
+/// The notification `target` resolves to at `stage`, or `None` while
+/// the stage does not yet satisfy the target. The single home of both
+/// the satisfaction rule and the payload rule.
+pub(crate) fn try_notification(
+    target: &SignatureSubscriptionType,
+    stage: &TxStage,
+    current_slot: Slot,
+) -> Option<SignatureNotification> {
+    match (target, stage) {
+        (SignatureSubscriptionType::Received, stage) => {
+            Some(SignatureNotification::Received { slot: stage.slot() })
+        }
+        (SignatureSubscriptionType::Commitment(level), TxStage::Executed { slot, err }) => {
+            (executed_rank(*slot, current_slot) >= commitment_rank(*level)).then(|| {
+                SignatureNotification::Processed {
+                    slot: *slot,
+                    err: err.clone(),
+                }
+            })
+        }
+        (SignatureSubscriptionType::Commitment(level), TxStage::Failed { slot, err }) => {
+            (*level == CommitmentLevel::Processed).then(|| SignatureNotification::Processed {
+                slot: *slot,
+                err: Some(err.clone()),
+            })
+        }
+        (SignatureSubscriptionType::Commitment(_), TxStage::Received { .. }) => None,
+    }
+}
+
+impl SignatureSubscriptions {
+    /// Atomically resolves `target` against the signature's stage or
+    /// registers a waiter. `known_stage` carries what the caller read
+    /// from the persistent transaction store, so a waiter registered
+    /// against an already-executed transaction is seeded with the stage
+    /// later ticks advance.
+    pub fn subscribe(
+        &mut self,
+        signature: &Signature,
+        target: SignatureSubscriptionType,
+        known_stage: Option<TxStage>,
+        current_slot: Slot,
+    ) -> SignatureSubscribeOutcome {
+        let lifecycle = self.lifecycles.entry(*signature).or_default();
+        if let Some(stage) = known_stage {
+            Self::advance(lifecycle, stage);
+        }
+        let outcome = match &lifecycle.stage {
+            Some(stage) => match try_notification(&target, stage, current_slot) {
+                Some(notification) => SignatureSubscribeOutcome::Now(notification),
+                None => Self::wait(lifecycle, target),
+            },
+            None => Self::wait(lifecycle, target),
+        };
+        if !lifecycle.is_live() {
+            self.lifecycles.remove(signature);
+        }
+        outcome
+    }
+
+    /// Records a stage transition and completes the waiters it
+    /// satisfies. A stage never regresses: a `Received` recorded after
+    /// `Executed` is ignored.
+    pub fn record(&mut self, signature: &Signature, stage: TxStage, current_slot: Slot) {
+        let lifecycle = self.lifecycles.entry(*signature).or_default();
+        Self::advance(lifecycle, stage);
+        Self::drain(lifecycle, current_slot);
+        if !lifecycle.is_live() {
+            self.lifecycles.remove(signature);
+        }
+    }
+
+    /// Re-evaluates every waiter against the clock. Called once per
+    /// produced block: this is where `Executed` stages cross the
+    /// confirmed and finalized boundaries. Also the sweep: waiters
+    /// whose receiver was dropped are removed, and `Received` stages
+    /// old enough that their transaction can no longer land are
+    /// forgotten.
+    pub fn tick(&mut self, current_slot: Slot) {
+        self.lifecycles.retain(|_, lifecycle| {
+            Self::drain(lifecycle, current_slot);
+            if let Some(TxStage::Received { slot }) = &lifecycle.stage
+                && current_slot >= slot.saturating_add(FINALIZATION_SLOT_THRESHOLD)
+            {
+                lifecycle.stage = None;
+            }
+            lifecycle.is_live()
+        });
+    }
+
+    fn advance(lifecycle: &mut SignatureLifecycle, stage: TxStage) {
+        let advances = lifecycle
+            .stage
+            .as_ref()
+            .is_none_or(|current| stage.order() > current.order());
+        if advances {
+            lifecycle.stage = Some(stage);
+        }
+    }
+
+    fn wait(
+        lifecycle: &mut SignatureLifecycle,
+        target: SignatureSubscriptionType,
+    ) -> SignatureSubscribeOutcome {
+        let (tx, rx) = oneshot::channel();
+        let known_locally = lifecycle.stage.is_some();
+        lifecycle.waiters.push(Waiter { target, tx });
+        SignatureSubscribeOutcome::Wait { rx, known_locally }
+    }
+
+    fn drain(lifecycle: &mut SignatureLifecycle, current_slot: Slot) {
+        let stage = lifecycle.stage.clone();
+        let waiters = std::mem::take(&mut lifecycle.waiters);
+        for waiter in waiters {
+            if waiter.tx.is_closed() {
+                continue;
+            }
+            let notification = stage
+                .as_ref()
+                .and_then(|stage| try_notification(&waiter.target, stage, current_slot));
+            match notification {
+                // A send failure means the receiver was dropped after
+                // the is_closed check: the same outcome as a sweep.
+                Some(notification) => {
+                    let _ = waiter.tx.send(notification);
+                }
+                None => lifecycle.waiters.push(waiter),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sig(n: u8) -> Signature {
+        Signature::from([n; 64])
+    }
+
+    fn processed() -> SignatureSubscriptionType {
+        SignatureSubscriptionType::Commitment(CommitmentLevel::Processed)
+    }
+
+    fn confirmed() -> SignatureSubscriptionType {
+        SignatureSubscriptionType::Commitment(CommitmentLevel::Confirmed)
+    }
+
+    fn finalized() -> SignatureSubscriptionType {
+        SignatureSubscriptionType::Commitment(CommitmentLevel::Finalized)
+    }
+
+    fn expect_wait(outcome: SignatureSubscribeOutcome) -> oneshot::Receiver<SignatureNotification> {
+        match outcome {
+            SignatureSubscribeOutcome::Wait { rx, .. } => rx,
+            SignatureSubscribeOutcome::Now(n) => panic!("expected Wait, got Now({n:?})"),
+        }
+    }
+
+    fn expect_now(outcome: SignatureSubscribeOutcome) -> SignatureNotification {
+        match outcome {
+            SignatureSubscribeOutcome::Now(n) => n,
+            SignatureSubscribeOutcome::Wait { .. } => panic!("expected Now, got Wait"),
+        }
+    }
+
+    #[test]
+    fn transition_completes_a_registered_waiter() {
+        let mut subs = SignatureSubscriptions::default();
+        let mut rx = expect_wait(subs.subscribe(&sig(1), processed(), None, 10));
+        assert!(rx.try_recv().is_err());
+        subs.record(
+            &sig(1),
+            TxStage::Executed {
+                slot: 10,
+                err: None,
+            },
+            10,
+        );
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            SignatureNotification::Processed {
+                slot: 10,
+                err: None
+            }
+        );
+        assert!(subs.lifecycles.is_empty());
+    }
+
+    #[test]
+    fn late_subscriber_is_satisfied_from_recorded_received_stage() {
+        // The scan-before-store race of the old design: received fires,
+        // then the subscriber arrives, then the transaction stores.
+        // With the stage recorded, the late subscriber resolves now.
+        let mut subs = SignatureSubscriptions::default();
+        subs.record(&sig(1), TxStage::Received { slot: 7 }, 7);
+        let n = expect_now(subs.subscribe(&sig(1), SignatureSubscriptionType::Received, None, 7));
+        assert_eq!(n, SignatureNotification::Received { slot: 7 });
+    }
+
+    #[test]
+    fn received_stage_does_not_satisfy_commitment_targets() {
+        let mut subs = SignatureSubscriptions::default();
+        subs.record(&sig(1), TxStage::Received { slot: 7 }, 7);
+        let mut rx = expect_wait(subs.subscribe(&sig(1), processed(), None, 7));
+        subs.record(&sig(1), TxStage::Executed { slot: 8, err: None }, 8);
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            SignatureNotification::Processed { slot: 8, err: None }
+        );
+    }
+
+    #[test]
+    fn received_target_resolves_from_executed_stage_with_received_variant() {
+        let mut subs = SignatureSubscriptions::default();
+        let n = expect_now(subs.subscribe(
+            &sig(1),
+            SignatureSubscriptionType::Received,
+            Some(TxStage::Executed { slot: 5, err: None }),
+            5,
+        ));
+        assert_eq!(n, SignatureNotification::Received { slot: 5 });
+    }
+
+    #[test]
+    fn ticks_advance_executed_stages_across_commitment_boundaries() {
+        let mut subs = SignatureSubscriptions::default();
+        let mut confirmed_rx = expect_wait(subs.subscribe(&sig(1), confirmed(), None, 10));
+        let mut finalized_rx = expect_wait(subs.subscribe(&sig(1), finalized(), None, 10));
+        subs.record(
+            &sig(1),
+            TxStage::Executed {
+                slot: 10,
+                err: None,
+            },
+            10,
+        );
+        assert!(confirmed_rx.try_recv().is_err());
+
+        subs.tick(11);
+        assert_eq!(
+            confirmed_rx.try_recv().unwrap(),
+            SignatureNotification::Processed {
+                slot: 10,
+                err: None
+            }
+        );
+        assert!(finalized_rx.try_recv().is_err());
+
+        subs.tick(10 + FINALIZATION_SLOT_THRESHOLD);
+        assert_eq!(
+            finalized_rx.try_recv().unwrap(),
+            SignatureNotification::Processed {
+                slot: 10,
+                err: None
+            }
+        );
+        assert!(subs.lifecycles.is_empty());
+    }
+
+    #[test]
+    fn known_stage_seeds_the_entry_so_ticks_can_finish_it() {
+        // A finalized-target subscriber for a transaction the store
+        // already holds: the waiter must carry the executed stage into
+        // the registry, or no tick could ever complete it.
+        let mut subs = SignatureSubscriptions::default();
+        let mut rx = expect_wait(subs.subscribe(
+            &sig(1),
+            finalized(),
+            Some(TxStage::Executed {
+                slot: 10,
+                err: None,
+            }),
+            11,
+        ));
+        subs.tick(10 + FINALIZATION_SLOT_THRESHOLD);
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            SignatureNotification::Processed {
+                slot: 10,
+                err: None
+            }
+        );
+    }
+
+    #[test]
+    fn failed_stage_satisfies_processed_only_and_never_advances() {
+        let mut subs = SignatureSubscriptions::default();
+        let mut processed_rx = expect_wait(subs.subscribe(&sig(1), processed(), None, 10));
+        let mut confirmed_rx = expect_wait(subs.subscribe(&sig(1), confirmed(), None, 10));
+        let err = TransactionError::BlockhashNotFound;
+        subs.record(
+            &sig(1),
+            TxStage::Failed {
+                slot: 10,
+                err: err.clone(),
+            },
+            10,
+        );
+        assert_eq!(
+            processed_rx.try_recv().unwrap(),
+            SignatureNotification::Processed {
+                slot: 10,
+                err: Some(err)
+            }
+        );
+        assert!(confirmed_rx.try_recv().is_err());
+        subs.tick(10 + FINALIZATION_SLOT_THRESHOLD);
+        assert!(confirmed_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn stages_never_regress() {
+        let mut subs = SignatureSubscriptions::default();
+        // The confirmed-target waiter keeps the entry live at Executed.
+        let mut rx = expect_wait(subs.subscribe(&sig(1), confirmed(), None, 9));
+        subs.record(&sig(1), TxStage::Executed { slot: 9, err: None }, 9);
+        // A received recorded after execution (a duplicate submission)
+        // must not regress the stage: were Received to win, this tick
+        // could no longer confirm.
+        subs.record(&sig(1), TxStage::Received { slot: 9 }, 9);
+        subs.tick(10);
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            SignatureNotification::Processed { slot: 9, err: None }
+        );
+    }
+
+    #[test]
+    fn dropped_receivers_are_swept() {
+        let mut subs = SignatureSubscriptions::default();
+        let rx = expect_wait(subs.subscribe(&sig(1), confirmed(), None, 10));
+        drop(rx);
+        subs.tick(11);
+        assert!(subs.lifecycles.is_empty());
+    }
+
+    #[test]
+    fn stale_received_stages_are_forgotten() {
+        let mut subs = SignatureSubscriptions::default();
+        subs.record(&sig(1), TxStage::Received { slot: 5 }, 5);
+        subs.tick(5 + FINALIZATION_SLOT_THRESHOLD - 1);
+        assert_eq!(subs.lifecycles.len(), 1);
+        subs.tick(5 + FINALIZATION_SLOT_THRESHOLD);
+        assert!(subs.lifecycles.is_empty());
+    }
+
+    #[test]
+    fn immediate_satisfaction_registers_no_entry() {
+        let mut subs = SignatureSubscriptions::default();
+        let n = expect_now(subs.subscribe(
+            &sig(1),
+            processed(),
+            Some(TxStage::Executed { slot: 4, err: None }),
+            4,
+        ));
+        assert_eq!(n, SignatureNotification::Processed { slot: 4, err: None });
+        assert!(subs.lifecycles.is_empty());
+    }
+}

--- a/crates/core/src/surfnet/signature_subscriptions.rs
+++ b/crates/core/src/surfnet/signature_subscriptions.rs
@@ -52,6 +52,15 @@ pub enum TxStage {
     },
 }
 
+/// The stage ordering `advance` enforces. Variant order is the
+/// ordering; the derived `Ord` owns it.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum TxStageKind {
+    Received,
+    Failed,
+    Executed,
+}
+
 impl TxStage {
     fn slot(&self) -> Slot {
         match self {
@@ -61,11 +70,11 @@ impl TxStage {
         }
     }
 
-    fn order(&self) -> u8 {
+    fn kind(&self) -> TxStageKind {
         match self {
-            TxStage::Received { .. } => 0,
-            TxStage::Failed { .. } => 1,
-            TxStage::Executed { .. } => 2,
+            TxStage::Received { .. } => TxStageKind::Received,
+            TxStage::Failed { .. } => TxStageKind::Failed,
+            TxStage::Executed { .. } => TxStageKind::Executed,
         }
     }
 }
@@ -146,19 +155,36 @@ pub struct SignatureSubscriptions {
     lifecycles: HashMap<Signature, SignatureLifecycle>,
 }
 
-fn commitment_rank(level: CommitmentLevel) -> u8 {
-    match level {
-        CommitmentLevel::Processed => 1,
-        CommitmentLevel::Confirmed => 2,
-        CommitmentLevel::Finalized => 3,
+/// The commitment lattice both foreign types project into: a
+/// subscription's target level and a transaction's confirmation status
+/// have no common comparison in the solana crates, so satisfaction
+/// compares their projections here. Variant order is the ordering; the
+/// derived `Ord` owns it, and the two `From` impls read name-to-name,
+/// so a mismapping is visible at a glance.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum CommitmentRank {
+    Processed,
+    Confirmed,
+    Finalized,
+}
+
+impl From<CommitmentLevel> for CommitmentRank {
+    fn from(level: CommitmentLevel) -> Self {
+        match level {
+            CommitmentLevel::Processed => CommitmentRank::Processed,
+            CommitmentLevel::Confirmed => CommitmentRank::Confirmed,
+            CommitmentLevel::Finalized => CommitmentRank::Finalized,
+        }
     }
 }
 
-fn status_rank(status: TransactionConfirmationStatus) -> u8 {
-    match status {
-        TransactionConfirmationStatus::Processed => 1,
-        TransactionConfirmationStatus::Confirmed => 2,
-        TransactionConfirmationStatus::Finalized => 3,
+impl From<TransactionConfirmationStatus> for CommitmentRank {
+    fn from(status: TransactionConfirmationStatus) -> Self {
+        match status {
+            TransactionConfirmationStatus::Processed => CommitmentRank::Processed,
+            TransactionConfirmationStatus::Confirmed => CommitmentRank::Confirmed,
+            TransactionConfirmationStatus::Finalized => CommitmentRank::Finalized,
+        }
     }
 }
 
@@ -191,8 +217,9 @@ pub(crate) fn try_notification(
             Some(notification_for(target, stage.slot(), None))
         }
         (SignatureSubscriptionType::Commitment(level), TxStage::Executed { slot, err }) => {
-            (status_rank(confirmation_status_at(*slot, current_slot)) >= commitment_rank(*level))
-                .then(|| notification_for(target, *slot, err.clone()))
+            (CommitmentRank::from(confirmation_status_at(*slot, current_slot))
+                >= CommitmentRank::from(*level))
+            .then(|| notification_for(target, *slot, err.clone()))
         }
         (SignatureSubscriptionType::Commitment(level), TxStage::Failed { slot, err }) => (*level
             == CommitmentLevel::Processed)
@@ -292,7 +319,7 @@ impl SignatureSubscriptions {
         let advances = lifecycle
             .stage
             .as_ref()
-            .is_none_or(|current| stage.order() > current.order());
+            .is_none_or(|current| stage.kind() > current.kind());
         if advances {
             lifecycle.stage = Some(stage);
         }

--- a/crates/core/src/surfnet/signature_subscriptions.rs
+++ b/crates/core/src/surfnet/signature_subscriptions.rs
@@ -16,7 +16,7 @@
 //! carry neither, so the map is bounded by in-flight work rather than
 //! transaction history.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 
 use solana_clock::{MAX_PROCESSING_AGE, Slot};
 use solana_commitment_config::CommitmentLevel;
@@ -24,7 +24,9 @@ use solana_signature::Signature;
 use solana_transaction_error::TransactionError;
 use tokio::sync::oneshot;
 
-use super::{FINALIZATION_SLOT_THRESHOLD, SignatureSubscriptionType};
+use solana_transaction_status::TransactionConfirmationStatus;
+
+use super::{SignatureSubscriptionType, confirmation_status_at};
 
 /// The recorded lifecycle stage of a signature.
 ///
@@ -94,6 +96,25 @@ pub enum SignatureSubscribeOutcome {
     },
 }
 
+#[cfg(test)]
+impl SignatureSubscribeOutcome {
+    /// Unwraps a pending subscription's receiver.
+    pub fn expect_wait(self) -> oneshot::Receiver<SignatureNotification> {
+        match self {
+            SignatureSubscribeOutcome::Wait { rx, .. } => rx,
+            SignatureSubscribeOutcome::Now(n) => panic!("expected Wait, got Now({n:?})"),
+        }
+    }
+
+    /// Unwraps an immediately resolved subscription's notification.
+    pub fn expect_now(self) -> SignatureNotification {
+        match self {
+            SignatureSubscribeOutcome::Now(n) => n,
+            SignatureSubscribeOutcome::Wait { .. } => panic!("expected Now, got Wait"),
+        }
+    }
+}
+
 struct Waiter {
     target: SignatureSubscriptionType,
     tx: oneshot::Sender<SignatureNotification>,
@@ -125,15 +146,6 @@ pub struct SignatureSubscriptions {
     lifecycles: HashMap<Signature, SignatureLifecycle>,
 }
 
-/// A cloned registry is empty. SVM clones exist for profiling and
-/// bundle sandboxes, which must not complete live subscribers'
-/// waiters; one-shot delivery cannot be shared between two SVMs.
-impl Clone for SignatureSubscriptions {
-    fn clone(&self) -> Self {
-        Self::default()
-    }
-}
-
 fn commitment_rank(level: CommitmentLevel) -> u8 {
     match level {
         CommitmentLevel::Processed => 1,
@@ -142,19 +154,33 @@ fn commitment_rank(level: CommitmentLevel) -> u8 {
     }
 }
 
-fn executed_rank(executed_slot: Slot, current_slot: Slot) -> u8 {
-    if current_slot >= executed_slot.saturating_add(FINALIZATION_SLOT_THRESHOLD) {
-        3
-    } else if current_slot > executed_slot {
-        2
-    } else {
-        1
+fn status_rank(status: TransactionConfirmationStatus) -> u8 {
+    match status {
+        TransactionConfirmationStatus::Processed => 1,
+        TransactionConfirmationStatus::Confirmed => 2,
+        TransactionConfirmationStatus::Finalized => 3,
+    }
+}
+
+/// The payload a satisfied `target` resolves to. The satisfaction
+/// decision belongs to the caller: `try_notification` decides from a
+/// recorded stage, the ws remote path from the remote's own
+/// confirmation status.
+pub(crate) fn notification_for(
+    target: &SignatureSubscriptionType,
+    slot: Slot,
+    err: Option<TransactionError>,
+) -> SignatureNotification {
+    match target {
+        SignatureSubscriptionType::Received => SignatureNotification::Received { slot },
+        SignatureSubscriptionType::Commitment(_) => SignatureNotification::Processed { slot, err },
     }
 }
 
 /// The notification `target` resolves to at `stage`, or `None` while
-/// the stage does not yet satisfy the target. The single home of both
-/// the satisfaction rule and the payload rule.
+/// the stage does not yet satisfy the target. The satisfaction rule in
+/// one place; the slot-distance ladder itself lives in
+/// [`confirmation_status_at`].
 pub(crate) fn try_notification(
     target: &SignatureSubscriptionType,
     stage: &TxStage,
@@ -162,22 +188,15 @@ pub(crate) fn try_notification(
 ) -> Option<SignatureNotification> {
     match (target, stage) {
         (SignatureSubscriptionType::Received, stage) => {
-            Some(SignatureNotification::Received { slot: stage.slot() })
+            Some(notification_for(target, stage.slot(), None))
         }
         (SignatureSubscriptionType::Commitment(level), TxStage::Executed { slot, err }) => {
-            (executed_rank(*slot, current_slot) >= commitment_rank(*level)).then(|| {
-                SignatureNotification::Processed {
-                    slot: *slot,
-                    err: err.clone(),
-                }
-            })
+            (status_rank(confirmation_status_at(*slot, current_slot)) >= commitment_rank(*level))
+                .then(|| notification_for(target, *slot, err.clone()))
         }
-        (SignatureSubscriptionType::Commitment(level), TxStage::Failed { slot, err }) => {
-            (*level == CommitmentLevel::Processed).then(|| SignatureNotification::Processed {
-                slot: *slot,
-                err: Some(err.clone()),
-            })
-        }
+        (SignatureSubscriptionType::Commitment(level), TxStage::Failed { slot, err }) => (*level
+            == CommitmentLevel::Processed)
+            .then(|| notification_for(target, *slot, Some(err.clone()))),
         (SignatureSubscriptionType::Commitment(_), TxStage::Received { .. }) => None,
     }
 }
@@ -195,21 +214,41 @@ impl SignatureSubscriptions {
         known_stage: Option<TxStage>,
         current_slot: Slot,
     ) -> SignatureSubscribeOutcome {
-        let lifecycle = self.lifecycles.entry(*signature).or_default();
-        if let Some(stage) = known_stage {
-            Self::advance(lifecycle, stage);
+        match self.lifecycles.entry(*signature) {
+            // An immediately satisfied subscription on an unknown
+            // signature never touches the map.
+            Entry::Vacant(vacant) => {
+                if let Some(stage) = &known_stage
+                    && let Some(notification) = try_notification(&target, stage, current_slot)
+                {
+                    return SignatureSubscribeOutcome::Now(notification);
+                }
+                let mut lifecycle = SignatureLifecycle {
+                    stage: known_stage,
+                    waiters: Vec::new(),
+                };
+                let outcome = Self::wait(&mut lifecycle, target);
+                vacant.insert(lifecycle);
+                outcome
+            }
+            Entry::Occupied(mut occupied) => {
+                let lifecycle = occupied.get_mut();
+                if let Some(stage) = known_stage {
+                    Self::advance(lifecycle, stage);
+                }
+                let outcome = match &lifecycle.stage {
+                    Some(stage) => match try_notification(&target, stage, current_slot) {
+                        Some(notification) => SignatureSubscribeOutcome::Now(notification),
+                        None => Self::wait(lifecycle, target),
+                    },
+                    None => Self::wait(lifecycle, target),
+                };
+                if !occupied.get().is_live() {
+                    occupied.remove();
+                }
+                outcome
+            }
         }
-        let outcome = match &lifecycle.stage {
-            Some(stage) => match try_notification(&target, stage, current_slot) {
-                Some(notification) => SignatureSubscribeOutcome::Now(notification),
-                None => Self::wait(lifecycle, target),
-            },
-            None => Self::wait(lifecycle, target),
-        };
-        if !lifecycle.is_live() {
-            self.lifecycles.remove(signature);
-        }
-        outcome
     }
 
     /// Records a stage transition and completes the waiters it
@@ -278,18 +317,16 @@ impl SignatureSubscriptions {
         let stage = lifecycle.stage.clone();
         let waiters = std::mem::take(&mut lifecycle.waiters);
         for waiter in waiters {
-            if waiter.tx.is_closed() {
-                continue;
-            }
             let notification = stage
                 .as_ref()
                 .and_then(|stage| try_notification(&waiter.target, stage, current_slot));
             match notification {
-                // A send failure means the receiver was dropped after
-                // the is_closed check: the same outcome as a sweep.
+                // A send to a dropped receiver fails harmlessly: the
+                // same outcome as the sweep below.
                 Some(notification) => {
                     let _ = waiter.tx.send(notification);
                 }
+                None if waiter.tx.is_closed() => {}
                 None => lifecycle.waiters.push(waiter),
             }
         }
@@ -299,6 +336,7 @@ impl SignatureSubscriptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::surfnet::FINALIZATION_SLOT_THRESHOLD;
 
     fn sig(n: u8) -> Signature {
         Signature::from([n; 64])
@@ -316,24 +354,10 @@ mod tests {
         SignatureSubscriptionType::Commitment(CommitmentLevel::Finalized)
     }
 
-    fn expect_wait(outcome: SignatureSubscribeOutcome) -> oneshot::Receiver<SignatureNotification> {
-        match outcome {
-            SignatureSubscribeOutcome::Wait { rx, .. } => rx,
-            SignatureSubscribeOutcome::Now(n) => panic!("expected Wait, got Now({n:?})"),
-        }
-    }
-
-    fn expect_now(outcome: SignatureSubscribeOutcome) -> SignatureNotification {
-        match outcome {
-            SignatureSubscribeOutcome::Now(n) => n,
-            SignatureSubscribeOutcome::Wait { .. } => panic!("expected Now, got Wait"),
-        }
-    }
-
     #[test]
     fn transition_completes_a_registered_waiter() {
         let mut subs = SignatureSubscriptions::default();
-        let mut rx = expect_wait(subs.subscribe(&sig(1), processed(), None, 10));
+        let mut rx = subs.subscribe(&sig(1), processed(), None, 10).expect_wait();
         assert!(rx.try_recv().is_err());
         subs.record(
             &sig(1),
@@ -360,7 +384,9 @@ mod tests {
         // With the stage recorded, the late subscriber resolves now.
         let mut subs = SignatureSubscriptions::default();
         subs.record(&sig(1), TxStage::Received { slot: 7 }, 7);
-        let n = expect_now(subs.subscribe(&sig(1), SignatureSubscriptionType::Received, None, 7));
+        let n = subs
+            .subscribe(&sig(1), SignatureSubscriptionType::Received, None, 7)
+            .expect_now();
         assert_eq!(n, SignatureNotification::Received { slot: 7 });
     }
 
@@ -368,7 +394,7 @@ mod tests {
     fn received_stage_does_not_satisfy_commitment_targets() {
         let mut subs = SignatureSubscriptions::default();
         subs.record(&sig(1), TxStage::Received { slot: 7 }, 7);
-        let mut rx = expect_wait(subs.subscribe(&sig(1), processed(), None, 7));
+        let mut rx = subs.subscribe(&sig(1), processed(), None, 7).expect_wait();
         subs.record(&sig(1), TxStage::Executed { slot: 8, err: None }, 8);
         assert_eq!(
             rx.try_recv().unwrap(),
@@ -379,20 +405,22 @@ mod tests {
     #[test]
     fn received_target_resolves_from_executed_stage_with_received_variant() {
         let mut subs = SignatureSubscriptions::default();
-        let n = expect_now(subs.subscribe(
-            &sig(1),
-            SignatureSubscriptionType::Received,
-            Some(TxStage::Executed { slot: 5, err: None }),
-            5,
-        ));
+        let n = subs
+            .subscribe(
+                &sig(1),
+                SignatureSubscriptionType::Received,
+                Some(TxStage::Executed { slot: 5, err: None }),
+                5,
+            )
+            .expect_now();
         assert_eq!(n, SignatureNotification::Received { slot: 5 });
     }
 
     #[test]
     fn ticks_advance_executed_stages_across_commitment_boundaries() {
         let mut subs = SignatureSubscriptions::default();
-        let mut confirmed_rx = expect_wait(subs.subscribe(&sig(1), confirmed(), None, 10));
-        let mut finalized_rx = expect_wait(subs.subscribe(&sig(1), finalized(), None, 10));
+        let mut confirmed_rx = subs.subscribe(&sig(1), confirmed(), None, 10).expect_wait();
+        let mut finalized_rx = subs.subscribe(&sig(1), finalized(), None, 10).expect_wait();
         subs.record(
             &sig(1),
             TxStage::Executed {
@@ -430,15 +458,17 @@ mod tests {
         // already holds: the waiter must carry the executed stage into
         // the registry, or no tick could ever complete it.
         let mut subs = SignatureSubscriptions::default();
-        let mut rx = expect_wait(subs.subscribe(
-            &sig(1),
-            finalized(),
-            Some(TxStage::Executed {
-                slot: 10,
-                err: None,
-            }),
-            11,
-        ));
+        let mut rx = subs
+            .subscribe(
+                &sig(1),
+                finalized(),
+                Some(TxStage::Executed {
+                    slot: 10,
+                    err: None,
+                }),
+                11,
+            )
+            .expect_wait();
         subs.tick(10 + FINALIZATION_SLOT_THRESHOLD);
         assert_eq!(
             rx.try_recv().unwrap(),
@@ -452,8 +482,8 @@ mod tests {
     #[test]
     fn failed_stage_satisfies_processed_only_and_never_advances() {
         let mut subs = SignatureSubscriptions::default();
-        let mut processed_rx = expect_wait(subs.subscribe(&sig(1), processed(), None, 10));
-        let mut confirmed_rx = expect_wait(subs.subscribe(&sig(1), confirmed(), None, 10));
+        let mut processed_rx = subs.subscribe(&sig(1), processed(), None, 10).expect_wait();
+        let mut confirmed_rx = subs.subscribe(&sig(1), confirmed(), None, 10).expect_wait();
         let err = TransactionError::BlockhashNotFound;
         subs.record(
             &sig(1),
@@ -479,7 +509,7 @@ mod tests {
     fn stages_never_regress() {
         let mut subs = SignatureSubscriptions::default();
         // The confirmed-target waiter keeps the entry live at Executed.
-        let mut rx = expect_wait(subs.subscribe(&sig(1), confirmed(), None, 9));
+        let mut rx = subs.subscribe(&sig(1), confirmed(), None, 9).expect_wait();
         subs.record(&sig(1), TxStage::Executed { slot: 9, err: None }, 9);
         // A received recorded after execution (a duplicate submission)
         // must not regress the stage: were Received to win, this tick
@@ -495,7 +525,7 @@ mod tests {
     #[test]
     fn dropped_receivers_are_swept() {
         let mut subs = SignatureSubscriptions::default();
-        let rx = expect_wait(subs.subscribe(&sig(1), confirmed(), None, 10));
+        let rx = subs.subscribe(&sig(1), confirmed(), None, 10).expect_wait();
         drop(rx);
         subs.tick(11);
         assert!(subs.lifecycles.is_empty());
@@ -526,7 +556,7 @@ mod tests {
             },
             5,
         );
-        let n = expect_now(subs.subscribe(&sig(1), processed(), None, 6));
+        let n = subs.subscribe(&sig(1), processed(), None, 6).expect_now();
         assert_eq!(
             n,
             SignatureNotification::Processed {
@@ -567,12 +597,14 @@ mod tests {
     #[test]
     fn immediate_satisfaction_registers_no_entry() {
         let mut subs = SignatureSubscriptions::default();
-        let n = expect_now(subs.subscribe(
-            &sig(1),
-            processed(),
-            Some(TxStage::Executed { slot: 4, err: None }),
-            4,
-        ));
+        let n = subs
+            .subscribe(
+                &sig(1),
+                processed(),
+                Some(TxStage::Executed { slot: 4, err: None }),
+                4,
+            )
+            .expect_now();
         assert_eq!(n, SignatureNotification::Processed { slot: 4, err: None });
         assert!(subs.lifecycles.is_empty());
     }

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -1889,6 +1889,11 @@ impl SurfnetSvm {
         self.runbook_executions.clear();
         self.streamed_accounts.clear()?;
         self.scheduled_overrides.clear()?;
+        // Recorded stages describe transactions the reset just wiped,
+        // and the rewound clock would misjudge them; dropping the
+        // senders resolves every open subscription as
+        // unable-to-complete instead.
+        self.signature_subscriptions = SignatureSubscriptions::default();
 
         let current_time = chrono::Utc::now().timestamp_millis() as u64;
         self.updated_at = current_time;

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -48,10 +48,7 @@ use solana_slot_hashes::MAX_ENTRIES as MAX_SLOT_HASHES_ENTRIES;
 use solana_system_interface::instruction as system_instruction;
 use solana_transaction::versioned::VersionedTransaction;
 use solana_transaction_error::TransactionError;
-use solana_transaction_status::{
-    TransactionConfirmationStatus as RpcTransactionConfirmationStatus, TransactionDetails,
-    TransactionStatusMeta, UiConfirmedBlock,
-};
+use solana_transaction_status::{TransactionDetails, TransactionStatusMeta, UiConfirmedBlock};
 use spl_token_2022_interface::extension::{
     BaseStateWithExtensions, StateWithExtensions, interest_bearing_mint::InterestBearingConfig,
     scaled_ui_amount::ScaledUiAmountConfig,
@@ -81,9 +78,10 @@ use uuid::Uuid;
 use super::{
     AccountSource, AccountSubscriptionData, BlockHeader, BlockIdentifier, CoupledAccount,
     FINALIZATION_SLOT_THRESHOLD, GetAccountResult, GeyserBlockMetadata, GeyserEntryInfo,
-    GeyserEvent, GeyserSlotStatus, LocalSignatureStatus, LocalSignatureStatusOrSubscription,
-    ProgramSubscriptionData, SignatureSubscriptionData, SignatureSubscriptionType,
-    SlotsUpdatesSubscriptionData, remote::SurfnetRemoteClient,
+    GeyserEvent, GeyserSlotStatus, ProgramSubscriptionData, SignatureSubscriptionType,
+    SlotsUpdatesSubscriptionData,
+    remote::SurfnetRemoteClient,
+    signature_subscriptions::{SignatureSubscribeOutcome, SignatureSubscriptions, TxStage},
 };
 use crate::{
     error::{AirdropError, SurfpoolError, SurfpoolResult},
@@ -310,7 +308,7 @@ pub struct SurfnetSvm {
     pub latest_epoch_info: EpochInfo,
     pub simnet_events_tx: SimnetEventsTx,
     pub geyser_events_tx: Sender<GeyserEvent>,
-    pub signature_subscriptions: HashMap<Signature, Vec<SignatureSubscriptionData>>,
+    pub signature_subscriptions: SignatureSubscriptions,
     pub account_subscriptions: AccountSubscriptionData,
     pub program_subscriptions: ProgramSubscriptionData,
     pub slot_subscriptions: Vec<Sender<SlotInfo>>,
@@ -586,7 +584,7 @@ impl SurfnetSvm {
             simnet_events_tx: dummy_simnet_tx,
             geyser_events_tx: dummy_geyser_tx,
 
-            signature_subscriptions: HashMap::new(),
+            signature_subscriptions: SignatureSubscriptions::default(),
             account_subscriptions: HashMap::new(),
             program_subscriptions: HashMap::new(),
             // All subscription containers are emptied on the sandbox so that no notification
@@ -837,11 +835,12 @@ impl SurfnetSvm {
                 }
                 _ => (None, Vec::new()),
             };
-            self.notify_signature_subscribers(
-                SignatureSubscriptionType::processed(),
+            self.record_signature_stage(
                 sig,
-                slot,
-                err.clone(),
+                TxStage::Executed {
+                    slot,
+                    err: err.clone(),
+                },
             );
             self.notify_logs_subscribers(sig, err, logs, CommitmentLevel::Processed);
             let _ = bundle_status_tx.try_send(TransactionStatusEvent::Success(
@@ -1040,7 +1039,7 @@ impl SurfnetSvm {
             latest_epoch_info: epoch_info.clone(),
             transactions_queued_for_confirmation: VecDeque::new(),
             transactions_queued_for_finalization: VecDeque::new(),
-            signature_subscriptions: HashMap::new(),
+            signature_subscriptions: SignatureSubscriptions::default(),
             account_subscriptions: HashMap::new(),
             program_subscriptions: HashMap::new(),
             slot_subscriptions: Vec::new(),
@@ -1229,12 +1228,7 @@ impl SurfnetSvm {
                     HashSet::from([*pubkey]),
                 ),
             )?;
-            self.notify_signature_subscribers(
-                SignatureSubscriptionType::processed(),
-                tx.get_signature(),
-                slot,
-                None,
-            );
+            self.record_signature_stage(tx.get_signature(), TxStage::Executed { slot, err: None });
             self.notify_logs_subscribers(
                 tx.get_signature(),
                 None,
@@ -2173,7 +2167,6 @@ impl SurfnetSvm {
     fn confirm_transactions(&mut self) -> Result<(Vec<Signature>, u64), SurfpoolError> {
         let mut confirmed_transactions = vec![];
         let mut num_failed: u64 = 0;
-        let slot = self.latest_epoch_info.slot_index;
         let current_slot = self.latest_epoch_info.absolute_slot;
 
         while let Some((tx, status_tx, error)) =
@@ -2193,13 +2186,6 @@ impl SurfnetSvm {
                 status_tx,
                 error.clone(),
             ));
-
-            self.notify_signature_subscribers(
-                SignatureSubscriptionType::confirmed(),
-                &signature,
-                slot,
-                error,
-            );
 
             let Some(SurfnetTransactionStatus::Processed(tx_data)) =
                 self.transactions.get(&signature.to_string()).ok().flatten()
@@ -2243,12 +2229,6 @@ impl SurfnetSvm {
                     TransactionConfirmationStatus::Finalized,
                 ));
                 let signature = &tx.signatures[0];
-                self.notify_signature_subscribers(
-                    SignatureSubscriptionType::finalized(),
-                    signature,
-                    self.latest_epoch_info.absolute_slot,
-                    error,
-                );
                 let Some(SurfnetTransactionStatus::Processed(tx_data)) =
                     self.transactions.get(&signature.to_string()).ok().flatten()
                 else {
@@ -2589,6 +2569,10 @@ impl SurfnetSvm {
         self.inner.set_sysvar(&clock);
 
         self.finalize_transactions()?;
+        // One tick per produced block: this is where executed stages
+        // cross the confirmed and finalized boundaries for signature
+        // waiters (the clock advanced above, so current is now N+1).
+        self.evaluate_signature_waiters();
 
         // Notify geyser plugins of newly rooted (finalized) slot
         // Only emit if root is a valid slot (greater than genesis)
@@ -2999,65 +2983,46 @@ impl SurfnetSvm {
         Ok(new_account_data)
     }
 
-    /// Subscribes for updates on a transaction signature for a given subscription type.
+    /// Atomically resolves a signature subscription against local state or registers a waiter,
+    /// all under the SVM writer borrow.
     ///
-    /// # Arguments
-    /// * `signature` - The transaction signature to subscribe to.
-    /// * `subscription_type` - The type of subscription (confirmed/finalized).
-    ///
-    /// # Returns
-    /// A receiver for slot and transaction error updates.
-    pub fn subscribe_for_signature_updates(
+    /// The persistent transaction store answers for executed transactions; the registry answers
+    /// for received and failed stages and holds the waiter otherwise. Registration and stage
+    /// transitions mutate the same registry under the same lock, so a transaction cannot be
+    /// committed between the status check and the waiter installation.
+    pub fn subscribe_signature(
         &mut self,
         signature: &Signature,
-        subscription_type: SignatureSubscriptionType,
-    ) -> Receiver<(Slot, Option<TransactionError>)> {
-        let (tx, rx) = unbounded();
-        self.signature_subscriptions
-            .entry(*signature)
-            .or_default()
-            .push((subscription_type, tx));
-        rx
+        target: SignatureSubscriptionType,
+    ) -> SurfpoolResult<SignatureSubscribeOutcome> {
+        let current_slot = self.get_latest_absolute_slot();
+        let known_stage = match self.transactions.get(&signature.to_string())? {
+            Some(SurfnetTransactionStatus::Processed(transaction)) => {
+                let (transaction, _) = transaction.as_ref();
+                Some(TxStage::Executed {
+                    slot: transaction.slot,
+                    err: transaction.meta.status.clone().err(),
+                })
+            }
+            _ => None,
+        };
+        Ok(self
+            .signature_subscriptions
+            .subscribe(signature, target, known_stage, current_slot))
     }
 
-    /// Atomically returns a local signature status that already satisfies a subscription, or
-    /// registers the subscription before releasing the SVM write lock.
-    ///
-    /// This closes the check-then-subscribe race for WebSocket clients: a transaction cannot be
-    /// committed between the local status check and receiver registration. The compact status is
-    /// derived directly from the stored transaction metadata, avoiding transaction encoding.
-    pub fn get_local_signature_status_or_subscribe(
-        &mut self,
-        signature: &Signature,
-        subscription_type: SignatureSubscriptionType,
-    ) -> SurfpoolResult<LocalSignatureStatusOrSubscription> {
+    /// Records a signature lifecycle transition, completing the waiters it satisfies.
+    pub fn record_signature_stage(&mut self, signature: &Signature, stage: TxStage) {
         let current_slot = self.get_latest_absolute_slot();
-        if let Some(SurfnetTransactionStatus::Processed(transaction)) =
-            self.transactions.get(&signature.to_string())?
-        {
-            let (transaction, _) = transaction.as_ref();
-            let confirmation_status =
-                if current_slot >= transaction.slot + FINALIZATION_SLOT_THRESHOLD {
-                    RpcTransactionConfirmationStatus::Finalized
-                } else if current_slot > transaction.slot {
-                    RpcTransactionConfirmationStatus::Confirmed
-                } else {
-                    RpcTransactionConfirmationStatus::Processed
-                };
+        self.signature_subscriptions
+            .record(signature, stage, current_slot);
+    }
 
-            if subscription_type.is_satisfied_by(confirmation_status) {
-                return Ok(LocalSignatureStatusOrSubscription::Status(
-                    LocalSignatureStatus {
-                        slot: transaction.slot,
-                        err: transaction.meta.status.clone().err(),
-                    },
-                ));
-            }
-        }
-
-        Ok(LocalSignatureStatusOrSubscription::Subscription(
-            self.subscribe_for_signature_updates(signature, subscription_type),
-        ))
+    /// Re-evaluates signature waiters against the advanced clock; called once per produced
+    /// block, where executed stages cross the confirmed and finalized boundaries.
+    pub fn evaluate_signature_waiters(&mut self) {
+        let current_slot = self.get_latest_absolute_slot();
+        self.signature_subscriptions.tick(current_slot);
     }
 
     pub fn subscribe_for_account_updates(
@@ -3085,38 +3050,6 @@ impl SurfnetSvm {
             .or_default()
             .push((encoding, filters, tx));
         rx
-    }
-
-    /// Notifies signature subscribers of a status update, sending slot and error info.
-    ///
-    /// # Arguments
-    /// * `status` - The subscription type (confirmed/finalized).
-    /// * `signature` - The transaction signature.
-    /// * `slot` - The slot number.
-    /// * `err` - Optional transaction error.
-    pub fn notify_signature_subscribers(
-        &mut self,
-        status: SignatureSubscriptionType,
-        signature: &Signature,
-        slot: Slot,
-        err: Option<TransactionError>,
-    ) {
-        let mut remaining = vec![];
-        if let Some(subscriptions) = self.signature_subscriptions.remove(signature) {
-            for (subscription_type, tx) in subscriptions {
-                if status.eq(&subscription_type) {
-                    if tx.send((slot, err.clone())).is_err() {
-                        // The receiver has been dropped, so we can skip notifying
-                        continue;
-                    }
-                } else {
-                    remaining.push((subscription_type, tx));
-                }
-            }
-            if !remaining.is_empty() {
-                self.signature_subscriptions.insert(*signature, remaining);
-            }
-        }
     }
 
     pub fn notify_account_subscribers(

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -284,7 +284,6 @@ impl Default for SurfnetSvmConfig {
 /// remote RPC connections, transaction processing, and account management.
 ///
 /// It also exposes channels to listen for simulation events (`SimnetEvent`) and Geyser plugin events (`GeyserEvent`).
-#[derive(Clone)]
 pub struct SurfnetSvm {
     pub inner: SurfnetLiteSvm,
     pub remote_rpc_url: Option<String>,

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -3971,7 +3971,7 @@ async fn test_get_local_signatures_without_limit(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let (svm_instance, _simnet_events_rx, _geyser_events_rx) = test_type.initialize_svm();
 
-    let svm_locker_for_context = SurfnetSvmLocker::new(svm_instance.clone());
+    let svm_locker_for_context = SurfnetSvmLocker::new(svm_instance.clone_for_profiling());
 
     let (simnet_cmd_tx, _simnet_cmd_rx) = crossbeam_unbounded::<SimnetCommand>();
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
@@ -4076,7 +4076,7 @@ async fn test_get_local_signatures_without_limit(test_type: TestType) {
 async fn test_get_local_signatures_with_limit(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let (svm_instance, _simnet_events_rx, _geyser_events_rx) = test_type.initialize_svm();
-    let svm_locker_for_context = SurfnetSvmLocker::new(svm_instance.clone());
+    let svm_locker_for_context = SurfnetSvmLocker::new(svm_instance.clone_for_profiling());
 
     let (simnet_cmd_tx, _simnet_cmd_rx) = crossbeam_unbounded::<SimnetCommand>();
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
@@ -6917,18 +6917,6 @@ async fn test_remote_get_multiple_accounts_ordering(test_type: TestType) {
 
 // websocket rpc methods tests
 
-/// Unwraps a subscribe outcome into its pending receiver.
-fn expect_signature_wait(
-    outcome: SignatureSubscribeOutcome,
-) -> tokio::sync::oneshot::Receiver<SignatureNotification> {
-    match outcome {
-        SignatureSubscribeOutcome::Wait { rx, .. } => rx,
-        SignatureSubscribeOutcome::Now(notification) => {
-            panic!("expected a pending subscription, got immediate {notification:?}")
-        }
-    }
-}
-
 #[test_case(SignatureSubscriptionType::processed() ; "processed commitment")]
 #[test_case(SignatureSubscriptionType::received() ; "received commitment")]
 #[test_case(SignatureSubscriptionType::confirmed() ; "confirmed commitment")]
@@ -6961,11 +6949,10 @@ async fn test_ws_signature_subscribe(subscription_type: SignatureSubscriptionTyp
     let signature = tx.signatures[0];
 
     // subscribe before the transaction is known to the surfnet
-    let notification_rx = expect_signature_wait(
-        svm_locker
-            .subscribe_signature(&signature, subscription_type.clone())
-            .unwrap(),
-    );
+    let notification_rx = svm_locker
+        .subscribe_signature(&signature, subscription_type.clone())
+        .unwrap()
+        .expect_wait();
 
     // process the transaction
     let (status_tx, _status_rx) = unbounded();
@@ -7046,11 +7033,10 @@ async fn test_ws_signature_subscribe_failed_transaction(test_type: TestType) {
 
     // subscribe with processed commitment
     let subscription_type = SignatureSubscriptionType::processed();
-    let notification_rx = expect_signature_wait(
-        svm_locker
-            .subscribe_signature(&signature, subscription_type)
-            .unwrap(),
-    );
+    let notification_rx = svm_locker
+        .subscribe_signature(&signature, subscription_type)
+        .unwrap()
+        .expect_wait();
 
     // process the transaction (should fail)
     let (status_tx, _status_rx) = unbounded();
@@ -7113,21 +7099,18 @@ async fn test_ws_signature_subscribe_multiple_subscribers(test_type: TestType) {
     let signature = tx.signatures[0];
 
     // create multiple subscriptions to the same signature
-    let notification_rx1 = expect_signature_wait(
-        svm_locker
-            .subscribe_signature(&signature, SignatureSubscriptionType::processed())
-            .unwrap(),
-    );
-    let notification_rx2 = expect_signature_wait(
-        svm_locker
-            .subscribe_signature(&signature, SignatureSubscriptionType::processed())
-            .unwrap(),
-    );
-    let notification_rx3 = expect_signature_wait(
-        svm_locker
-            .subscribe_signature(&signature, SignatureSubscriptionType::confirmed())
-            .unwrap(),
-    );
+    let notification_rx1 = svm_locker
+        .subscribe_signature(&signature, SignatureSubscriptionType::processed())
+        .unwrap()
+        .expect_wait();
+    let notification_rx2 = svm_locker
+        .subscribe_signature(&signature, SignatureSubscriptionType::processed())
+        .unwrap()
+        .expect_wait();
+    let notification_rx3 = svm_locker
+        .subscribe_signature(&signature, SignatureSubscriptionType::confirmed())
+        .unwrap()
+        .expect_wait();
 
     // process the transaction
     let (status_tx, _status_rx) = unbounded();
@@ -7201,11 +7184,10 @@ async fn test_ws_signature_subscribe_before_transaction_exists(test_type: TestTy
 
     // subscribe before the transaction exists
     let subscription_type = SignatureSubscriptionType::processed();
-    let notification_rx = expect_signature_wait(
-        svm_locker
-            .subscribe_signature(&signature, subscription_type)
-            .unwrap(),
-    );
+    let notification_rx = svm_locker
+        .subscribe_signature(&signature, subscription_type)
+        .unwrap()
+        .expect_wait();
 
     // small delay to ensure the subscription is registered
     tokio::time::sleep(Duration::from_millis(100)).await;

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -99,8 +99,9 @@ use crate::{
     runloops::start_local_surfnet_runloop,
     storage::tests::TestType,
     surfnet::{
-        FINALIZATION_SLOT_THRESHOLD, GeyserEvent, LocalSignatureStatusOrSubscription,
-        PluginCommand, SignatureSubscriptionType, locker::SurfnetSvmLocker, svm::SurfnetSvm,
+        FINALIZATION_SLOT_THRESHOLD, GeyserEvent, PluginCommand, SignatureNotification,
+        SignatureSubscribeOutcome, SignatureSubscriptionType, TxStage, locker::SurfnetSvmLocker,
+        svm::SurfnetSvm,
     },
     tests::helpers::get_free_port,
     types::{TimeTravelConfig, TransactionLoadedAddresses},
@@ -6916,6 +6917,18 @@ async fn test_remote_get_multiple_accounts_ordering(test_type: TestType) {
 
 // websocket rpc methods tests
 
+/// Unwraps a subscribe outcome into its pending receiver.
+fn expect_signature_wait(
+    outcome: SignatureSubscribeOutcome,
+) -> tokio::sync::oneshot::Receiver<SignatureNotification> {
+    match outcome {
+        SignatureSubscribeOutcome::Wait { rx, .. } => rx,
+        SignatureSubscribeOutcome::Now(notification) => {
+            panic!("expected a pending subscription, got immediate {notification:?}")
+        }
+    }
+}
+
 #[test_case(SignatureSubscriptionType::processed() ; "processed commitment")]
 #[test_case(SignatureSubscriptionType::received() ; "received commitment")]
 #[test_case(SignatureSubscriptionType::confirmed() ; "confirmed commitment")]
@@ -6947,9 +6960,12 @@ async fn test_ws_signature_subscribe(subscription_type: SignatureSubscriptionTyp
     );
     let signature = tx.signatures[0];
 
-    // subscribe with processed commitment
-    let notification_rx =
-        svm_locker.subscribe_for_signature_updates(&signature, subscription_type.clone());
+    // subscribe before the transaction is known to the surfnet
+    let notification_rx = expect_signature_wait(
+        svm_locker
+            .subscribe_signature(&signature, subscription_type.clone())
+            .unwrap(),
+    );
 
     // process the transaction
     let (status_tx, _status_rx) = unbounded();
@@ -6969,22 +6985,29 @@ async fn test_ws_signature_subscribe(subscription_type: SignatureSubscriptionTyp
         _ => {}
     }
 
-    // wait for the notification
-    let notification = notification_rx.recv_timeout(Duration::from_secs(5));
-    assert!(
-        notification.is_ok(),
-        "Should receive {} notification",
-        subscription_type
-    );
+    // wait for the notification, and check the payload variant matches
+    // the subscription target
+    let notification = tokio::time::timeout(Duration::from_secs(5), notification_rx)
+        .await
+        .unwrap_or_else(|_| panic!("Should receive {} notification", subscription_type))
+        .expect("the waiter should complete rather than be swept");
 
-    let (slot, error_opt) = notification.unwrap();
-    assert!(
-        error_opt.is_none(),
-        "Transaction should succeed without error"
-    );
+    match (&subscription_type, &notification) {
+        (SignatureSubscriptionType::Received, SignatureNotification::Received { .. }) => {}
+        (
+            SignatureSubscriptionType::Commitment(_),
+            SignatureNotification::Processed { err, .. },
+        ) => {
+            assert!(err.is_none(), "Transaction should succeed without error");
+        }
+        _ => panic!(
+            "{} subscription received mismatched payload {:?}",
+            subscription_type, notification
+        ),
+    }
     println!(
-        "✓ Received {} signature notification at slot {}",
-        subscription_type, slot
+        "✓ Received {} signature notification: {:?}",
+        subscription_type, notification
     );
 }
 
@@ -7023,7 +7046,11 @@ async fn test_ws_signature_subscribe_failed_transaction(test_type: TestType) {
 
     // subscribe with processed commitment
     let subscription_type = SignatureSubscriptionType::processed();
-    let notification_rx = svm_locker.subscribe_for_signature_updates(&signature, subscription_type);
+    let notification_rx = expect_signature_wait(
+        svm_locker
+            .subscribe_signature(&signature, subscription_type)
+            .unwrap(),
+    );
 
     // process the transaction (should fail)
     let (status_tx, _status_rx) = unbounded();
@@ -7038,17 +7065,18 @@ async fn test_ws_signature_subscribe_failed_transaction(test_type: TestType) {
         .await;
 
     // wait for the notification with error
-    let notification = notification_rx.recv_timeout(Duration::from_secs(5));
-    assert!(
-        notification.is_ok(),
-        "Should receive notification for failed transaction"
-    );
+    let notification = tokio::time::timeout(Duration::from_secs(5), notification_rx)
+        .await
+        .expect("Should receive notification for failed transaction")
+        .expect("the waiter should complete rather than be swept");
 
-    let (slot, error_opt) = notification.unwrap();
-    assert!(error_opt.is_some(), "Failed transaction should have error");
+    let SignatureNotification::Processed { slot, err } = notification else {
+        panic!("a processed subscription should resolve to a Processed payload");
+    };
+    assert!(err.is_some(), "Failed transaction should have error");
     println!(
         "✓ Received signature notification for failed transaction at slot {} with error: {:?}",
-        slot, error_opt
+        slot, err
     );
 }
 
@@ -7085,12 +7113,21 @@ async fn test_ws_signature_subscribe_multiple_subscribers(test_type: TestType) {
     let signature = tx.signatures[0];
 
     // create multiple subscriptions to the same signature
-    let notification_rx1 = svm_locker
-        .subscribe_for_signature_updates(&signature, SignatureSubscriptionType::processed());
-    let notification_rx2 = svm_locker
-        .subscribe_for_signature_updates(&signature, SignatureSubscriptionType::processed());
-    let notification_rx3 = svm_locker
-        .subscribe_for_signature_updates(&signature, SignatureSubscriptionType::confirmed());
+    let notification_rx1 = expect_signature_wait(
+        svm_locker
+            .subscribe_signature(&signature, SignatureSubscriptionType::processed())
+            .unwrap(),
+    );
+    let notification_rx2 = expect_signature_wait(
+        svm_locker
+            .subscribe_signature(&signature, SignatureSubscriptionType::processed())
+            .unwrap(),
+    );
+    let notification_rx3 = expect_signature_wait(
+        svm_locker
+            .subscribe_signature(&signature, SignatureSubscriptionType::confirmed())
+            .unwrap(),
+    );
 
     // process the transaction
     let (status_tx, _status_rx) = unbounded();
@@ -7107,24 +7144,24 @@ async fn test_ws_signature_subscribe_multiple_subscribers(test_type: TestType) {
 
     // all processed subscriptions should receive notification
     assert!(
-        notification_rx1
-            .recv_timeout(Duration::from_secs(5))
-            .is_ok(),
+        tokio::time::timeout(Duration::from_secs(5), notification_rx1)
+            .await
+            .is_ok_and(|received| received.is_ok()),
         "Subscriber 1 should receive notification"
     );
     assert!(
-        notification_rx2
-            .recv_timeout(Duration::from_secs(5))
-            .is_ok(),
+        tokio::time::timeout(Duration::from_secs(5), notification_rx2)
+            .await
+            .is_ok_and(|received| received.is_ok()),
         "Subscriber 2 should receive notification"
     );
 
     // confirm the block for confirmed subscription
     svm_locker.confirm_current_block(&None).await.unwrap();
     assert!(
-        notification_rx3
-            .recv_timeout(Duration::from_secs(5))
-            .is_ok(),
+        tokio::time::timeout(Duration::from_secs(5), notification_rx3)
+            .await
+            .is_ok_and(|received| received.is_ok()),
         "Confirmed subscriber should receive notification"
     );
 
@@ -7164,7 +7201,11 @@ async fn test_ws_signature_subscribe_before_transaction_exists(test_type: TestTy
 
     // subscribe before the transaction exists
     let subscription_type = SignatureSubscriptionType::processed();
-    let notification_rx = svm_locker.subscribe_for_signature_updates(&signature, subscription_type);
+    let notification_rx = expect_signature_wait(
+        svm_locker
+            .subscribe_signature(&signature, subscription_type)
+            .unwrap(),
+    );
 
     // small delay to ensure the subscription is registered
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -7183,14 +7224,15 @@ async fn test_ws_signature_subscribe_before_transaction_exists(test_type: TestTy
         .unwrap();
 
     // should still receive notification
-    let notification = notification_rx.recv_timeout(Duration::from_secs(5));
-    assert!(
-        notification.is_ok(),
-        "Should receive notification even when subscribed before transaction"
-    );
+    let notification = tokio::time::timeout(Duration::from_secs(5), notification_rx)
+        .await
+        .expect("Should receive notification even when subscribed before transaction")
+        .expect("the waiter should complete rather than be swept");
 
-    let (slot, error_opt) = notification.unwrap();
-    assert!(error_opt.is_none(), "Transaction should succeed");
+    let SignatureNotification::Processed { slot, err } = notification else {
+        panic!("a processed subscription should resolve to a Processed payload");
+    };
+    assert!(err.is_none(), "Transaction should succeed");
     println!(
         "✓ Subscription before transaction works correctly at slot {}",
         slot
@@ -7203,27 +7245,26 @@ fn test_atomic_signature_subscription_returns_live_receiver_for_absent_signature
     let locker = SurfnetSvmLocker::new(svm);
     let signature = Signature::new_unique();
 
-    let receiver = match locker
-        .get_local_signature_status_or_subscribe(&signature, SignatureSubscriptionType::processed())
+    let mut receiver = match locker
+        .subscribe_signature(&signature, SignatureSubscriptionType::processed())
         .expect("an absent signature should register successfully")
     {
-        LocalSignatureStatusOrSubscription::Subscription(receiver) => receiver,
-        LocalSignatureStatusOrSubscription::Status(_) => {
-            panic!("an absent signature must return a subscription receiver")
+        SignatureSubscribeOutcome::Wait { rx, known_locally } => {
+            assert!(!known_locally, "an absent signature is not locally known");
+            rx
+        }
+        SignatureSubscribeOutcome::Now(_) => {
+            panic!("an absent signature must return a pending waiter")
         }
     };
 
     locker.with_svm_writer(|svm| {
-        svm.notify_signature_subscribers(
-            SignatureSubscriptionType::processed(),
-            &signature,
-            svm.get_latest_absolute_slot(),
-            None,
-        );
+        let slot = svm.get_latest_absolute_slot();
+        svm.record_signature_stage(&signature, TxStage::Executed { slot, err: None });
     });
 
     assert!(
-        receiver.recv_timeout(Duration::from_secs(1)).is_ok(),
+        receiver.try_recv().is_ok(),
         "the returned receiver should remain live after atomic registration"
     );
 }
@@ -7266,22 +7307,22 @@ async fn test_atomic_signature_subscription_returns_committed_local_status() {
         .expect("transaction should be committed locally");
 
     match locker
-        .get_local_signature_status_or_subscribe(&signature, SignatureSubscriptionType::processed())
+        .subscribe_signature(&signature, SignatureSubscriptionType::processed())
         .expect("the atomic lookup should succeed")
     {
-        LocalSignatureStatusOrSubscription::Status(status) => {
-            assert!(
-                status.err.is_none(),
-                "the committed transaction should succeed"
-            );
+        SignatureSubscribeOutcome::Now(SignatureNotification::Processed { slot, err }) => {
+            assert!(err.is_none(), "the committed transaction should succeed");
             assert_eq!(
-                status.slot,
+                slot,
                 locker.with_svm_reader(|svm| svm.get_latest_absolute_slot()),
                 "the immediate status should use the transaction metadata slot"
             );
         }
-        LocalSignatureStatusOrSubscription::Subscription(_) => {
-            panic!("a committed processed transaction must not register a new receiver")
+        SignatureSubscribeOutcome::Now(notification) => {
+            panic!("a processed subscription should resolve to Processed, got {notification:?}")
+        }
+        SignatureSubscribeOutcome::Wait { .. } => {
+            panic!("a committed processed transaction must not register a new waiter")
         }
     }
 }
@@ -7323,12 +7364,18 @@ async fn test_atomic_higher_commitment_subscription_waits_for_promotion() {
         .await
         .expect("transaction should be committed locally");
 
-    let receiver = match locker
-        .get_local_signature_status_or_subscribe(&signature, SignatureSubscriptionType::confirmed())
+    let mut receiver = match locker
+        .subscribe_signature(&signature, SignatureSubscriptionType::confirmed())
         .expect("the atomic lookup should succeed")
     {
-        LocalSignatureStatusOrSubscription::Subscription(receiver) => receiver,
-        LocalSignatureStatusOrSubscription::Status(_) => {
+        SignatureSubscribeOutcome::Wait { rx, known_locally } => {
+            assert!(
+                known_locally,
+                "a committed transaction is locally known even while its waiter is pending"
+            );
+            rx
+        }
+        SignatureSubscribeOutcome::Now(_) => {
             panic!("a processed transaction must wait for confirmed commitment")
         }
     };
@@ -7342,7 +7389,9 @@ async fn test_atomic_higher_commitment_subscription_waits_for_promotion() {
         .await
         .expect("the current block should confirm");
     assert!(
-        receiver.recv_timeout(Duration::from_secs(1)).is_ok(),
+        tokio::time::timeout(Duration::from_secs(1), receiver)
+            .await
+            .is_ok_and(|received| received.is_ok()),
         "the pending receiver should be notified at confirmed commitment"
     );
 }


### PR DESCRIPTION

## TODO
- [ ] Review spec / model / impl / test relationship for surfpool state machines.
- [ ] DRY refactor of cargo-doc generation

#772 closed the check-then-subscribe race for signature subscriptions
at commitment levels: the final local check and receiver registration
now share one SVM writer section, so a transaction cannot land between
them. Following up on that, I modeled the subscription paths in Promela
and ran Spin over their interleavings to see what remains on main.

Three failure windows remain. This PR closes them by converting
signature subscriptions from a scan-at-notify mechanism to a lifecycle
state machine. A fourth is identified below and deliberately left open:
its fix applies to every subscription family and deserves its own
change.

## The failure windows on main

The first three carry Spin verdicts: an acceptance cycle the verifier
finds (a schedule where a subscriber waits forever) or a window it
proves reachable.

**`received` (acceptance cycle).** A subscriber at the `received` level
can park forever. The received notify runs in a writer section that
closes before account fetching begins
(`fetch_all_tx_accounts_then_process_tx_returning_profile_res`), and
the store lands in a later section, as processed. A received
subscription established between the two sections misses both: the
notify scan finds no sender, the atomic check finds no stored
transaction, and nothing a received subscription matches ever fires
again. The #772 mechanism cannot close this cell: its atomicity
argument needs store-then-scan inside one section, while the received
path does the reverse. Closed here: received becomes a recorded
transition, so a subscriber arriving late reads it from state.

**`parked` (acceptance cycle).** Unsubscribe removes only the sink
(`signature_unsubscribe`); the delivery task keeps polling at 50ms and
its sender stays registered until a matching notify or channel
disconnect, neither of which is guaranteed. Closed here: the delivery
task awaits a oneshot instead of polling, unsubscribe drops a cancel
handle that ends the task, and the dropped receiver is swept from the
registry on the next transition or tick. A signature that never lands
and is never unsubscribed now costs one map entry rather than a polling
task.

**`hang` (registration delay).** On main the remote `getTransaction`
lookup precedes registration; the transport deadline from #731 bounds
it at 60 seconds, so a slow remote delays registration by up to the
deadline. A transaction landing in that window is caught by the
re-check, so this is delay, not loss. Closed structurally here: the
waiter installs first and the remote lookup runs after it, so a
transaction landing during the lookup is delivered through the waiter.

**Unsubscribe-before-insert (identified, left open).** The client holds
its subscription id from `assign_id` before the spawned task inserts
the map entry; an unsubscribe arriving in that window removes nothing,
and the insert then lands as if nothing happened. This one comes from
the lifecycle table rather than the models above; the verifier run for
it covers the six multi-shot families and travels with the family-wide
fix. The cell exists in
all seven subscription families; for signatures the exposure is one
notification delivered after unsubscribing. The fix shape (reserve the
entry before `assign_id`, carry it on a handle so early returns release
it) applies uniformly across the families, so it belongs to a separate
change rather than this one.

## The conversion

Subscriptions become predicates over recorded state rather than events
scanned at moments. Each signature carries a monotone stage (received,
then executed with a slot and an optional error); subscribing reads the
stage or installs a waiter under the same lock that guards the stage;
a transition records the stage and then drains the waiters it
satisfies. Confirmed and finalized derive from slot distance and are
re-evaluated on the existing per-block tick. The notification payload
is a function of the stage reached, computed in one place, so the
variant cannot depend on which path delivered it.

One semantic decision to flag: recording received means writing
something at that moment, and nothing was persisted there before. The
stage lives in memory beside the persisted transaction store; Agave
treats received as pubsub-only (signature statuses exist only after
processing), so `getTransaction` semantics are unchanged and sqlite is
untouched.

## Verdicts, before and after

The paired model puts both implementations against identical
participants and schedules (the send path's two writer sections with
the remote-fetch gap between them, plus a confirm tick); only the
delivery mechanism differs.

| Subscriber target     | main (post #772) | this PR |
| --------------------- | ---------------- | ------- |
| received              | acceptance cycle | clean   |
| processed             | clean            | clean   |
| confirmed / finalized | clean            | clean   |

The parity rows matter: the conversion preserves what #772 established
for commitment levels, including tick-driven delivery, while closing
the received-level cycle. I can attach the Promela models and the
failing trail for the first row if that is useful for review.

## Also corrected on the way

Three observable payload defects fell out of unifying the delivery
paths, all pre-dating #772:

* The confirmed-path notify passed `slot_index` (epoch-relative) where
every other site passes the absolute slot; past the first epoch
boundary one API reported two slot spaces.
* The immediate arms sent `ProcessedSignature` to received
subscriptions where the channel path sent `ReceivedSignature`.
* Slot arithmetic in `found_transaction` underflowed for a remote
transaction whose slot is ahead of the local clock; the ladder now
saturates and lives in one function (`confirmation_status_at`).

## Testing

`cargo test -p surfpool-core --lib signature` runs everything
signature-related: 52 tests, all passing.
