### PR TITLE
fix(core): keep local token accounts when the datasource has never seen the mint

### DIFF
--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -99,12 +99,16 @@ fn sanitized_client_error(error: &ClientError, datasource_url: &str) -> String {
     }
 }
 
-/// JSON-RPC `-32602`: the datasource understood the request and rejected its params.
-fn is_invalid_params(error: &ClientError) -> bool {
-    matches!(
-        error.kind(),
-        ClientErrorKind::RpcError(RpcError::RpcResponseError { code: -32602, .. })
-    )
+/// The datasource's answer for a `Mint` filter it cannot resolve: JSON-RPC `-32602` with
+/// `could not find mint`. Any other `-32602` (bad encoding, bad program filter) is a request
+/// error the caller must see.
+fn is_unknown_mint(filter: &TokenAccountsFilter, error: &ClientError) -> bool {
+    matches!(filter, TokenAccountsFilter::Mint(_))
+        && matches!(
+            error.kind(),
+            ClientErrorKind::RpcError(RpcError::RpcResponseError { code: -32602, message, .. })
+                if message.contains("could not find mint")
+        )
 }
 
 /// Bounds how long the sender it wraps may take, so a datasource that stops
@@ -487,12 +491,12 @@ impl SurfnetRemoteClient {
             .await;
         match res {
             Ok(res) => Ok(res.value),
-            // The datasource rejected the filter itself: a mint that exists only on this surfnet
-            // is `could not find mint` upstream. That is a definite "no remote accounts", not a
-            // failed lookup, and must not discard the local accounts the caller merges with.
-            Err(e) if is_invalid_params(&e) => {
+            // A mint that exists only on this surfnet is `could not find mint` upstream. That is
+            // a definite "no remote accounts", not a failed lookup, and must not discard the
+            // local accounts the caller merges with.
+            Err(e) if is_unknown_mint(filter, &e) => {
                 log::debug!(
-                    "datasource rejected getTokenAccountsByOwner filter for {owner}; \
+                    "datasource does not know the mint in getTokenAccountsByOwner for {owner}; \
                      answering from local accounts only"
                 );
                 Ok(vec![])
@@ -1037,6 +1041,68 @@ mod tests {
             .expect("a rejected filter is an empty remote answer, not a failure");
 
         assert!(accounts.is_empty());
+    }
+
+    struct RejectsParams;
+
+    #[async_trait]
+    impl RpcSender for RejectsParams {
+        async fn send(
+            &self,
+            _request: RpcRequest,
+            _params: serde_json::Value,
+        ) -> ClientResult<serde_json::Value> {
+            Err(ClientErrorKind::RpcError(RpcError::RpcResponseError {
+                code: -32602,
+                message: "Invalid param: unsupported encoding".to_string(),
+                data: RpcResponseErrorData::Empty,
+            })
+            .into())
+        }
+
+        fn get_transport_stats(&self) -> RpcTransportStats {
+            RpcTransportStats::default()
+        }
+
+        fn url(&self) -> String {
+            "http://rejects-params.example".to_string()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn any_other_invalid_params_rejection_is_still_an_error() {
+        let client = SurfnetRemoteClient {
+            client: RpcClient::new_sender(RejectsParams, RpcClientConfig::default()).into(),
+        };
+
+        let error = client
+            .get_token_accounts_by_owner(
+                Pubkey::new_unique(),
+                &TokenAccountsFilter::Mint(Pubkey::new_unique()),
+                &RpcAccountInfoConfig::default(),
+            )
+            .await
+            .expect_err("a rejected encoding is a request error, not an empty answer");
+
+        assert!(error.to_string().contains("unsupported encoding"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unknown_mint_answer_on_a_program_filter_is_still_an_error() {
+        let client = SurfnetRemoteClient {
+            client: RpcClient::new_sender(RejectsUnknownMint, RpcClientConfig::default()).into(),
+        };
+
+        let error = client
+            .get_token_accounts_by_owner(
+                Pubkey::new_unique(),
+                &TokenAccountsFilter::ProgramId(Pubkey::new_unique()),
+                &RpcAccountInfoConfig::default(),
+            )
+            .await
+            .expect_err("only a Mint filter can be answered by an unknown mint");
+
+        assert!(error.to_string().contains("could not find mint"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -99,6 +99,14 @@ fn sanitized_client_error(error: &ClientError, datasource_url: &str) -> String {
     }
 }
 
+/// JSON-RPC `-32602`: the datasource understood the request and rejected its params.
+fn is_invalid_params(error: &ClientError) -> bool {
+    matches!(
+        error.kind(),
+        ClientErrorKind::RpcError(RpcError::RpcResponseError { code: -32602, .. })
+    )
+}
+
 /// Bounds how long the sender it wraps may take, so a datasource that stops
 /// answering surfaces as an error rather than as a surfnet that appears stuck.
 struct DeadlineSender<S> {
@@ -477,8 +485,20 @@ impl SurfnetRemoteClient {
                 json!([owner.to_string(), token_account_filter, config]),
             )
             .await;
-        res.map_err(|e| SurfpoolError::get_token_accounts(owner, filter, e))
-            .map(|res| res.value)
+        match res {
+            Ok(res) => Ok(res.value),
+            // The datasource rejected the filter itself: a mint that exists only on this surfnet
+            // is `could not find mint` upstream. That is a definite "no remote accounts", not a
+            // failed lookup, and must not discard the local accounts the caller merges with.
+            Err(e) if is_invalid_params(&e) => {
+                log::debug!(
+                    "datasource rejected getTokenAccountsByOwner filter for {owner}; \
+                     answering from local accounts only"
+                );
+                Ok(vec![])
+            }
+            Err(e) => Err(SurfpoolError::get_token_accounts(owner, filter, e)),
+        }
     }
 
     pub async fn get_token_largest_accounts(
@@ -973,5 +993,128 @@ mod tests {
             message.contains("GetSlot"),
             "the failure should identify the request: {message}"
         );
+    }
+
+    struct RejectsUnknownMint;
+
+    #[async_trait]
+    impl RpcSender for RejectsUnknownMint {
+        async fn send(
+            &self,
+            _request: RpcRequest,
+            _params: serde_json::Value,
+        ) -> ClientResult<serde_json::Value> {
+            Err(ClientErrorKind::RpcError(RpcError::RpcResponseError {
+                code: -32602,
+                message: "Invalid param: could not find mint".to_string(),
+                data: RpcResponseErrorData::Empty,
+            })
+            .into())
+        }
+
+        fn get_transport_stats(&self) -> RpcTransportStats {
+            RpcTransportStats::default()
+        }
+
+        fn url(&self) -> String {
+            "http://rejects-unknown-mint.example".to_string()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_mint_unknown_to_the_datasource_has_no_remote_token_accounts() {
+        let client = SurfnetRemoteClient {
+            client: RpcClient::new_sender(RejectsUnknownMint, RpcClientConfig::default()).into(),
+        };
+
+        let accounts = client
+            .get_token_accounts_by_owner(
+                Pubkey::new_unique(),
+                &TokenAccountsFilter::Mint(Pubkey::new_unique()),
+                &RpcAccountInfoConfig::default(),
+            )
+            .await
+            .expect("a rejected filter is an empty remote answer, not a failure");
+
+        assert!(accounts.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_token_accounts_provider_failure_is_still_an_error() {
+        let client = SurfnetRemoteClient {
+            client: RpcClient::new_sender(ReturnsError, RpcClientConfig::default()).into(),
+        };
+
+        let error = client
+            .get_token_accounts_by_owner(
+                Pubkey::new_unique(),
+                &TokenAccountsFilter::Mint(Pubkey::new_unique()),
+                &RpcAccountInfoConfig::default(),
+            )
+            .await
+            .expect_err("a provider failure must not be reported as an empty answer");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to get token accounts by owner")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_fork_born_mint_keeps_its_local_token_accounts() {
+        use solana_account::Account;
+        use solana_account_decoder::UiAccountEncoding;
+        use solana_program_pack::Pack;
+        use spl_token_interface::state::{Account as TokenAccount, AccountState};
+
+        let (svm, _, _) = SurfnetSvm::default();
+        let locker = SurfnetSvmLocker::new(svm);
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let token_account_pubkey = Pubkey::new_unique();
+        let mut data = vec![0u8; TokenAccount::LEN];
+        TokenAccount {
+            mint,
+            owner,
+            amount: 42,
+            state: AccountState::Initialized,
+            ..Default::default()
+        }
+        .pack_into_slice(&mut data);
+        locker.with_svm_writer(|svm| {
+            svm.set_account(
+                &token_account_pubkey,
+                Account {
+                    lamports: 2_039_280,
+                    data,
+                    owner: spl_token_interface::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .unwrap();
+        });
+        let remote = SurfnetRemoteClient {
+            client: RpcClient::new_sender(RejectsUnknownMint, RpcClientConfig::default()).into(),
+        };
+        let config = RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::Base64),
+            ..RpcAccountInfoConfig::default()
+        };
+
+        let accounts = locker
+            .get_token_accounts_by_owner(
+                &Some(remote),
+                owner,
+                &TokenAccountsFilter::Mint(mint),
+                &config,
+            )
+            .await
+            .expect("local token accounts survive a datasource that has never seen the mint")
+            .inner;
+
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].pubkey, token_account_pubkey.to_string());
     }
 }

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -1010,7 +1010,9 @@ mod tests {
         ) -> ClientResult<serde_json::Value> {
             Err(ClientErrorKind::RpcError(RpcError::RpcResponseError {
                 code: -32602,
-                message: "Invalid param: could not find mint".to_string(),
+                message:
+                    "Error getting token program id and mint: Invalid param: could not find mint"
+                        .to_string(),
                 data: RpcResponseErrorData::Empty,
             })
             .into())


### PR DESCRIPTION
## Summary

`get_token_accounts_by_owner_local_then_remote` resolves the local token accounts first, then propagates any error from the remote leg with `?`. For a mint that exists only on the surfnet — one created by a transaction that ran here — the datasource answers `-32602 Invalid param: could not find mint`, and the local accounts that were just resolved correctly are discarded with it. A wallet that just received a freshly minted token reads as holding nothing, even though `getAccountInfo` on the token account itself works.

This is the normal shape of a fork: every mint launched on the surfnet is unknown upstream.

## Fix

In `SurfnetRemoteClient::get_token_accounts_by_owner`, treat the datasource's `-32602 … could not find mint` on a `Mint` filter as "no remote accounts": it is a definite answer about that mint, not a failed lookup. Any other error — a transport failure, or a `-32602` for a bad encoding or program filter — still propagates through `SurfpoolError::get_token_accounts`, so neither a provider outage nor a malformed request is reported as an empty wallet. The locker's merge is unchanged.

## Regression tests

- `a_mint_unknown_to_the_datasource_has_no_remote_token_accounts` — a sender answering `-32602 could not find mint` yields `Ok(vec![])`.
- `a_token_accounts_provider_failure_is_still_an_error` — a transport-level failure still surfaces as an error.
- `any_other_invalid_params_rejection_is_still_an_error` — a `-32602` with a different message (`unsupported encoding`) still surfaces as an error.
- `an_unknown_mint_answer_on_a_program_filter_is_still_an_error` — the unknown-mint message on a `ProgramId` filter still surfaces as an error.
- `a_fork_born_mint_keeps_its_local_token_accounts` — a token account set locally for a mint the datasource rejects is returned through `SurfnetSvmLocker::get_token_accounts_by_owner` with a remote client attached. Before this patch it fails with `Failed to get token accounts by owner … could not find mint`.

## Validation

- `cargo test -p surfpool-core --lib -- surfnet::remote::tests` — 13 passed
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p surfpool-core --all-targets` — no new warnings against `main`
- `git diff --check`

Note: `cargo test -p surfpool-core` does not compile on `main` right now (`locker.rs:4713`, the test added in #789 builds a bare `RpcClient` where an `Arc<RpcClient>` is expected); the tests above were run with that one-line `.into()` applied locally. Sent separately as its own PR.
