### PR TITLE
fix(types): require explicit delivery classes for every known event variant

### DIFF
--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -633,10 +633,7 @@ impl SimnetEventsTx {
     /// Routes a pre-built event by its class: telemetry and guard-context
     /// state events go through `log`, lifecycle events through `emit`. For
     /// forwarding buffered events (the startup replay); a new call site
-    /// names its event instead.
-    ///
-    /// Wildcard-free on purpose: a new variant does not compile until its
-    /// delivery class is chosen here.
+   /// names its event instead.
     pub fn forward(&self, event: SimnetEvent) {
         match &event {
             SimnetEvent::InfoLog(..)

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -634,6 +634,9 @@ impl SimnetEventsTx {
     /// state events go through `log`, lifecycle events through `emit`. For
     /// forwarding buffered events (the startup replay); a new call site
     /// names its event instead.
+    ///
+    /// Wildcard-free on purpose: a new variant does not compile until its
+    /// delivery class is chosen here.
     pub fn forward(&self, event: SimnetEvent) {
         match &event {
             SimnetEvent::InfoLog(..)
@@ -643,7 +646,18 @@ impl SimnetEventsTx {
             | SimnetEvent::SystemClockUpdated(..)
             | SimnetEvent::StartupStatusChanged(..)
             | SimnetEvent::AccountUpdate(..) => self.log(event),
-            _ => self.emit(event),
+            SimnetEvent::CoreStarted(..)
+            | SimnetEvent::Connected(..)
+            | SimnetEvent::Aborted(..)
+            | SimnetEvent::Shutdown
+            | SimnetEvent::ClockUpdate(..)
+            | SimnetEvent::EpochInfoUpdate(..)
+            | SimnetEvent::PluginLoaded(..)
+            | SimnetEvent::TransactionReceived(..)
+            | SimnetEvent::TransactionProcessed(..)
+            | SimnetEvent::TaggedProfile { .. }
+            | SimnetEvent::RunbookStarted(..)
+            | SimnetEvent::RunbookCompleted(..) => self.emit(event),
         }
     }
 

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -633,7 +633,7 @@ impl SimnetEventsTx {
     /// Routes a pre-built event by its class: telemetry and guard-context
     /// state events go through `log`, lifecycle events through `emit`. For
     /// forwarding buffered events (the startup replay); a new call site
-   /// names its event instead.
+    /// names its event instead.
     pub fn forward(&self, event: SimnetEvent) {
         match &event {
             SimnetEvent::InfoLog(..)


### PR DESCRIPTION
The forwarding match ends in a wildcard arm. A future log-class variant could therefore silently default to lossless delivery and block while the SVM lock is held, defeating the safety property enforced by the sender type.

- Name all twelve emit-class variants explicitly.
- Make the compiler reject new `SimnetEvent` variants until their delivery class is chosen.