### PR TITLE
perf(core): add remote tx fetch bypassing

### DIFF
--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -1637,8 +1637,11 @@ impl Full for SurfpoolFullRpc {
         &self,
         meta: Self::Metadata,
         signature_strs: Vec<String>,
-        _config: Option<RpcSignatureStatusConfig>,
+        config: Option<RpcSignatureStatusConfig>,
     ) -> BoxFuture<Result<RpcResponse<Vec<Option<TransactionStatus>>>>> {
+        let search_transaction_history = config
+            .map(|config| config.search_transaction_history)
+            .unwrap_or(false);
         let signatures = match signature_strs
             .iter()
             .map(|s| {
@@ -1658,7 +1661,11 @@ impl Full for SurfpoolFullRpc {
             Ok(res) => res,
             Err(e) => return e.into(),
         };
-        let remote_client = remote_ctx.map(|(r, _)| r);
+        let remote_client = if search_transaction_history {
+            remote_ctx.map(|(remote_client, _)| remote_client)
+        } else {
+            None
+        };
 
         Box::pin(async move {
             // Capture the context slot once at the beginning to ensure consistency
@@ -2762,6 +2769,7 @@ mod tests {
     };
     use surfpool_types::{SimnetCommand, TransactionConfirmationStatus};
     use test_case::test_case;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
     use crate::{
@@ -3111,6 +3119,83 @@ mod tests {
             invalid_txs,
             "incorrect number of invalid txs"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_signature_statuses_respects_search_transaction_history() {
+        let missing_signature = Signature::new_unique();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test datasource should bind");
+        let address = listener
+            .local_addr()
+            .expect("test datasource should have an address");
+        let datasource_request = tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("history lookup should reach the datasource");
+            let mut request = [0; 4096];
+            let bytes_read = stream
+                .read(&mut request)
+                .await
+                .expect("test datasource should read the request");
+            let request = String::from_utf8_lossy(&request[..bytes_read]);
+            assert!(request.contains("getTransaction"));
+
+            let body = r#"{"jsonrpc":"2.0","result":null,"id":0}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test datasource should write the response");
+        });
+
+        let mut setup = TestSetup::new(SurfpoolFullRpc);
+        setup.context.remote_rpc_client =
+            Some(SurfnetRemoteClient::new(format!("http://{address}")));
+
+        for config in [
+            None,
+            Some(RpcSignatureStatusConfig {
+                search_transaction_history: false,
+            }),
+        ] {
+            let response = setup
+                .rpc
+                .get_signature_statuses(
+                    Some(setup.context.clone()),
+                    vec![missing_signature.to_string()],
+                    config,
+                )
+                .await
+                .expect("recent-status lookups must not query the datasource");
+
+            assert_eq!(response.value.len(), 1);
+            assert!(response.value[0].is_none());
+        }
+
+        let result = setup
+            .rpc
+            .get_signature_statuses(
+                Some(setup.context),
+                vec![missing_signature.to_string()],
+                Some(RpcSignatureStatusConfig {
+                    search_transaction_history: true,
+                }),
+            )
+            .await
+            .expect("history lookup should accept a missing upstream transaction");
+
+        assert_eq!(result.value.len(), 1);
+        assert!(result.value[0].is_none());
+        datasource_request
+            .await
+            .expect("test datasource should receive the history lookup");
     }
 
     #[test]

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -1755,7 +1755,9 @@ impl Full for SurfpoolFullRpc {
         };
 
         let (status_update_tx, status_update_rx) = crossbeam_channel::bounded(1);
-        ctx.simnet_commands_tx
+        ctx.svm_locker.mark_transaction_pending(signature);
+        if ctx
+            .simnet_commands_tx
             .send(SimnetCommand::ProcessTransaction(
                 ctx.id,
                 unsanitized_tx,
@@ -1763,9 +1765,14 @@ impl Full for SurfpoolFullRpc {
                 config.base.skip_preflight,
                 config.skip_sig_verify,
             ))
-            .map_err(|_| RpcCustomError::NodeUnhealthy {
+            .is_err()
+        {
+            ctx.svm_locker.mark_transaction_complete(&signature);
+            return Err(RpcCustomError::NodeUnhealthy {
                 num_slots_behind: None,
-            })?;
+            }
+            .into());
+        }
 
         match status_update_rx.recv() {
             Ok(TransactionStatusEvent::SimulationFailure((error, metadata))) => {
@@ -2827,6 +2834,11 @@ mod tests {
         loop {
             match mempool_rx.recv() {
                 Ok(SimnetCommand::ProcessTransaction(_, tx, status_tx, _, _)) => {
+                    let sig = tx.signatures[0];
+                    assert!(
+                        setup.context.svm_locker.is_transaction_pending(&sig),
+                        "sendTransaction should mark the signature before enqueueing it"
+                    );
                     let mut writer = setup.context.svm_locker.0.write().await;
                     let slot = writer.get_latest_absolute_slot();
                     writer.transactions_queued_for_confirmation.push_back((
@@ -2834,7 +2846,6 @@ mod tests {
                         status_tx.clone(),
                         None,
                     ));
-                    let sig = tx.signatures[0];
                     let tx_with_status_meta = TransactionWithStatusMeta {
                         slot,
                         transaction: tx,
@@ -2856,6 +2867,9 @@ mod tests {
                             TransactionConfirmationStatus::Confirmed,
                         ))
                         .unwrap();
+                    drop(writer);
+                    setup.context.svm_locker.mark_transaction_complete(&sig);
+                    assert!(!setup.context.svm_locker.is_transaction_pending(&sig));
                     break;
                 }
                 Ok(SimnetCommand::AirdropProcessed) => continue,
@@ -3179,6 +3193,36 @@ mod tests {
             assert!(response.value[0].is_none());
         }
 
+        setup
+            .context
+            .svm_locker
+            .mark_transaction_pending(missing_signature);
+        setup
+            .context
+            .svm_locker
+            .mark_transaction_pending(missing_signature);
+
+        for _ in 0..2 {
+            let response = setup
+                .rpc
+                .get_signature_statuses(
+                    Some(setup.context.clone()),
+                    vec![missing_signature.to_string()],
+                    Some(RpcSignatureStatusConfig {
+                        search_transaction_history: true,
+                    }),
+                )
+                .await
+                .expect("pending local transactions must not query the datasource");
+
+            assert_eq!(response.value.len(), 1);
+            assert!(response.value[0].is_none());
+            setup
+                .context
+                .svm_locker
+                .mark_transaction_complete(&missing_signature);
+        }
+
         let result = setup
             .rpc
             .get_signature_statuses(
@@ -3196,6 +3240,30 @@ mod tests {
         datasource_request
             .await
             .expect("test datasource should receive the history lookup");
+    }
+
+    #[test]
+    fn test_send_transaction_clears_pending_signature_when_enqueue_fails() {
+        let (mempool_tx, mempool_rx) = crossbeam_channel::unbounded();
+        drop(mempool_rx);
+        let setup = TestSetup::new_with_mempool(SurfpoolFullRpc, mempool_tx);
+        let payer = Keypair::new();
+        let recent_blockhash = setup
+            .context
+            .svm_locker
+            .with_svm_reader(|svm_reader| svm_reader.latest_blockhash());
+        let transaction =
+            build_legacy_transaction(&payer.pubkey(), &[&payer], &[], &recent_blockhash);
+        let signature = transaction.signatures[0];
+
+        let result = setup.rpc.send_transaction(
+            Some(setup.context.clone()),
+            bs58::encode(bincode::serialize(&transaction).unwrap()).into_string(),
+            None,
+        );
+
+        assert!(result.is_err());
+        assert!(!setup.context.svm_locker.is_transaction_pending(&signature));
     }
 
     #[test]

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -506,7 +506,10 @@ pub async fn start_block_production_runloop(
                     SimnetCommand::ProcessTransaction(_key, transaction, status_tx, skip_preflight, skip_sig_verify_override) => {
                        let skip_sig_verify = skip_sig_verify_override.unwrap_or(global_skip_sig_verify);
                        let sigverify = !skip_sig_verify;
-                       if let Err(e) = svm_locker.process_transaction(&remote_client_with_commitment, transaction, status_tx, skip_preflight, sigverify).await {
+                       let signature = transaction.signatures[0];
+                       let result = svm_locker.process_transaction(&remote_client_with_commitment, transaction, status_tx, skip_preflight, sigverify).await;
+                       svm_locker.mark_transaction_complete(&signature);
+                       if let Err(e) = result {
                             svm_locker.simnet_events_tx().error(format!("Failed to process transaction: {}", e));
                        }
                        if block_production_mode.eq(&BlockProductionMode::Transaction) {

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -94,6 +94,12 @@ enum ProcessTransactionResult {
     ExecutionFailure(FailedTransactionMetadata),
 }
 
+struct LocalTransactionLookup {
+    result: GetTransactionResult,
+    is_pending: bool,
+    latest_absolute_slot: Slot,
+}
+
 pub struct SvmAccessContext<T> {
     pub slot: Slot,
     pub latest_epoch_info: EpochInfo,
@@ -1604,6 +1610,19 @@ impl SurfnetSvmLocker {
 
 /// Functions for getting transactions from the underlying SurfnetSvm instance or remote client
 impl SurfnetSvmLocker {
+    pub(crate) fn mark_transaction_pending(&self, signature: Signature) {
+        self.with_svm_writer(|svm_writer| svm_writer.mark_transaction_pending(signature));
+    }
+
+    pub(crate) fn mark_transaction_complete(&self, signature: &Signature) {
+        self.with_svm_writer(|svm_writer| svm_writer.mark_transaction_complete(signature));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_transaction_pending(&self, signature: &Signature) -> bool {
+        self.with_svm_reader(|svm_reader| svm_reader.is_transaction_pending(signature))
+    }
+
     /// Retrieves a transaction by signature, using local or remote based on context.
     pub async fn get_transaction(
         &self,
@@ -1645,11 +1664,26 @@ impl SurfnetSvmLocker {
         signature: &Signature,
         config: &RpcTransactionConfig,
     ) -> SurfpoolResult<GetTransactionResult> {
+        Ok(self
+            .get_transaction_local_with_pending(signature, config)?
+            .result)
+    }
+
+    fn get_transaction_local_with_pending(
+        &self,
+        signature: &Signature,
+        config: &RpcTransactionConfig,
+    ) -> SurfpoolResult<LocalTransactionLookup> {
         self.with_svm_reader(|svm_reader| {
             let latest_absolute_slot = svm_reader.get_latest_absolute_slot();
+            let is_pending = svm_reader.is_transaction_pending(signature);
 
             let Some(entry) = svm_reader.transactions.get(&signature.to_string())? else {
-                return Ok(GetTransactionResult::None(*signature));
+                return Ok(LocalTransactionLookup {
+                    result: GetTransactionResult::None(*signature),
+                    is_pending,
+                    latest_absolute_slot,
+                });
             };
 
             let (transaction_with_status_meta, _) = entry.expect_processed();
@@ -1664,16 +1698,20 @@ impl SurfnetSvmLocker {
                 config.max_supported_transaction_version,
                 true,
             )?;
-            Ok(GetTransactionResult::found_transaction(
-                *signature,
-                EncodedConfirmedTransactionWithStatusMeta {
-                    slot,
-                    transaction: encoded,
-                    block_time,
-                    transaction_index: None,
-                },
+            Ok(LocalTransactionLookup {
+                result: GetTransactionResult::found_transaction(
+                    *signature,
+                    EncodedConfirmedTransactionWithStatusMeta {
+                        slot,
+                        transaction: encoded,
+                        block_time,
+                        transaction_index: None,
+                    },
+                    latest_absolute_slot,
+                ),
+                is_pending,
                 latest_absolute_slot,
-            ))
+            })
         })
     }
 
@@ -1684,14 +1722,14 @@ impl SurfnetSvmLocker {
         signature: &Signature,
         config: RpcTransactionConfig,
     ) -> SurfpoolResult<GetTransactionResult> {
-        let local_result = self.get_transaction_local(signature, &config)?;
-        let latest_absolute_slot = self.get_latest_absolute_slot();
-        if local_result.is_none() {
+        let local_lookup = self.get_transaction_local_with_pending(signature, &config)?;
+
+        if local_lookup.result.is_none() && !local_lookup.is_pending {
             client
-                .try_get_transaction(*signature, config, latest_absolute_slot)
+                .try_get_transaction(*signature, config, local_lookup.latest_absolute_slot)
                 .await
         } else {
-            Ok(local_result)
+            Ok(local_lookup.result)
         }
     }
 }

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -293,6 +293,12 @@ pub struct SurfnetSvm {
     pub chain_tip: BlockIdentifier,
     pub blocks: Box<dyn Storage<u64, BlockHeader>>,
     pub transactions: Box<dyn Storage<String, SurfnetTransactionStatus>>,
+    /// Signatures accepted by `sendTransaction` that have not finished processing yet.
+    ///
+    /// Counts are used because clients may submit the same signed transaction concurrently.
+    /// Keeping this next to `transactions` lets readers atomically distinguish a genuinely
+    /// unknown signature from one that is waiting in the runloop queue.
+    pending_transaction_signatures: HashMap<Signature, usize>,
     pub jito_bundles: Box<dyn Storage<String, Vec<String>>>,
     pub transactions_queued_for_confirmation: VecDeque<(
         VersionedTransaction,
@@ -503,6 +509,28 @@ fn synthetic_blockhash_for_slot(slot: Slot, genesis_slot: Slot) -> SyntheticBloc
 }
 
 impl SurfnetSvm {
+    pub(crate) fn mark_transaction_pending(&mut self, signature: Signature) {
+        *self
+            .pending_transaction_signatures
+            .entry(signature)
+            .or_default() += 1;
+    }
+
+    pub(crate) fn mark_transaction_complete(&mut self, signature: &Signature) {
+        let Some(pending_count) = self.pending_transaction_signatures.get_mut(signature) else {
+            return;
+        };
+
+        *pending_count -= 1;
+        if *pending_count == 0 {
+            self.pending_transaction_signatures.remove(signature);
+        }
+    }
+
+    pub(crate) fn is_transaction_pending(&self, signature: &Signature) -> bool {
+        self.pending_transaction_signatures.contains_key(signature)
+    }
+
     pub fn default() -> (Self, Receiver<SimnetEvent>, Receiver<GeyserEvent>) {
         Self::new(SurfnetSvmConfig::default()).unwrap()
     }
@@ -554,6 +582,8 @@ impl SurfnetSvm {
             // Wrap all storage fields with OverlayStorage
             blocks: OverlayStorage::wrap(self.blocks.clone_box()),
             transactions: OverlayStorage::wrap(self.transactions.clone_box()),
+            // Profiling sandboxes do not consume the live transaction command queue.
+            pending_transaction_signatures: HashMap::new(),
             jito_bundles: OverlayStorage::wrap(self.jito_bundles.clone_box()),
             profile_tag_map: OverlayStorage::wrap(self.profile_tag_map.clone_box()),
             simulated_transaction_profiles: OverlayStorage::wrap(
@@ -1032,6 +1062,7 @@ impl SurfnetSvm {
             chain_tip,
             blocks: blocks_db,
             transactions: transactions_db,
+            pending_transaction_signatures: HashMap::new(),
             jito_bundles: jito_bundles_db,
             perf_samples: VecDeque::new(),
             transactions_processed,

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -11073,7 +11073,7 @@ async fn test_send_transaction_skip_sig_verify_processes_and_updates_state(test_
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
 
     let _runloop = spawn_runloop(
-        svm_locker,
+        svm_locker.clone(),
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
@@ -11146,6 +11146,7 @@ async fn test_send_transaction_skip_sig_verify_processes_and_updates_state(test_
         },
         skip_sig_verify: Some(true),
     };
+    let signature = tx.signatures[0];
     let _sig = full_client
         .send_transaction(data, Some(send_config))
         .await
@@ -11161,6 +11162,13 @@ async fn test_send_transaction_skip_sig_verify_processes_and_updates_state(test_
         }
     })
     .await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while svm_locker.0.read().await.is_transaction_pending(&signature) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the runloop should clear the pending signature after processing");
 
     // Assert recipient received the transfer
     let final_recipient_balance = minimal_client


### PR DESCRIPTION
Claude and I discovered two cases where we fetched txs from remote that can be bypassed:
 1. `getSignatureStatuses` config has default `search_transaction_history = false`. If false, no remote fetches are needed
 2. If a transaction is submitted then immediately fetched, it's not found locally because it's processing. It also will never be in the remote. So, we store pending txs temporarily so we can bypass remote fetch if a tx is pending