### PR TITLE
fix(tests): convert RpcClient to the expected type in the genesis-hash locker test

### DIFF
--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -4716,7 +4716,8 @@ mod tests {
                     requests: Arc::clone(&requests),
                 },
                 RpcClientConfig::default(),
-            ),
+            )
+            .into(),
         };
         let remote_ctx = Some(remote_client);
 


### PR DESCRIPTION
## Summary

`cargo test -p surfpool-core` no longer compiles on `main`:

```
error[E0308]: mismatched types
    --> crates/core/src/surfnet/locker.rs:4713:21
     | expected `Arc<RpcClient>`, found `RpcClient`
```

`SurfnetRemoteClient.client` is an `Arc<RpcClient>`; the `initialize_fetches_and_caches_genesis_hash` test added in #789 builds a bare `RpcClient`. Same mismatch #791 fixed in `remote.rs`, one call site later.

## Fix

`.into()` on the `RpcClient::new_sender(...)` in that test. No production code touched.

## Validation

- `cargo test -p surfpool-core --lib initialize_fetches_and_caches_genesis_hash` — passes
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p surfpool-core --all-targets` — no new warnings
