### PR TITLE
fix(rpc): omit empty simulateTransaction return data

### DIFF
--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -27,7 +27,6 @@ use solana_pubkey::Pubkey;
 use solana_rpc_client_api::response::Response as RpcResponse;
 use solana_sdk_ids::compute_budget;
 use solana_signature::Signature;
-use solana_system_interface::program as system_program;
 use solana_transaction_error::TransactionError;
 use solana_transaction_status::{
     EncodedConfirmedTransactionWithStatusMeta, EncodedTransactionWithStatusMeta,
@@ -2722,9 +2721,7 @@ fn get_simulate_transaction_result(
         },
         logs: Some(metadata.logs.clone()),
         replacement_blockhash,
-        return_data: if metadata.return_data.program_id == system_program::id()
-            && metadata.return_data.data.is_empty()
-        {
+        return_data: if metadata.return_data.data.is_empty() {
             None
         } else {
             Some(metadata.return_data.clone().into())
@@ -2832,6 +2829,28 @@ mod tests {
             recent_blockhash,
         ));
         VersionedTransaction::try_new(msg, signers).unwrap()
+    }
+
+    #[test]
+    fn simulate_transaction_omits_only_empty_return_data() {
+        let mut metadata = TransactionMetadata::default();
+        metadata.return_data.program_id = Pubkey::new_unique();
+        let message = VersionedMessage::Legacy(LegacyMessage::default());
+
+        let result = get_simulate_transaction_result(
+            metadata, None, None, None, false, &message, None, None,
+        );
+
+        assert!(result.return_data.is_none());
+
+        let mut metadata = TransactionMetadata::default();
+        metadata.return_data.program_id = Pubkey::new_unique();
+        metadata.return_data.data = vec![1];
+        let result = get_simulate_transaction_result(
+            metadata, None, None, None, false, &message, None, None,
+        );
+
+        assert!(result.return_data.is_some());
     }
 
     async fn send_and_await_transaction(


### PR DESCRIPTION
## Problem

`get_simulate_transaction_result` only omitted empty return data when its program ID was the System Program.

LiteSVM metadata can contain another program ID with an empty data vector. Surfpool therefore returned an empty `returnData` object where canonical Solana RPC returns `null`.

## Fix

Treat any empty return-data vector as absent, regardless of program ID. Non-empty return data remains unchanged.

## Testing

- Added a regression test for empty and non-empty data with a non-system program ID.
- The regression test fails before the fix and passes afterward.
- `cargo test -p surfpool-core simulate_transaction_omits_only_empty_return_data`
- `cargo test -p surfpool-core --lib --features ignore_tests_ci -- --test-threads=20` (710 passed, 64 ignored)
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
