### PR TITLE
fix(core): serialize postgres table creation with a tx-scoped advisory lock

### DIFF
--- a/crates/core/src/storage/postgres.rs
+++ b/crates/core/src/storage/postgres.rs
@@ -135,17 +135,8 @@ where
         debug!("Getting connection from pool for table creation");
         let mut conn = self.pool.get().map_err(|_| StorageError::LockError)?;
 
-        // IF NOT EXISTS is a catalog lookup then a create, atomic only
-        // against itself: two sessions can both pass the lookup, and the
-        // loser fails on a duplicate key in pg_type. An advisory lock keyed
-        // by table name serializes the two halves across sessions. The lock
-        // must be transaction-scoped: a session-scoped lock survives an
-        // error between lock and unlock, rides its pooled connection back
-        // into the pool, and parks every later constructor forever. Per
-        // the PostgreSQL docs, an xact lock "is automatically released at
-        // the end of the current transaction and cannot be released
-        // explicitly": release is the database's job alone, on commit and
-        // rollback alike, so no error path can leak it.
+        // pg_advisory_xact_lock serializes this transaction, at the server,
+        // against every other session taking the same key, preventing a race.
         conn.transaction(|conn| {
             sql_query("SELECT pg_advisory_xact_lock(hashtext('surfpool:ddl:' || $1))")
                 .bind::<Text, _>(&self.table_name)

--- a/crates/core/src/storage/postgres.rs
+++ b/crates/core/src/storage/postgres.rs
@@ -379,6 +379,8 @@ where
 mod tests {
     use std::sync::{Arc, Barrier};
 
+    use surfpool_db::diesel::QueryableByName;
+
     use super::*;
     use crate::storage::tests::{POSTGRES_TEST_URL_ENV, random_surfnet_id};
 
@@ -452,6 +454,75 @@ mod tests {
             lost,
             ATTEMPTS,
             first_loss.unwrap()
+        );
+    }
+
+    #[derive(QueryableByName)]
+    struct LockProbe {
+        #[diesel(sql_type = diesel::sql_types::Bool)]
+        free: bool,
+    }
+
+    /// True when no session holds the DDL advisory lock for this table.
+    /// Probes with try-lock from a fresh transaction; the probe's own
+    /// lock evaporates when its transaction ends.
+    ///
+    /// The probe connection is established outside the pool on purpose:
+    /// advisory locks are reentrant within a session, so a probe drawn
+    /// from the pool can land on the very connection that leaked the
+    /// lock and report it free. A dedicated connection is a distinct
+    /// session by construction, which is what the probe's question is
+    /// about.
+    fn ddl_lock_is_free(url: &str, table: &str) -> bool {
+        let mut conn = diesel::PgConnection::establish(url).unwrap();
+        conn.transaction(|conn| {
+            sql_query(
+                "SELECT pg_try_advisory_xact_lock(hashtext('surfpool:ddl:' || $1)) AS free",
+            )
+            .bind::<Text, _>(table)
+            .get_result::<LockProbe>(conn)
+            .map(|row| row.free)
+        })
+        .unwrap()
+    }
+
+    /// The lock is transaction-scoped, so a successful construction leaves
+    /// it free for the next session the moment its transaction commits.
+    #[test]
+    fn ddl_lock_is_released_after_successful_create() {
+        let Some(url) = test_url() else {
+            println!("skipping: {} not set", POSTGRES_TEST_URL_ENV);
+            return;
+        };
+        let table = random_table_name();
+        let backend = PostgresBackend::open(&url, &random_surfnet_id()).unwrap();
+        backend.open_store::<String, String>(&table).unwrap();
+        let free = ddl_lock_is_free(&url, &table);
+        drop_tables(&url, std::slice::from_ref(&table));
+        assert!(free, "the DDL advisory lock outlived a successful create");
+    }
+
+    /// The wedge regression: an error between lock and unlock must not
+    /// leak the lock into the pool, where it would park every later
+    /// constructor of this table forever. A table name that breaks the
+    /// CREATE forces the error path after the lock is taken; the database
+    /// releases the lock when the transaction rolls back.
+    #[test]
+    fn ddl_lock_is_released_after_failed_create() {
+        let Some(url) = test_url() else {
+            println!("skipping: {} not set", POSTGRES_TEST_URL_ENV);
+            return;
+        };
+        let table = "ddl race bad name"; // spaces break the unquoted CREATE
+        let backend = PostgresBackend::open(&url, &random_surfnet_id()).unwrap();
+        let result = backend.open_store::<String, String>(table);
+        assert!(
+            result.is_err(),
+            "a syntactically broken CREATE should fail construction"
+        );
+        assert!(
+            ddl_lock_is_free(&url, table),
+            "the DDL advisory lock outlived a failed create"
         );
     }
 }

--- a/crates/core/src/storage/postgres.rs
+++ b/crates/core/src/storage/postgres.rs
@@ -6,7 +6,7 @@ use std::{
 use log::debug;
 use serde::{Deserialize, Serialize};
 use surfpool_db::diesel::{
-    self, RunQueryDsl,
+    self, Connection, RunQueryDsl,
     connection::SimpleConnection,
     r2d2::{ConnectionManager, Pool},
     sql_query,
@@ -135,8 +135,24 @@ where
         debug!("Getting connection from pool for table creation");
         let mut conn = self.pool.get().map_err(|_| StorageError::LockError)?;
 
-        conn.batch_execute(&create_table_sql)
-            .map_err(|e| StorageError::create_table(&self.table_name, NAME, e))?;
+        // IF NOT EXISTS is a catalog lookup then a create, atomic only
+        // against itself: two sessions can both pass the lookup, and the
+        // loser fails on a duplicate key in pg_type. An advisory lock keyed
+        // by table name serializes the two halves across sessions. The lock
+        // must be transaction-scoped: a session-scoped lock survives an
+        // error between lock and unlock, rides its pooled connection back
+        // into the pool, and parks every later constructor forever. Per
+        // the PostgreSQL docs, an xact lock "is automatically released at
+        // the end of the current transaction and cannot be released
+        // explicitly": release is the database's job alone, on commit and
+        // rollback alike, so no error path can leak it.
+        conn.transaction(|conn| {
+            sql_query("SELECT pg_advisory_xact_lock(hashtext('surfpool:ddl:' || $1))")
+                .bind::<Text, _>(&self.table_name)
+                .execute(conn)?;
+            conn.batch_execute(&create_table_sql)
+        })
+        .map_err(|e| StorageError::create_table(&self.table_name, NAME, e))?;
 
         debug!("Successfully ensured table '{}' exists", self.table_name);
         Ok(())

--- a/crates/core/src/storage/postgres.rs
+++ b/crates/core/src/storage/postgres.rs
@@ -358,3 +358,84 @@ where
         Ok(Box::new(iter))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use super::*;
+    use crate::storage::tests::{POSTGRES_TEST_URL_ENV, random_surfnet_id};
+
+    fn test_url() -> Option<String> {
+        std::env::var(POSTGRES_TEST_URL_ENV).ok()
+    }
+
+    fn random_table_name() -> String {
+        format!("ddl_race_{}", random_surfnet_id().replace('-', ""))
+    }
+
+    fn drop_tables(url: &str, tables: &[String]) {
+        let pool = get_or_create_shared_pool(url).unwrap();
+        let mut conn = pool.get().unwrap();
+        for table in tables {
+            let _ = conn.batch_execute(&format!("DROP TABLE IF EXISTS {}", table));
+        }
+    }
+
+    /// Two sessions running CREATE TABLE IF NOT EXISTS for the same new
+    /// table can both pass the existence check; the loser's catalog
+    /// insert then fails with a duplicate key on pg_type_typname_nsp_index
+    /// and storage construction fails over a table that exists. Each
+    /// attempt uses a fresh table name so every attempt replays the
+    /// creation window that CI replays once per container.
+    #[test]
+    fn concurrent_open_store_survives_the_create_race() {
+        let Some(url) = test_url() else {
+            println!("skipping: {} not set", POSTGRES_TEST_URL_ENV);
+            return;
+        };
+        const ATTEMPTS: usize = 50;
+        const SESSIONS: usize = 4;
+
+        let mut tables = Vec::with_capacity(ATTEMPTS);
+        let mut lost = 0usize;
+        let mut first_loss = None;
+        for _ in 0..ATTEMPTS {
+            let table = random_table_name();
+            tables.push(table.clone());
+            let barrier = Arc::new(Barrier::new(SESSIONS));
+            let handles: Vec<_> = (0..SESSIONS)
+                .map(|_| {
+                    let url = url.clone();
+                    let table = table.clone();
+                    let barrier = barrier.clone();
+                    std::thread::spawn(move || {
+                        let backend =
+                            PostgresBackend::open(&url, &random_surfnet_id()).unwrap();
+                        barrier.wait();
+                        backend.open_store::<String, String>(&table).map(|_| ())
+                    })
+                })
+                .collect();
+            let mut attempt_lost = false;
+            for handle in handles {
+                if let Err(e) = handle.join().unwrap() {
+                    attempt_lost = true;
+                    first_loss.get_or_insert(e);
+                }
+            }
+            if attempt_lost {
+                lost += 1;
+            }
+        }
+        drop_tables(&url, &tables);
+
+        assert!(
+            lost == 0,
+            "lost the DDL race in {}/{} attempts; first loss: {:?}",
+            lost,
+            ATTEMPTS,
+            first_loss.unwrap()
+        );
+    }
+}

--- a/crates/core/src/storage/postgres.rs
+++ b/crates/core/src/storage/postgres.rs
@@ -428,8 +428,7 @@ mod tests {
                     let table = table.clone();
                     let barrier = barrier.clone();
                     std::thread::spawn(move || {
-                        let backend =
-                            PostgresBackend::open(&url, &random_surfnet_id()).unwrap();
+                        let backend = PostgresBackend::open(&url, &random_surfnet_id()).unwrap();
                         barrier.wait();
                         backend.open_store::<String, String>(&table).map(|_| ())
                     })
@@ -476,12 +475,10 @@ mod tests {
     fn ddl_lock_is_free(url: &str, table: &str) -> bool {
         let mut conn = diesel::PgConnection::establish(url).unwrap();
         conn.transaction(|conn| {
-            sql_query(
-                "SELECT pg_try_advisory_xact_lock(hashtext('surfpool:ddl:' || $1)) AS free",
-            )
-            .bind::<Text, _>(table)
-            .get_result::<LockProbe>(conn)
-            .map(|row| row.free)
+            sql_query("SELECT pg_try_advisory_xact_lock(hashtext('surfpool:ddl:' || $1)) AS free")
+                .bind::<Text, _>(table)
+                .get_result::<LockProbe>(conn)
+                .map(|row| row.free)
         })
         .unwrap()
     }


### PR DESCRIPTION
## What was failing

`CREATE TABLE IF NOT EXISTS` reads as one step but runs as two: check whether the table exists, then create it. Two connections setting up storage for the same table at the same time can both pass the check. Both then create, and the loser fails with:

    duplicate key value violates unique constraint "pg_type_typname_nsp_index"

So construction errors out over a table that now exists.

The race is only open the first time a table name is created in a database, which makes it a rare CI flake but easy to force:

- PR #730, run 30679928707:
  `test_blockhash_consistency_across_calls::with_postgres_db`
- main at e4e3c546 (push build for #774), run 33210436114:
  `test_account_update_removes_old_indexes::with_postgres_db`
- the reproducer in this PR, which starts the sessions on a shared
  barrier, loses 48 of 50 attempts
  
I modeled the interactions with pml and spin to find race. pml SO GOOD.

## The fix

Before creating the table, each session takes an advisory lock keyed on the table name. An advisory lock is a named mutex the database hands out: it locks no table or row, it just makes sessions that ask for the same name proceed one at a time. The second session waits for the first to commit, so its existence check sees the finished table and skips the create. The lock lives in the database, so constructors in other processes serialize the same way.

PostgreSQL offers two flavors, and the choice is the safety argument:

| Flavor                                | Released by                               | If an error hits between lock and unlock                                                                                                              |
|---------------------------------------|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
| session (`pg_advisory_lock`)          | an explicit unlock call                   | the lock leaks; on a pooled connection it rides back into the pool on a healthy idle session, and every later constructor of that table waits forever |
| transaction (`pg_advisory_xact_lock`) | the database, at commit or rollback alike | nothing to leak; no code path can forget the release                                                                                                  |

This PR uses the transaction-scoped flavor.

## Tests

- Reproducer (RED commit): four sessions construct storage for a fresh
  table, released together by a barrier. Red before the fix,
  deterministically green after.
- Two contract tests (GREEN commit): a separate session probes that
  the lock is free after construction returns, on the success path and
  after a forced create failure.
- Both contract tests were verified by mutation: swapping in the
  session-scoped lock makes both fail.
- The mutation also exposed a probe bug: a probe drawn from the shared
  pool can land on the very connection that leaked the lock, and a
  session sees its own lock as free. The probe therefore opens a
  dedicated connection, a distinct session by construction.

## Testing

Any PostgreSQL 15+ works; without the environment variable the three new tests skip. A compose file matching the CI service container:

```yml
services:
  db:
    image: postgres
    restart: always
    shm_size: 128mb
    environment:
      POSTGRES_USER: surfpool
      POSTGRES_PASSWORD: surfpool
      POSTGRES_DB: surfpool_test
    ports:
      - 5432:5432
```

    SURFPOOL_TEST_POSTGRES_URL="postgres://surfpool:surfpool@localhost:5432/surfpool_test" \
      cargo test -p surfpool-core --features postgres --lib storage::postgres
