### PR TITLE
Add historical forks with --fork-slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Surfpool Cloud extends that same experience to the cloud — letting you index m
 With Surfpool Scenarios you can curate slot-by-slot account states for key accounts, mixing live mainnet data with overridden account states.
 This allows you to stress test your protocol in key real-world situations and to reproduce any chain-state conditions. See the [Scenarios Docs](./crates/core/src/scenarios/README.md) for more details.
 
+## Historical forks
+
+`surfpool start --rpc-url <URL> --fork-slot <SLOT>` is intended to behave as if
+`--rpc-url` pointed to a historical RPC frozen at that slot. Surfpool still runs
+local transactions and advances slots; remote state stays pinned.
+
+Requires Alchemy's [Account Archive](https://www.alchemy.com/docs/solana/account-archive) APIs; ordinary archival. Certain methods like historical program/delegate scans, rankings and aggregate supply aren't supported. Large signature histories can time out while paging back to the fork slot.
+
 ## Installation
 
 Surfpool installer:

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -266,6 +266,14 @@ pub struct StartNetworkOptions {
         long_help = "Fork from this datasource RPC URL. Cannot be used with --network.\n\nThis can also be set with SURFPOOL_DATASOURCE_RPC_URL.\n\nExample: surfpool start --rpc-url https://api.mainnet-beta.solana.com"
     )]
     pub rpc_url: Option<String>,
+    /// Load remote accounts at a finalized slot (requires Alchemy Account Archive support).
+    #[arg(
+        long,
+        value_name = "SLOT",
+        requires = "rpc_url",
+        conflicts_with = "offline"
+    )]
+    pub fork_slot: Option<u64>,
     /// Fork from a predefined Solana network.
     #[arg(
         long = "network",
@@ -647,6 +655,7 @@ impl StartSimnet {
         SurfnetSvmConfig {
             surfnet_id: self.accounts.surfnet_id.clone(),
             feature_config: self.feature_config(),
+            fork_slot: self.network.fork_slot,
             slot_time: self.svm.slot_time,
             instruction_profiling_enabled: !self.observability.disable_instruction_profiling,
             max_profiles: self.observability.max_profiles,
@@ -672,6 +681,7 @@ impl StartSimnet {
 
         SimnetConfig {
             remote_rpc_url,
+            fork_slot: self.network.fork_slot,
             slot_time: self.svm.slot_time,
             block_production_mode: self.svm.block_production_mode.clone(),
             airdrop_addresses,

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -2088,12 +2088,21 @@ impl Full for SurfpoolFullRpc {
         meta: Self::Metadata,
         slot: Slot,
     ) -> BoxFuture<Result<Option<UnixTimestamp>>> {
-        let svm_locker = match meta.get_svm_locker() {
-            Ok(locker) => locker,
+        let SurfnetRpcContext {
+            svm_locker,
+            remote_ctx,
+        } = match meta.get_rpc_context(()) {
+            Ok(context) => context,
             Err(e) => return e.into(),
         };
 
         Box::pin(async move {
+            if let Some((client, _)) = &remote_ctx
+                && client.fork_slot.is_some()
+                && slot < svm_locker.with_svm_reader(|svm| svm.genesis_slot)
+            {
+                return client.get_block_time(slot).await.map_err(Into::into);
+            }
             let block_time = svm_locker.with_svm_reader(|svm_reader| {
                 Ok::<_, jsonrpc_core::Error>(match svm_reader.blocks.get(&slot)? {
                     Some(block) => Some(block.block_time),
@@ -2203,10 +2212,8 @@ impl Full for SurfpoolFullRpc {
                     let remote_end = effective_end_slot.min(local_min.saturating_sub(1));
                     if start_slot <= remote_end {
                         remote_client
-                            .client
                             .get_blocks(start_slot, Some(remote_end))
-                            .await
-                            .unwrap_or_else(|_| vec![])
+                            .await?
                     } else {
                         vec![]
                     }
@@ -2218,10 +2225,8 @@ impl Full for SurfpoolFullRpc {
                     .as_ref()
                     .unwrap()
                     .0
-                    .client
                     .get_blocks(start_slot, Some(effective_end_slot))
-                    .await
-                    .unwrap_or_else(|_| vec![])
+                    .await?
             } else {
                 vec![]
             };
@@ -2302,11 +2307,18 @@ impl Full for SurfpoolFullRpc {
                 if start_slot < local_min {
                     let remote_end = committed_latest_slot.min(local_min.saturating_sub(1));
                     if start_slot <= remote_end {
-                        remote_client
-                            .client
-                            .get_blocks(start_slot, Some(remote_end))
-                            .await
-                            .unwrap_or_else(|_| vec![])
+                        if remote_client.fork_slot.is_some() {
+                            remote_client
+                                .get_blocks_with_limit(start_slot, limit)
+                                .await?
+                                .into_iter()
+                                .take_while(|slot| *slot <= remote_end)
+                                .collect()
+                        } else {
+                            remote_client
+                                .get_blocks(start_slot, Some(remote_end))
+                                .await?
+                        }
                     } else {
                         vec![]
                     }
@@ -2319,10 +2331,8 @@ impl Full for SurfpoolFullRpc {
                     .as_ref()
                     .unwrap()
                     .0
-                    .client
                     .get_blocks(start_slot, Some(committed_latest_slot))
-                    .await
-                    .unwrap_or_else(|_| vec![])
+                    .await?
             } else {
                 vec![]
             };

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -186,11 +186,12 @@ pub async fn start_local_surfnet_runloop(
 
     let remote_rpc_client = match simnet.offline_mode {
         true => None,
-        false => Some(SurfnetRemoteClient::try_new(
+        false => Some(SurfnetRemoteClient::try_new_at_slot(
             simnet
                 .remote_rpc_url
                 .as_ref()
                 .unwrap_or(&DEFAULT_MAINNET_RPC_URL.to_string()),
+            simnet.fork_slot,
         )?),
     };
 

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -273,10 +273,16 @@ impl SurfnetSvmLocker {
             (epoch_info, epoch_schedule, some_genesis_hash)
         };
         epoch_info.transaction_count = None;
+        let fork_clock = remote_client.get_fork_clock().await?;
 
         self.with_svm_writer(move |svm_writer| {
             svm_writer.cached_genesis_hash = some_genesis_hash;
             svm_writer.initialize(epoch_info, epoch_schedule);
+            if let Some(clock) = fork_clock {
+                svm_writer.updated_at = clock.unix_timestamp as u64 * 1_000;
+                svm_writer.genesis_updated_at = svm_writer.updated_at;
+                svm_writer.inner.set_sysvar(&clock);
+            }
         });
         Ok(())
     }
@@ -1599,6 +1605,32 @@ impl SurfnetSvmLocker {
         pubkey: &Pubkey,
         config: Option<&RpcSignaturesForAddressConfig>,
     ) -> SurfpoolContextualizedResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        let mut historical_config;
+        let config = if let Some((client, _)) = remote_ctx {
+            if client.fork_slot.is_some() {
+                historical_config = config.cloned().unwrap_or_default();
+                let limit = historical_config.limit.unwrap_or(1000);
+                if !(1..=1000).contains(&limit) {
+                    return Err(SurfpoolError::invalid_params(
+                        "Signature limit must be between 1 and 1000",
+                    ));
+                }
+                if historical_config
+                    .min_context_slot
+                    .take()
+                    .is_some_and(|minimum| minimum > self.get_latest_absolute_slot())
+                {
+                    return Err(SurfpoolError::invalid_params(
+                        "Minimum context slot has not been reached",
+                    ));
+                }
+                Some(&historical_config)
+            } else {
+                config
+            }
+        } else {
+            config
+        };
         let results = if let Some((remote_client, _)) = remote_ctx {
             self.get_signatures_for_address_local_then_remote(remote_client, pubkey, config)
                 .await?
@@ -2681,8 +2713,17 @@ impl SurfnetSvmLocker {
         };
         epoch_info.transaction_count = None;
 
+        let fork_clock = match remote_ctx {
+            Some(client) => client.get_fork_clock().await?,
+            None => None,
+        };
         self.with_svm_writer(move |svm_writer| {
             let _ = svm_writer.reset_network(epoch_info, epoch_schedule);
+            if let Some(clock) = fork_clock {
+                svm_writer.updated_at = clock.unix_timestamp as u64 * 1_000;
+                svm_writer.genesis_updated_at = svm_writer.updated_at;
+                svm_writer.inner.set_sysvar(&clock);
+            }
             let _ = svm_writer.offline_accounts.clear();
         });
         Ok(())
@@ -2900,8 +2941,19 @@ impl SurfnetSvmLocker {
             inner: local_accounts,
         } = self.get_token_accounts_by_owner_local(owner, filter, config)?;
 
+        let mut remote_config = config.clone();
+        if remote_client.fork_slot.is_some()
+            && remote_config
+                .min_context_slot
+                .take()
+                .is_some_and(|minimum| minimum > slot)
+        {
+            return Err(SurfpoolError::invalid_params(
+                "Minimum context slot has not been reached",
+            ));
+        }
         let remote_accounts = remote_client
-            .get_token_accounts_by_owner(owner, filter, config)
+            .get_token_accounts_by_owner(owner, filter, &remote_config)
             .await?;
 
         let mut combined_accounts = remote_accounts;
@@ -4710,6 +4762,7 @@ mod tests {
         let expected_hash = Hash::new_from_array([8; 32]);
         let requests = Arc::new(AtomicUsize::new(0));
         let remote_client = SurfnetRemoteClient {
+            fork_slot: None,
             client: RpcClient::new_sender(
                 StartupRpcSender {
                     genesis_hash: expected_hash,

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use serde_json::json;
@@ -18,7 +23,7 @@ use solana_client::{
         RpcTokenAccountBalance,
     },
 };
-use solana_clock::Slot;
+use solana_clock::{Clock, Slot};
 use solana_commitment_config::CommitmentConfig;
 use solana_epoch_info::EpochInfo;
 use solana_epoch_schedule::EpochSchedule;
@@ -33,6 +38,7 @@ use solana_rpc_client_api::client_error::{
     Error as ClientError, ErrorKind as ClientErrorKind, Result as ClientResult,
 };
 use solana_signature::Signature;
+use solana_sysvar_id::SysvarId;
 use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiConfirmedBlock};
 use surfpool_types::sanitized_datasource_url;
 
@@ -54,6 +60,7 @@ use crate::{
 const DATASOURCE_DEADLINE: Duration = Duration::from_secs(60);
 const DATASOURCE_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const DATASOURCE_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+const MAX_HISTORICAL_PAGES: usize = 1024;
 
 fn sanitized_client_error(error: &ClientError, datasource_url: &str) -> String {
     let endpoint =
@@ -157,6 +164,421 @@ impl<S: RpcSender + Send + Sync> RpcSender for DeadlineSender<S> {
     }
 }
 
+/// Pins account hydration and bounds remote history to one slot.
+/// Queries without a historical source fail rather than mixing current state into the fork.
+struct ForkSender<S> {
+    inner: S,
+    slot: Option<Slot>,
+    signature_cursors: Mutex<HashMap<Pubkey, (String, Slot)>>,
+}
+
+impl<S: RpcSender + Send + Sync> ForkSender<S> {
+    async fn transaction_slot(&self, signature: &str) -> ClientResult<Slot> {
+        Signature::from_str(signature)
+            .map_err(|_| ClientErrorKind::Custom("Invalid signature cursor".into()))?;
+        let response = self.inner.send(RpcRequest::GetTransaction,
+            json!([signature, {"encoding": "base64", "commitment": "finalized", "maxSupportedTransactionVersion": 0}])).await?;
+        response["slot"].as_u64().ok_or_else(|| {
+            ClientErrorKind::Custom("Cannot resolve historical signature cursor".into()).into()
+        })
+    }
+
+    async fn signatures(
+        &self,
+        params: serde_json::Value,
+        slot: Slot,
+    ) -> ClientResult<serde_json::Value> {
+        let address = params[0]
+            .as_str()
+            .ok_or_else(|| ClientErrorKind::Custom("Invalid address".into()))?;
+        let address_key = Pubkey::from_str(address)
+            .map_err(|_| ClientErrorKind::Custom("Invalid address".into()))?;
+        let mut config: RpcSignaturesForAddressConfig = if params[1].is_null() {
+            Default::default()
+        } else {
+            serde_json::from_value(params[1].clone())?
+        };
+        let limit = config.limit.unwrap_or(1000);
+        if !(1..=1000).contains(&limit) || config.min_context_slot.is_some_and(|min| min > slot) {
+            return Err(ClientErrorKind::Custom(
+                "Invalid limit or minimum context slot for historical signatures".into(),
+            )
+            .into());
+        }
+        let mut cursor_slot = u64::MAX;
+        let mut until_slot = None;
+        for (cursor, is_before) in [(&config.before, true), (&config.until, false)] {
+            if let Some(cursor) = cursor {
+                let resolved_slot = self.transaction_slot(cursor).await?;
+                if resolved_slot > slot {
+                    return Err(ClientErrorKind::Custom(
+                        "Signature cursor is after the fork slot".into(),
+                    )
+                    .into());
+                }
+                if is_before {
+                    cursor_slot = resolved_slot;
+                } else {
+                    until_slot = Some(resolved_slot);
+                }
+            }
+        }
+        if config.before.is_none()
+            && let Some((cursor, cached_slot)) =
+                self.signature_cursors.lock().unwrap().get(&address_key)
+        {
+            config.before = Some(cursor.clone());
+            cursor_slot = *cached_slot;
+        }
+        config.commitment = Some(CommitmentConfig::finalized());
+        config.min_context_slot = None;
+        config.limit = Some(1000);
+        let mut seen = HashSet::new();
+        if let Some(before) = &config.before {
+            seen.insert(before.clone());
+        }
+        let mut result = Vec::new();
+        for _ in 0..MAX_HISTORICAL_PAGES {
+            let response = self
+                .inner
+                .send(
+                    RpcRequest::GetSignaturesForAddress,
+                    json!([address, config]),
+                )
+                .await?;
+            let page: Vec<RpcConfirmedTransactionStatusWithSignature> =
+                serde_json::from_value(response)?;
+            if page.is_empty() {
+                return Ok(serde_json::to_value(result)?);
+            }
+            if page.len() > 1000 {
+                return Err(ClientErrorKind::Custom("Oversized signature page".into()).into());
+            }
+            for entry in &page {
+                if entry.slot > cursor_slot
+                    || until_slot.is_some_and(|until| entry.slot < until)
+                    || config.until.as_ref() == Some(&entry.signature)
+                    || Signature::from_str(&entry.signature).is_err()
+                    || !seen.insert(entry.signature.clone())
+                {
+                    return Err(ClientErrorKind::Custom(
+                        "Invalid or repeating historical signature page".into(),
+                    )
+                    .into());
+                }
+                cursor_slot = entry.slot;
+            }
+            // Binary search the descending page for the first signature at or before S.
+            let cutoff = page.partition_point(|entry| entry.slot > slot);
+            if cutoff > 0 {
+                let mut cursors = self.signature_cursors.lock().unwrap();
+                if cursors.len() >= 1024 && !cursors.contains_key(&address_key) {
+                    cursors.clear();
+                }
+                let boundary = &page[cutoff - 1];
+                cursors.insert(address_key, (boundary.signature.clone(), boundary.slot));
+            }
+            config.before = page.last().map(|entry| entry.signature.clone());
+            result.extend(page.into_iter().skip(cutoff).take(limit - result.len()));
+            if result.len() == limit {
+                return Ok(serde_json::to_value(result)?);
+            }
+        }
+        Err(ClientErrorKind::Custom(
+            "Historical signature pagination exceeded its page budget".into(),
+        )
+        .into())
+    }
+
+    async fn token_accounts_by_owner(
+        &self,
+        params: serde_json::Value,
+        slot: Slot,
+    ) -> ClientResult<serde_json::Value> {
+        let mut config = params[2].clone();
+        if config.is_null() {
+            config = json!({});
+        }
+        if !config.is_object() {
+            return Err(ClientErrorKind::Custom("Invalid account config".into()).into());
+        }
+        if config["minContextSlot"]
+            .as_u64()
+            .is_some_and(|min| min > slot)
+        {
+            return Err(
+                ClientErrorKind::Custom("Minimum context slot is after the fork".into()).into(),
+            );
+        }
+        let mut cursor = serde_json::Value::Null;
+        let mut cursors = HashSet::new();
+        let mut keys = HashSet::new();
+        let mut result = Vec::new();
+        for _ in 0..MAX_HISTORICAL_PAGES {
+            let mut archive_config = json!({"slot": slot, "pageLimit": 1000});
+            if !cursor.is_null() {
+                archive_config["pageKey"] = cursor;
+            }
+            let response = self
+                .inner
+                .send(
+                    RpcRequest::Custom {
+                        method: "getTokenAccountsByOwnerAtSlot",
+                    },
+                    json!([params[0], params[1], archive_config]),
+                )
+                .await?;
+            if response["context"]["slot"].as_u64() != Some(slot) {
+                return Err(ClientErrorKind::Custom(
+                    "Token account page is not at the fork slot".into(),
+                )
+                .into());
+            }
+            let page = response["value"]
+                .as_array()
+                .ok_or_else(|| ClientErrorKind::Custom("Invalid token account page".into()))?;
+            if page.len() > 1000 {
+                return Err(ClientErrorKind::Custom("Oversized token account page".into()).into());
+            }
+            for entry in page {
+                let key = entry["pubkey"].as_str().ok_or_else(|| {
+                    ClientErrorKind::Custom("Missing token account pubkey".into())
+                })?;
+                if Pubkey::from_str(key).is_err() || !keys.insert(key.to_owned()) {
+                    return Err(ClientErrorKind::Custom(
+                        "Invalid or repeating token account".into(),
+                    )
+                    .into());
+                }
+            }
+            // Discovery returns jsonParsed only. Read bytes at S to preserve the requested encoding/dataSlice.
+            for chunk in page.chunks(100) {
+                let accounts = jsonrpc_core::futures::future::try_join_all(
+                    chunk
+                        .iter()
+                        .map(|entry| self.account(entry["pubkey"].clone(), config.clone(), slot)),
+                )
+                .await?;
+                for (entry, account) in chunk.iter().zip(accounts) {
+                    if account["value"].is_null() {
+                        return Err(ClientErrorKind::Custom(
+                            "Historical token account disappeared during hydration".into(),
+                        )
+                        .into());
+                    }
+                    result.push(json!({"pubkey": entry["pubkey"], "account": account["value"]}));
+                }
+            }
+            cursor = response
+                .get("pageKey")
+                .cloned()
+                .ok_or_else(|| ClientErrorKind::Custom("Missing token pagination cursor".into()))?;
+            if cursor.is_null() {
+                return Ok(json!({"context": {"slot": slot}, "value": result}));
+            }
+            let next = cursor
+                .as_str()
+                .filter(|next| !next.is_empty())
+                .ok_or_else(|| ClientErrorKind::Custom("Invalid token pagination cursor".into()))?;
+            if !cursors.insert(next.to_owned()) {
+                return Err(
+                    ClientErrorKind::Custom("Repeating token pagination cursor".into()).into(),
+                );
+            }
+        }
+        Err(
+            ClientErrorKind::Custom("Historical token pagination exceeded its page budget".into())
+                .into(),
+        )
+    }
+    async fn account(
+        &self,
+        pubkey: serde_json::Value,
+        mut config: serde_json::Value,
+        slot: Slot,
+    ) -> ClientResult<serde_json::Value> {
+        if config.is_null() {
+            config = json!({});
+        }
+        let config = config
+            .as_object_mut()
+            .ok_or_else(|| ClientErrorKind::Custom("Invalid account config".into()))?;
+        if config
+            .get("minContextSlot")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|minimum| minimum > slot)
+        {
+            return Err(
+                ClientErrorKind::Custom("Minimum context slot is after the fork".into()).into(),
+            );
+        }
+        config.remove("minContextSlot");
+        config.insert("slot".into(), json!(slot));
+        config.insert("commitment".into(), json!("finalized"));
+        let response = self
+            .inner
+            .send(RpcRequest::GetAccountInfo, json!([pubkey, config]))
+            .await?;
+        if response["context"]["slot"].as_u64() != Some(slot) || response.get("value").is_none() {
+            return Err(ClientErrorKind::Custom(format!("Datasource did not return account state at fork slot {slot}; an account archive RPC is required")).into());
+        }
+        Ok(response)
+    }
+}
+
+#[async_trait]
+impl<S: RpcSender + Send + Sync> RpcSender for ForkSender<S> {
+    async fn send(
+        &self,
+        request: RpcRequest,
+        mut params: serde_json::Value,
+    ) -> ClientResult<serde_json::Value> {
+        let Some(slot) = self.slot else {
+            return self.inner.send(request, params).await;
+        };
+        if matches!(request, RpcRequest::GetBlock | RpcRequest::GetTransaction) {
+            let args = params
+                .as_array_mut()
+                .filter(|args| (1..=2).contains(&args.len()))
+                .ok_or_else(|| {
+                    ClientErrorKind::Custom("Invalid historical request parameters".into())
+                })?;
+            if args.len() == 1 {
+                args.push(json!({}));
+            }
+            if args[1].is_null() {
+                args[1] = json!({});
+            }
+            let config = args[1].as_object_mut().ok_or_else(|| {
+                ClientErrorKind::Custom("Invalid historical request config".into())
+            })?;
+            config.insert("commitment".into(), json!("finalized"));
+        }
+        match request {
+            RpcRequest::GetSignaturesForAddress => self.signatures(params, slot).await,
+            RpcRequest::GetTokenAccountsByOwner => self.token_accounts_by_owner(params, slot).await,
+            RpcRequest::GetBlocks | RpcRequest::GetBlocksWithLimit => {
+                let start = params[0]
+                    .as_u64()
+                    .ok_or_else(|| ClientErrorKind::Custom("Invalid block start slot".into()))?;
+                if start > slot {
+                    return Ok(json!([]));
+                }
+                let (end, limit, query) = if request == RpcRequest::GetBlocks {
+                    let end = if params[1].is_null() || params[1].is_object() {
+                        slot
+                    } else {
+                        params[1]
+                            .as_u64()
+                            .ok_or_else(|| {
+                                ClientErrorKind::Custom("Invalid block end slot".into())
+                            })?
+                            .min(slot)
+                    };
+                    if end < start {
+                        return Ok(json!([]));
+                    }
+                    (
+                        end,
+                        500_001,
+                        json!([start, end, {"commitment": "finalized"}]),
+                    )
+                } else {
+                    let limit = params[1]
+                        .as_u64()
+                        .filter(|limit| *limit <= 500_000)
+                        .ok_or_else(|| ClientErrorKind::Custom("Invalid block limit".into()))?
+                        as usize;
+                    (
+                        u64::MAX,
+                        limit,
+                        json!([start, limit, {"commitment": "finalized"}]),
+                    )
+                };
+                let blocks: Vec<Slot> =
+                    serde_json::from_value(self.inner.send(request, query).await?)?;
+                if blocks.len() > limit
+                    || blocks.iter().any(|block| *block < start || *block > end)
+                    || blocks.windows(2).any(|pair| pair[0] >= pair[1])
+                {
+                    return Err(
+                        ClientErrorKind::Custom("Invalid historical block list".into()).into(),
+                    );
+                }
+                Ok(serde_json::to_value(
+                    blocks
+                        .into_iter()
+                        .take_while(|block| *block <= slot)
+                        .collect::<Vec<_>>(),
+                )?)
+            }
+            RpcRequest::GetAccountInfo => {
+                self.account(params[0].clone(), params[1].clone(), slot)
+                    .await
+            }
+            RpcRequest::GetMultipleAccounts => {
+                let pubkeys = params[0]
+                    .as_array()
+                    .ok_or_else(|| ClientErrorKind::Custom("Invalid account list".into()))?;
+                // Archive providers may only support historical getAccountInfo.
+                let responses = jsonrpc_core::futures::future::try_join_all(
+                    pubkeys
+                        .iter()
+                        .map(|pubkey| self.account(pubkey.clone(), params[1].clone(), slot)),
+                )
+                .await?;
+                let values: Vec<_> = responses
+                    .into_iter()
+                    .map(|response| response["value"].clone())
+                    .collect();
+                Ok(json!({"context": {"slot": slot}, "value": values}))
+            }
+            RpcRequest::GetBlock | RpcRequest::GetBlockTime => {
+                let requested_slot = params[0]
+                    .as_u64()
+                    .ok_or_else(|| ClientErrorKind::Custom("Invalid block slot".into()))?;
+                if requested_slot > slot {
+                    return Err(ClientErrorKind::Custom(format!(
+                        "Block {requested_slot} is after fork slot {slot}"
+                    ))
+                    .into());
+                }
+                self.inner.send(request, params).await
+            }
+            RpcRequest::GetTransaction => {
+                let response = self.inner.send(request, params).await?;
+                if !response.is_null() {
+                    let transaction_slot = response["slot"].as_u64().ok_or_else(|| {
+                        ClientErrorKind::Custom("Transaction slot unavailable".into())
+                    })?;
+                    if transaction_slot > slot {
+                        return Err(ClientErrorKind::Custom(format!(
+                            "Transaction is after fork slot {slot}"
+                        ))
+                        .into());
+                    }
+                }
+                Ok(response)
+            }
+            RpcRequest::GetVersion | RpcRequest::GetGenesisHash | RpcRequest::GetEpochSchedule => {
+                self.inner.send(request, params).await
+            }
+            // "Unavailable" errors trigger callers' fallback to local-only results.
+            _ => Err(ClientErrorKind::Custom(format!(
+                "Cannot answer {request} at fork slot {slot}"
+            ))
+            .into()),
+        }
+    }
+
+    fn get_transport_stats(&self) -> RpcTransportStats {
+        self.inner.get_transport_stats()
+    }
+    fn url(&self) -> String {
+        self.inner.url()
+    }
+}
+
 /// The RPC client a surfnet reaches its datasource through: an HTTP transport
 /// wrapped in a [`DeadlineSender`], assembled behind one constructor so that
 /// layers added later (tracing, recording, a retry policy) land here without
@@ -166,14 +588,21 @@ struct SurfpoolRpcClient {
 }
 
 impl SurfpoolRpcClient {
-    fn try_new<U: ToString>(remote_rpc_url: U) -> Result<Self, reqwest::Error> {
+    fn try_new<U: ToString>(
+        remote_rpc_url: U,
+        fork_slot: Option<Slot>,
+    ) -> Result<Self, reqwest::Error> {
         let client = reqwest::Client::builder()
             .default_headers(HttpSender::default_headers())
             .timeout(DATASOURCE_HTTP_TIMEOUT)
             .pool_idle_timeout(DATASOURCE_POOL_IDLE_TIMEOUT)
             .build()?;
         let sender = DeadlineSender::new(
-            HttpSender::new_with_client(remote_rpc_url, client),
+            ForkSender {
+                inner: HttpSender::new_with_client(remote_rpc_url, client),
+                slot: fork_slot,
+                signature_cursors: Mutex::default(),
+            },
             DATASOURCE_DEADLINE,
         );
         let client = RpcClient::new_sender(
@@ -186,6 +615,7 @@ impl SurfpoolRpcClient {
 
 #[derive(Clone)]
 pub struct SurfnetRemoteClient {
+    pub fork_slot: Option<Slot>,
     pub client: Arc<RpcClient>,
 }
 
@@ -206,13 +636,64 @@ impl SurfnetRemoteClient {
     }
 
     pub fn try_new<U: ToString>(remote_rpc_url: U) -> Result<Self, reqwest::Error> {
-        SurfpoolRpcClient::try_new(remote_rpc_url).map(|rpc_client| SurfnetRemoteClient {
-            client: Arc::new(rpc_client.client),
+        Self::try_new_at_slot(remote_rpc_url, None)
+    }
+
+    pub fn try_new_at_slot<U: ToString>(
+        remote_rpc_url: U,
+        fork_slot: Option<Slot>,
+    ) -> Result<Self, reqwest::Error> {
+        SurfpoolRpcClient::try_new(remote_rpc_url, fork_slot).map(|rpc_client| {
+            SurfnetRemoteClient {
+                fork_slot,
+                client: Arc::new(rpc_client.client),
+            }
         })
     }
 
     pub async fn get_epoch_info(&self) -> SurfpoolResult<EpochInfo> {
-        self.client.get_epoch_info().await.map_err(Into::into)
+        let Some(slot) = self.fork_slot else {
+            return self.client.get_epoch_info().await.map_err(Into::into);
+        };
+        let schedule = self.get_epoch_schedule().await?;
+        let block = self
+            .get_block(
+                &slot,
+                RpcBlockConfig {
+                    commitment: Some(CommitmentConfig::finalized()),
+                    transaction_details: Some(solana_transaction_status::TransactionDetails::None),
+                    rewards: Some(false),
+                    max_supported_transaction_version: Some(0),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        let (epoch, slot_index) = schedule.get_epoch_and_slot_index(slot);
+        Ok(EpochInfo {
+            absolute_slot: slot,
+            block_height: block
+                .block_height
+                .ok_or_else(|| SurfpoolError::internal("Fork block height unavailable"))?,
+            epoch,
+            slot_index,
+            slots_in_epoch: schedule.get_slots_in_epoch(epoch),
+            transaction_count: None,
+        })
+    }
+
+    pub async fn get_fork_clock(&self) -> SurfpoolResult<Option<Clock>> {
+        let Some(slot) = self.fork_slot else {
+            return Ok(None);
+        };
+        let account = self.client.get_account(&Clock::id()).await?;
+        let clock: Clock = bincode::deserialize(&account.data)
+            .map_err(|e| SurfpoolError::internal(e.to_string()))?;
+        if clock.slot != slot || clock.unix_timestamp < 0 {
+            return Err(SurfpoolError::internal(
+                "Archive returned an invalid fork Clock",
+            ));
+        }
+        Ok(Some(clock))
     }
 
     pub async fn get_epoch_schedule(&self) -> SurfpoolResult<EpochSchedule> {
@@ -493,8 +974,9 @@ impl SurfnetRemoteClient {
             Ok(res) => Ok(res.value),
             // A mint that exists only on this surfnet is `could not find mint` upstream. That is
             // a definite "no remote accounts", not a failed lookup, and must not discard the
-            // local accounts the caller merges with.
-            Err(e) if is_unknown_mint(filter, &e) => {
+            // local accounts the caller merges with. Historical walks propagate errors since
+            // an error may come from a later page or account hydration.
+            Err(e) if self.fork_slot.is_none() && is_unknown_mint(filter, &e) => {
                 log::debug!(
                     "datasource does not know the mint in getTokenAccountsByOwner for {owner}; \
                      answering from local accounts only"
@@ -595,6 +1077,16 @@ impl SurfnetRemoteClient {
         pubkey: &Pubkey,
         config: Option<&RpcSignaturesForAddressConfig>,
     ) -> SurfpoolResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        if self.fork_slot.is_some() {
+            return self
+                .client
+                .send(
+                    RpcRequest::GetSignaturesForAddress,
+                    json!([pubkey.to_string(), config]),
+                )
+                .await
+                .map_err(SurfpoolError::get_signatures_for_address);
+        }
         let c = match config {
             Some(c) => GetConfirmedSignaturesForAddress2Config {
                 before: c
@@ -614,6 +1106,32 @@ impl SurfnetRemoteClient {
             .get_signatures_for_address_with_config(pubkey, c)
             .await
             .map_err(SurfpoolError::get_signatures_for_address)
+    }
+
+    pub async fn get_block_time(&self, slot: Slot) -> SurfpoolResult<Option<i64>> {
+        self.client
+            .send(RpcRequest::GetBlockTime, json!([slot]))
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Historical lookup failures must not become incomplete block lists.
+    pub async fn get_blocks(&self, start: Slot, end: Option<Slot>) -> SurfpoolResult<Vec<Slot>> {
+        match self.client.get_blocks(start, end).await {
+            Err(_) if self.fork_slot.is_none() => Ok(vec![]), // Preserve the live datasource fallback.
+            result => result.map_err(Into::into),
+        }
+    }
+
+    pub async fn get_blocks_with_limit(
+        &self,
+        start: Slot,
+        limit: usize,
+    ) -> SurfpoolResult<Vec<Slot>> {
+        self.client
+            .send(RpcRequest::GetBlocksWithLimit, json!([start, limit]))
+            .await
+            .map_err(Into::into)
     }
 
     pub async fn get_block(
@@ -653,6 +1171,802 @@ mod tests {
 
     use super::*;
     use crate::surfnet::{locker::SurfnetSvmLocker, svm::SurfnetSvm};
+
+    const FORK_SLOT: u64 = 1_000_000;
+
+    struct ArchiveRpc {
+        slot: u64,
+        program: Pubkey,
+    }
+
+    #[async_trait]
+    impl RpcSender for ArchiveRpc {
+        async fn send(
+            &self,
+            request: RpcRequest,
+            params: serde_json::Value,
+        ) -> ClientResult<serde_json::Value> {
+            use base64::{Engine, engine::general_purpose::STANDARD};
+            Ok(match request {
+                RpcRequest::GetAccountInfo => {
+                    assert_eq!(params[1]["slot"], FORK_SLOT);
+                    assert_eq!(params[1]["commitment"], "finalized");
+                    assert!(params[1].get("minContextSlot").is_none());
+                    let data = if params[0] == Clock::id().to_string() {
+                        bincode::serialize(&Clock {
+                            slot: FORK_SLOT,
+                            epoch: 2,
+                            unix_timestamp: 1_600_000_000,
+                            ..Clock::default()
+                        })
+                        .unwrap()
+                    } else {
+                        vec![1, 2, 3]
+                    };
+                    let value = if params[0] == "missing" {
+                        serde_json::Value::Null
+                    } else {
+                        json!({"lamports": 1_000_000, "owner": Pubkey::default().to_string(),
+                            "data": [STANDARD.encode(data), "base64"], "rentEpoch": 0,
+                            "executable": params[0] == self.program.to_string()})
+                    };
+                    json!({"context": {"slot": self.slot}, "value": value})
+                }
+                RpcRequest::GetSignaturesForAddress => {
+                    if params[1]["before"].as_str().is_some() {
+                        json!([])
+                    } else {
+                        json!([signature_row(99, FORK_SLOT - 1)])
+                    }
+                }
+                RpcRequest::GetTransaction => json!({"slot": self.slot}),
+                RpcRequest::GetEpochSchedule => {
+                    serde_json::to_value(EpochSchedule::without_warmup()).unwrap()
+                }
+                RpcRequest::GetGenesisHash => json!(Hash::default().to_string()),
+                RpcRequest::GetVersion => json!({"solana-core": "4.2.0", "feature-set": 0}),
+                RpcRequest::GetBlock => {
+                    assert_eq!(params[0], FORK_SLOT);
+                    json!({"blockhash": Hash::default().to_string(), "previousBlockhash": Hash::default().to_string(),
+                        "parentSlot": FORK_SLOT - 1, "blockHeight": 900_000, "blockTime": 1_600_000_000})
+                }
+                _ => panic!("unexpected archive request: {request}"),
+            })
+        }
+        fn get_transport_stats(&self) -> RpcTransportStats {
+            RpcTransportStats::default()
+        }
+        fn url(&self) -> String {
+            "http://archive.example".into()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fork_slot_pins_accounts_dependencies_and_startup() {
+        use solana_keypair::Keypair;
+        use solana_signer::Signer;
+        use solana_transaction::Transaction;
+
+        let program = Pubkey::new_unique();
+        let client = SurfnetRemoteClient {
+            fork_slot: Some(FORK_SLOT),
+            client: RpcClient::new_sender(
+                ForkSender {
+                    inner: ArchiveRpc {
+                        slot: FORK_SLOT,
+                        program,
+                    },
+                    slot: Some(FORK_SLOT),
+                    signature_cursors: Mutex::default(),
+                },
+                RpcClientConfig::default(),
+            )
+            .into(),
+        };
+        let program_data = get_program_data_address(&program);
+        for result in [
+            client
+                .get_account(&program, CommitmentConfig::processed())
+                .await
+                .unwrap(),
+            client
+                .get_multiple_accounts(&[program], CommitmentConfig::confirmed())
+                .await
+                .unwrap()
+                .remove(0),
+        ] {
+            assert!(
+                matches!(result, GetAccountResult::FoundCoupledAccount(_, CoupledAccount::ProgramData(key, Some(_)), _) if key == program_data)
+            );
+        }
+
+        let missing: serde_json::Value = client.client.send(RpcRequest::GetMultipleAccounts,
+            json!([["missing", program.to_string()], {"encoding": "base64", "minContextSlot": FORK_SLOT}])).await.unwrap();
+        assert!(missing["value"][0].is_null());
+        assert_eq!(missing["value"][1]["executable"], true);
+
+        let (svm, _, _) = SurfnetSvm::default();
+        let locker = SurfnetSvmLocker::new(svm);
+        let remote = Some(client);
+        locker.initialize(&remote).await.unwrap();
+        for reset in [false, true] {
+            if reset {
+                locker.reset_network(&remote).await.unwrap();
+            }
+            assert_eq!(locker.get_epoch_info().absolute_slot, FORK_SLOT);
+            assert_eq!(locker.get_epoch_info().block_height, 900_000);
+            locker.with_svm_reader(|svm| {
+                assert_eq!(svm.inner.get_sysvar::<Clock>().slot, FORK_SLOT);
+                assert_eq!(
+                    svm.inner.get_sysvar::<Clock>().unix_timestamp,
+                    1_600_000_000
+                );
+                assert_eq!(
+                    svm.calculate_block_time_for_slot(FORK_SLOT),
+                    1_600_000_000_000
+                );
+            });
+        }
+
+        // Advancing and transacting locally must not advance lazy remote reads.
+        locker
+            .with_svm_writer(|svm| svm.confirm_current_block())
+            .unwrap();
+        assert_eq!(locker.get_latest_absolute_slot(), FORK_SLOT + 1);
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        locker
+            .airdrop(&payer.pubkey(), 10_000_000)
+            .unwrap()
+            .unwrap();
+        locker.airdrop(&recipient, 1_000_000).unwrap().unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[solana_system_interface::instruction::transfer(
+                &payer.pubkey(),
+                &recipient,
+                1_000_000,
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            locker.latest_absolute_blockhash(),
+        );
+        let signature = tx.signatures[0];
+        let context = remote
+            .clone()
+            .map(|client| (client, CommitmentConfig::processed()));
+        let (status_tx, _) = crossbeam_channel::unbounded();
+        locker
+            .process_transaction(&context, tx.into(), status_tx, true, true)
+            .await
+            .unwrap();
+        let balance = locker
+            .get_account(&context, &recipient, None)
+            .await
+            .unwrap()
+            .inner
+            .map_account()
+            .unwrap()
+            .lamports;
+        assert_eq!(balance, 2_000_000);
+        assert!(
+            !locker
+                .get_transaction(&remote, &signature, RpcTransactionConfig::default())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let signatures = locker
+            .get_signatures_for_address(
+                &remote.clone().map(|client| (client, ())),
+                &recipient,
+                Some(&RpcSignaturesForAddressConfig {
+                    min_context_slot: Some(FORK_SLOT + 1),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap()
+            .inner;
+        assert!(
+            signatures
+                .iter()
+                .any(|row| row.signature == signature.to_string())
+        );
+        assert_eq!(signatures.last().unwrap().slot, FORK_SLOT - 1);
+        // ArchiveRpc asserts that this newly fetched account still requests FORK_SLOT.
+        let account = locker
+            .get_account(&context, &Pubkey::new_unique(), None)
+            .await
+            .unwrap();
+        assert_eq!(account.inner.map_account().unwrap().lamports, 1_000_000);
+    }
+
+    #[tokio::test]
+    async fn fork_slot_rejects_latest_state_and_unsupported_queries() {
+        let sender = ForkSender {
+            inner: ArchiveRpc {
+                slot: FORK_SLOT + 1,
+                program: Pubkey::new_unique(),
+            },
+            slot: Some(FORK_SLOT),
+            signature_cursors: Mutex::default(),
+        };
+        for (method, params) in [
+            (RpcRequest::GetBlock, json!([FORK_SLOT + 1, {}])),
+            (RpcRequest::GetBlockTime, json!([FORK_SLOT + 1])),
+            (RpcRequest::GetTransaction, json!(["signature", {}])),
+            (
+                RpcRequest::GetAccountInfo,
+                json!(["missing", {"minContextSlot": FORK_SLOT + 1}]),
+            ),
+        ] {
+            assert!(sender.send(method, params).await.is_err());
+        }
+        for transaction_slot in [FORK_SLOT - 1, FORK_SLOT] {
+            let historical = ForkSender {
+                inner: ArchiveRpc {
+                    slot: transaction_slot,
+                    program: Pubkey::new_unique(),
+                },
+                slot: Some(FORK_SLOT),
+                signature_cursors: Mutex::default(),
+            };
+            let response = historical
+                .send(RpcRequest::GetTransaction, json!(["signature"]))
+                .await
+                .unwrap();
+            assert_eq!(response["slot"], transaction_slot);
+        }
+        for params in [json!(null), json!([]), json!([FORK_SLOT, "invalid"])] {
+            assert!(sender.send(RpcRequest::GetBlock, params).await.is_err());
+        }
+        for method in [RpcRequest::GetAccountInfo, RpcRequest::GetMultipleAccounts] {
+            let params = if method == RpcRequest::GetAccountInfo {
+                json!(["missing"])
+            } else {
+                json!([["missing"]])
+            };
+            assert!(
+                sender
+                    .send(method, params)
+                    .await
+                    .unwrap_err()
+                    .to_string()
+                    .contains("fork slot")
+            );
+        }
+        for method in [
+            RpcRequest::GetProgramAccounts,
+            RpcRequest::GetLargestAccounts,
+            RpcRequest::GetSignatureStatuses,
+        ] {
+            let error = sender.send(method, json!([])).await.unwrap_err();
+            assert!(error.to_string().contains("Cannot answer"));
+            assert!(!is_method_not_supported_error(&error));
+        }
+        let malformed = ForkSender {
+            inner: ReturnsNull {
+                requests: Arc::default(),
+            },
+            slot: Some(FORK_SLOT),
+            signature_cursors: Mutex::default(),
+        };
+        assert!(
+            malformed
+                .send(RpcRequest::GetAccountInfo, json!(["missing"]))
+                .await
+                .is_err()
+        );
+        let unavailable = ForkSender {
+            inner: ReturnsError,
+            slot: Some(FORK_SLOT),
+            signature_cursors: Mutex::default(),
+        };
+        assert!(
+            unavailable
+                .send(RpcRequest::GetAccountInfo, json!(["missing"]))
+                .await
+                .is_err()
+        );
+        let requests = Arc::default();
+        let ordinary = ForkSender {
+            inner: ReturnsNull {
+                requests: Arc::clone(&requests),
+            },
+            slot: None,
+            signature_cursors: Mutex::default(),
+        };
+        ordinary
+            .send(RpcRequest::GetProgramAccounts, json!(["program"]))
+            .await
+            .unwrap();
+        assert_eq!(
+            requests.lock().unwrap()[0],
+            (RpcRequest::GetProgramAccounts, json!(["program"]))
+        );
+    }
+
+    #[tokio::test]
+    async fn historical_scan_failures_cannot_become_local_only_results() {
+        for fork_slot in [None, Some(FORK_SLOT)] {
+            let client = SurfnetRemoteClient {
+                fork_slot,
+                client: RpcClient::new_sender(
+                    ForkSender {
+                        inner: ReturnsError,
+                        slot: fork_slot,
+                        signature_cursors: Mutex::default(),
+                    },
+                    RpcClientConfig::default(),
+                )
+                .into(),
+            };
+            let program_accounts = client
+                .get_program_accounts(&Pubkey::new_unique(), RpcAccountInfoConfig::default(), None)
+                .await;
+            let largest_accounts = client.get_largest_accounts(None).await;
+            if fork_slot.is_some() {
+                assert!(program_accounts.is_err());
+                assert!(largest_accounts.is_err());
+            } else {
+                assert!(matches!(
+                    program_accounts,
+                    Ok(RemoteRpcResult::MethodNotSupported)
+                ));
+                assert!(matches!(
+                    largest_accounts,
+                    Ok(RemoteRpcResult::MethodNotSupported)
+                ));
+            }
+        }
+    }
+
+    struct ScriptedHistory {
+        responses: Mutex<std::collections::VecDeque<ClientResult<serde_json::Value>>>,
+        requests: Mutex<Vec<(RpcRequest, serde_json::Value)>>,
+    }
+
+    #[async_trait]
+    impl RpcSender for ScriptedHistory {
+        async fn send(
+            &self,
+            request: RpcRequest,
+            params: serde_json::Value,
+        ) -> ClientResult<serde_json::Value> {
+            self.requests.lock().unwrap().push((request, params));
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("unexpected datasource request")
+        }
+        fn get_transport_stats(&self) -> RpcTransportStats {
+            RpcTransportStats::default()
+        }
+        fn url(&self) -> String {
+            "http://history.example".into()
+        }
+    }
+
+    fn history(responses: Vec<ClientResult<serde_json::Value>>) -> ForkSender<ScriptedHistory> {
+        ForkSender {
+            inner: ScriptedHistory {
+                responses: Mutex::new(responses.into()),
+                requests: Mutex::default(),
+            },
+            slot: Some(FORK_SLOT),
+            signature_cursors: Mutex::default(),
+        }
+    }
+
+    fn signature_row(n: u8, slot: Slot) -> serde_json::Value {
+        json!({"signature": Signature::from([n; 64]).to_string(), "slot": slot,
+            "err": null, "memo": null, "blockTime": null, "confirmationStatus": "finalized"})
+    }
+
+    #[tokio::test]
+    async fn historical_signatures_fill_pages_and_reuse_the_cutoff() {
+        let rows = [
+            signature_row(1, FORK_SLOT + 2),
+            signature_row(2, FORK_SLOT + 1),
+            signature_row(3, FORK_SLOT),
+            signature_row(4, FORK_SLOT),
+            signature_row(5, FORK_SLOT - 1),
+        ];
+        let sender = history(vec![
+            Ok(json!([rows[0]])),
+            Ok(json!([rows[1], rows[2]])),
+            Ok(json!([rows[3], rows[4]])),
+            Ok(json!([rows[2], rows[3], rows[4]])),
+        ]);
+        let query = json!([Pubkey::new_unique().to_string(), {"limit": 3}]);
+        for _ in 0..2 {
+            let result = sender
+                .send(RpcRequest::GetSignaturesForAddress, query.clone())
+                .await
+                .unwrap();
+            assert_eq!(
+                result
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|row| row["signature"].clone())
+                    .collect::<Vec<_>>(),
+                rows[2..]
+                    .iter()
+                    .map(|row| row["signature"].clone())
+                    .collect::<Vec<_>>()
+            );
+        }
+        let requests = sender.inner.requests.lock().unwrap();
+        assert_eq!(requests.len(), 4);
+        assert_eq!(requests[1].1[1]["before"], rows[0]["signature"]);
+        assert_eq!(requests[2].1[1]["before"], rows[2]["signature"]);
+        assert_eq!(requests[3].1[1]["before"], rows[1]["signature"]);
+        for (_, params) in requests.iter() {
+            assert_eq!(params[1]["commitment"], "finalized");
+            assert_eq!(params[1]["limit"], 1000);
+        }
+    }
+
+    #[tokio::test]
+    async fn historical_signature_cursors_are_exclusive_and_resolved_at_the_fork() {
+        let before = signature_row(1, FORK_SLOT);
+        let until = signature_row(4, FORK_SLOT - 1);
+        let row = signature_row(2, FORK_SLOT);
+        let sender = history(vec![
+            Ok(json!({"slot": FORK_SLOT})),
+            Ok(json!({"slot": FORK_SLOT - 1})),
+            Ok(json!([row])),
+            Ok(json!([])),
+        ]);
+        let result = sender.send(RpcRequest::GetSignaturesForAddress,
+            json!([Pubkey::new_unique().to_string(), {"before": before["signature"], "until": until["signature"]}])).await.unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 1);
+        {
+            let requests = sender.inner.requests.lock().unwrap();
+            assert_eq!(requests[2].1[1]["before"], before["signature"]);
+            assert_eq!(requests[3].1[1]["before"], row["signature"]);
+            assert_eq!(requests[3].1[1]["until"], until["signature"]);
+        }
+        for resolved in [json!(null), json!({"slot": FORK_SLOT + 1})] {
+            let sender = history(vec![Ok(resolved)]);
+            assert!(
+                sender
+                    .send(
+                        RpcRequest::GetSignaturesForAddress,
+                        json!([Pubkey::new_unique().to_string(), {"before": before["signature"]}])
+                    )
+                    .await
+                    .is_err()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn historical_signatures_reject_incomplete_or_disordered_history() {
+        let row = signature_row(1, FORK_SLOT);
+        for responses in [
+            vec![Ok(json!([row])), Ok(json!([row]))],
+            vec![Ok(json!([row, signature_row(2, FORK_SLOT + 1)]))],
+            vec![
+                Ok(json!([row])),
+                Err(ClientErrorKind::Custom("unavailable".into()).into()),
+            ],
+        ] {
+            let sender = history(responses);
+            assert!(
+                sender
+                    .send(
+                        RpcRequest::GetSignaturesForAddress,
+                        json!([Pubkey::new_unique().to_string(), {"limit": 3}])
+                    )
+                    .await
+                    .is_err()
+            );
+        }
+        // A failed walk retains safe progress through future history for the next attempt.
+        let future = signature_row(3, FORK_SLOT + 1);
+        let sender = history(vec![
+            Ok(json!([future])),
+            Err(ClientErrorKind::Custom("unavailable".into()).into()),
+            Ok(json!([row])),
+        ]);
+        let query = json!([Pubkey::new_unique().to_string(), {"limit": 1}]);
+        assert!(
+            sender
+                .send(RpcRequest::GetSignaturesForAddress, query.clone())
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            sender
+                .send(RpcRequest::GetSignaturesForAddress, query)
+                .await
+                .unwrap()[0]["signature"],
+            row["signature"]
+        );
+        assert_eq!(
+            sender.inner.requests.lock().unwrap()[2].1[1]["before"],
+            future["signature"]
+        );
+    }
+
+    #[tokio::test]
+    async fn historical_block_ranges_are_bounded_and_validate_order() {
+        let sender = history(vec![
+            Ok(json!([FORK_SLOT - 2, FORK_SLOT])),
+            Ok(json!([FORK_SLOT - 2, FORK_SLOT, FORK_SLOT + 1])),
+        ]);
+        assert_eq!(
+            sender
+                .send(
+                    RpcRequest::GetBlocks,
+                    json!([FORK_SLOT - 2, FORK_SLOT + 10])
+                )
+                .await
+                .unwrap(),
+            json!([FORK_SLOT - 2, FORK_SLOT])
+        );
+        assert_eq!(
+            sender
+                .send(RpcRequest::GetBlocksWithLimit, json!([FORK_SLOT - 2, 3]))
+                .await
+                .unwrap(),
+            json!([FORK_SLOT - 2, FORK_SLOT])
+        );
+        assert_eq!(
+            sender.inner.requests.lock().unwrap()[0].1,
+            json!([FORK_SLOT - 2, FORK_SLOT, {"commitment": "finalized"}])
+        );
+        assert_eq!(
+            sender
+                .send(RpcRequest::GetBlocks, json!([FORK_SLOT + 1]))
+                .await
+                .unwrap(),
+            json!([])
+        );
+        for invalid in [
+            json!([FORK_SLOT + 1]),
+            json!([FORK_SLOT, FORK_SLOT - 1]),
+            json!([FORK_SLOT, FORK_SLOT]),
+        ] {
+            assert!(
+                history(vec![Ok(invalid)])
+                    .send(RpcRequest::GetBlocks, json!([FORK_SLOT - 2, FORK_SLOT]))
+                    .await
+                    .is_err()
+            );
+        }
+    }
+
+    fn token_page(keys: &[Pubkey], next: serde_json::Value) -> serde_json::Value {
+        json!({"context": {"slot": FORK_SLOT}, "value": keys.iter().map(|key| json!({"pubkey": key.to_string()})).collect::<Vec<_>>(), "pageKey": next})
+    }
+
+    fn token_bytes() -> serde_json::Value {
+        json!({"context": {"slot": FORK_SLOT}, "value": {"lamports": 2_039_280,
+            "owner": spl_token_interface::id().to_string(), "data": ["AQ==", "base64"],
+            "executable": false, "rentEpoch": 0}})
+    }
+
+    #[tokio::test]
+    async fn historical_owner_scan_paginates_and_preserves_encoding() {
+        let keys = [Pubkey::new_unique(), Pubkey::new_unique()];
+        let sender = history(vec![
+            Ok(token_page(&keys[..1], json!("next"))),
+            Ok(token_bytes()),
+            Ok(token_page(&keys[1..], json!(null))),
+            Ok(token_bytes()),
+        ]);
+        let query = json!([Pubkey::new_unique().to_string(), {"programId": spl_token_interface::id().to_string()},
+            {"encoding": "base64", "dataSlice": {"offset": 0, "length": 1}}]);
+        let result = sender
+            .send(RpcRequest::GetTokenAccountsByOwner, query.clone())
+            .await
+            .unwrap();
+        assert_eq!(result["value"].as_array().unwrap().len(), 2);
+        let requests = sender.inner.requests.lock().unwrap();
+        assert_eq!(
+            requests[0].0,
+            RpcRequest::Custom {
+                method: "getTokenAccountsByOwnerAtSlot"
+            }
+        );
+        assert_eq!(
+            requests[2].1[2],
+            json!({"slot": FORK_SLOT, "pageLimit": 1000, "pageKey": "next"})
+        );
+        assert_eq!(requests[1].0, RpcRequest::GetAccountInfo);
+        assert_eq!(requests[1].1[1]["dataSlice"], query[2]["dataSlice"]);
+        assert_eq!(requests[1].1[1]["encoding"], "base64");
+        assert_eq!(requests[1].1[1]["slot"], FORK_SLOT);
+    }
+
+    #[tokio::test]
+    async fn historical_owner_scan_rejects_incomplete_or_inconsistent_pages() {
+        let key = Pubkey::new_unique();
+        let mut wrong_slot = token_page(&[], json!(null));
+        wrong_slot["context"]["slot"] = json!(FORK_SLOT + 1);
+        for responses in [
+            vec![Ok(wrong_slot)],
+            vec![
+                Ok(token_page(&[key], json!("next"))),
+                Ok(token_bytes()),
+                Err(ClientErrorKind::Custom("unavailable".into()).into()),
+            ],
+            vec![
+                Ok(token_page(&[], json!("same"))),
+                Ok(token_page(&[], json!("same"))),
+            ],
+            vec![
+                Ok(token_page(&[key], json!("next"))),
+                Ok(token_bytes()),
+                Ok(token_page(&[key], json!(null))),
+            ],
+            vec![
+                Ok(token_page(&[key], json!(null))),
+                Ok(json!({"context": {"slot": FORK_SLOT}, "value": null})),
+            ],
+        ] {
+            assert!(history(responses).send(RpcRequest::GetTokenAccountsByOwner,
+                json!([Pubkey::new_unique().to_string(), {"programId": spl_token_interface::id().to_string()}])).await.is_err());
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn historical_block_rpcs_merge_local_slots_and_propagate_errors() {
+        use crate::{
+            rpc::full::{Full, SurfpoolFullRpc},
+            tests::helpers::TestSetup,
+        };
+        let mut setup = TestSetup::new(SurfpoolFullRpc);
+        setup.context.svm_locker.with_svm_writer(|svm| {
+            svm.genesis_slot = FORK_SLOT;
+            svm.latest_epoch_info.absolute_slot = FORK_SLOT + 3;
+        });
+        setup.context.remote_rpc_client = Some(SurfnetRemoteClient {
+            fork_slot: Some(FORK_SLOT),
+            client: RpcClient::new_sender(
+                history(vec![
+                    Ok(json!([FORK_SLOT - 2, FORK_SLOT - 1])),
+                    Ok(json!([
+                        FORK_SLOT - 2,
+                        FORK_SLOT - 1,
+                        FORK_SLOT,
+                        FORK_SLOT + 1
+                    ])),
+                    Ok(json!(1_600_000_005)),
+                    Err(ClientErrorKind::Custom("unavailable".into()).into()),
+                ]),
+                RpcClientConfig::default(),
+            )
+            .into(),
+        });
+        assert_eq!(
+            setup
+                .rpc
+                .get_blocks(Some(setup.context.clone()), FORK_SLOT - 2, None, None)
+                .await
+                .unwrap(),
+            (FORK_SLOT - 2..=FORK_SLOT + 3).collect::<Vec<_>>()
+        );
+        // This spans over 500,000 slots but asks for only four blocks.
+        assert_eq!(
+            setup
+                .rpc
+                .get_blocks_with_limit(Some(setup.context.clone()), 0, 4, None)
+                .await
+                .unwrap(),
+            (FORK_SLOT - 2..=FORK_SLOT + 1).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            setup
+                .rpc
+                .get_block_time(Some(setup.context.clone()), FORK_SLOT - 1)
+                .await
+                .unwrap(),
+            Some(1_600_000_005)
+        );
+        assert!(
+            setup
+                .rpc
+                .get_block_time(Some(setup.context.clone()), FORK_SLOT + 1)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            setup
+                .rpc
+                .get_blocks(Some(setup.context), FORK_SLOT - 2, None, None)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn historical_owner_scan_merges_local_writes() {
+        use solana_account::Account;
+        use solana_account_decoder::UiAccountEncoding;
+        use solana_program_pack::Pack;
+        use spl_token_interface::state::{Account as SplAccount, AccountState};
+        let (svm, _, _) = SurfnetSvm::default();
+        let locker = SurfnetSvmLocker::new(svm);
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let keys: Vec<_> = (0..3).map(|_| Pubkey::new_unique()).collect();
+        let make_account = |owner, amount| {
+            let mut data = vec![0; SplAccount::LEN];
+            SplAccount {
+                owner,
+                mint,
+                amount,
+                state: AccountState::Initialized,
+                ..Default::default()
+            }
+            .pack_into_slice(&mut data);
+            Account {
+                lamports: 2_039_280,
+                data,
+                owner: spl_token_interface::id(),
+                ..Default::default()
+            }
+        };
+        locker.with_svm_writer(|svm| {
+            svm.latest_epoch_info.absolute_slot = FORK_SLOT + 10;
+            svm.set_account(&keys[0], make_account(owner, 42)).unwrap();
+            svm.set_account(&keys[2], make_account(owner, 5)).unwrap();
+        });
+        let remote = SurfnetRemoteClient {
+            fork_slot: Some(FORK_SLOT),
+            client: RpcClient::new_sender(
+                history(vec![
+                    Ok(token_page(&keys[..2], json!(null))),
+                    Ok(token_bytes()),
+                    Ok(token_bytes()),
+                ]),
+                RpcClientConfig::default(),
+            )
+            .into(),
+        };
+        let accounts = locker
+            .get_token_accounts_by_owner(
+                &Some(remote),
+                owner,
+                &TokenAccountsFilter::ProgramId(spl_token_interface::id()),
+                &RpcAccountInfoConfig {
+                    encoding: Some(UiAccountEncoding::Base64),
+                    min_context_slot: Some(FORK_SLOT + 10),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(accounts.slot, FORK_SLOT + 10);
+        let found: HashSet<_> = accounts
+            .inner
+            .iter()
+            .map(|account| account.pubkey.clone())
+            .collect();
+        assert_eq!(
+            found,
+            [keys[0], keys[1], keys[2]]
+                .iter()
+                .map(ToString::to_string)
+                .collect()
+        );
+        let updated = accounts
+            .inner
+            .iter()
+            .find(|account| account.pubkey == keys[0].to_string())
+            .unwrap()
+            .account
+            .data
+            .decode()
+            .unwrap();
+        assert_eq!(SplAccount::unpack(&updated).unwrap().amount, 42);
+    }
 
     struct ReturnsNull {
         requests: Arc<Mutex<Vec<(RpcRequest, serde_json::Value)>>>,
@@ -706,6 +2020,7 @@ mod tests {
     async fn a_missing_remote_transaction_remains_none_through_the_locker() {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let client = SurfnetRemoteClient {
+            fork_slot: None,
             client: RpcClient::new_sender(
                 ReturnsNull {
                     requests: Arc::clone(&requests),
@@ -744,6 +2059,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn a_remote_transaction_provider_failure_reaches_the_locker_caller() {
         let client = SurfnetRemoteClient {
+            fork_slot: None,
             client: RpcClient::new_sender(ReturnsError, RpcClientConfig::default()).into(),
         };
         let signature = Signature::new_unique();
@@ -884,6 +2200,7 @@ mod tests {
     async fn multiple_account_fetch_uses_the_requested_commitment() {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let client = SurfnetRemoteClient {
+            fork_slot: None,
             client: RpcClient::new_sender(
                 RecordsRequests {
                     requests: Arc::clone(&requests),
@@ -1030,6 +2347,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn a_mint_unknown_to_the_datasource_has_no_remote_token_accounts() {
         let client = SurfnetRemoteClient {
+            fork_slot: None,
             client: RpcClient::new_sender(RejectsUnknownMint, RpcClientConfig::default()).into(),
         };
 
@@ -1043,6 +2361,21 @@ mod tests {
             .expect("a rejected filter is an empty remote answer, not a failure");
 
         assert!(accounts.is_empty());
+        // An error during a historical walk may occur after earlier pages succeeded.
+        let historical = SurfnetRemoteClient {
+            fork_slot: Some(FORK_SLOT),
+            ..client
+        };
+        assert!(
+            historical
+                .get_token_accounts_by_owner(
+                    Pubkey::new_unique(),
+                    &TokenAccountsFilter::Mint(Pubkey::new_unique()),
+                    &RpcAccountInfoConfig::default()
+                )
+                .await
+                .is_err()
+        );
     }
 
     struct RejectsParams;
@@ -1074,6 +2407,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn any_other_invalid_params_rejection_is_still_an_error() {
         let client = SurfnetRemoteClient {
+            fork_slot: None,
             client: RpcClient::new_sender(RejectsParams, RpcClientConfig::default()).into(),
         };
 
@@ -1092,6 +2426,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn an_unknown_mint_answer_on_a_program_filter_is_still_an_error() {
         let client = SurfnetRemoteClient {
+            fork_slot: None,
             client: RpcClient::new_sender(RejectsUnknownMint, RpcClientConfig::default()).into(),
         };
 
@@ -1110,6 +2445,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn a_token_accounts_provider_failure_is_still_an_error() {
         let client = SurfnetRemoteClient {
+            fork_slot: None,
             client: RpcClient::new_sender(ReturnsError, RpcClientConfig::default()).into(),
         };
 
@@ -1164,6 +2500,7 @@ mod tests {
             .unwrap();
         });
         let remote = SurfnetRemoteClient {
+            fork_slot: None,
             client: RpcClient::new_sender(RejectsUnknownMint, RpcClientConfig::default()).into(),
         };
         let config = RpcAccountInfoConfig {

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -280,6 +280,8 @@ const DEFAULT_LOG_BYTES_LIMIT: Option<usize> = Some(10_000);
 pub struct SurfnetSvmConfig {
     pub surfnet_id: String,
     pub feature_config: SvmFeatureConfig,
+    /// Limit the bundled mainnet feature baseline to this slot before applying overrides.
+    pub fork_slot: Option<Slot>,
     pub slot_time: u64,
     pub instruction_profiling_enabled: bool,
     pub max_profiles: usize,
@@ -292,6 +294,7 @@ impl Default for SurfnetSvmConfig {
         Self {
             surfnet_id: "default".to_string(),
             feature_config: SvmFeatureConfig::default(),
+            fork_slot: None,
             slot_time: DEFAULT_SLOT_TIME_MS,
             instruction_profiling_enabled: true,
             max_profiles: DEFAULT_PROFILING_MAP_CAPACITY,
@@ -497,8 +500,18 @@ fn commit_overlay_storage<K, V>(
 /// then activated on top, and features in `config.disable` are deactivated.
 /// This is the single source of truth for the "mainnet defaults + deltas"
 /// semantic promised by `SvmFeatureConfig`.
-fn compose_feature_set(config: &SvmFeatureConfig) -> FeatureSet {
+fn compose_feature_set(config: &SvmFeatureConfig, fork_slot: Option<Slot>) -> FeatureSet {
     let mut feature_set = LiteSVM::mainnet_feature_set();
+    if let Some(slot) = fork_slot {
+        let future_features: Vec<_> = feature_set
+            .active()
+            .iter()
+            .filter_map(|(id, activated_at)| (*activated_at > slot).then_some(*id))
+            .collect();
+        for id in future_features {
+            feature_set.deactivate(&id);
+        }
+    }
     for pubkey in &config.enable {
         debug!("Activating feature {}", pubkey);
         feature_set.activate(pubkey, 0);
@@ -921,7 +934,7 @@ impl SurfnetSvm {
         // config.enable - config.disable) so that the inner LiteSVM is
         // constructed exactly once, with the correct features and feature
         // accounts loaded. See `compose_feature_set` for the composition rules.
-        let feature_set = compose_feature_set(&config.feature_config);
+        let feature_set = compose_feature_set(&config.feature_config, config.fork_slot);
         let storage_backend = StorageBackend::open(&database_url, &surfnet_id)?;
         let inner = SurfnetLiteSvm::new(&storage_backend, feature_set.clone())?;
 
@@ -5605,6 +5618,7 @@ mod tests {
         let config = SurfnetSvmConfig {
             surfnet_id: "constructor-test".to_string(),
             feature_config: SvmFeatureConfig::new().disable(disable_fees_sysvar::id()),
+            fork_slot: None,
             slot_time: 123,
             instruction_profiling_enabled: false,
             max_profiles: 17,
@@ -5639,6 +5653,7 @@ mod tests {
         let config = SurfnetSvmConfig {
             surfnet_id: "remote-init-test".to_string(),
             feature_config: SvmFeatureConfig::new().disable(disable_fees_sysvar::id()),
+            fork_slot: None,
             slot_time: 321,
             instruction_profiling_enabled: false,
             max_profiles: 23,
@@ -5731,6 +5746,24 @@ mod tests {
             "send should succeed when skip_blockhash_check is enabled: {:?}",
             send_result.err().map(|err| err.err)
         );
+    }
+
+    #[test]
+    fn fork_slot_feature_activation_boundary_and_overrides() {
+        let id = agave_feature_set::disable_fees_sysvar::id();
+        let activation = LiteSVM::mainnet_feature_set().activated_slot(&id).unwrap();
+        for (slot, enabled) in [(activation - 1, false), (activation, true)] {
+            let (svm, _, _) = SurfnetSvm::new(SurfnetSvmConfig {
+                fork_slot: Some(slot),
+                ..Default::default()
+            })
+            .unwrap();
+            assert_eq!(svm.feature_set.is_active(&id), enabled);
+        }
+        let overrides = SvmFeatureConfig::new().enable(id);
+        assert!(compose_feature_set(&overrides, Some(activation - 1)).is_active(&id));
+        let overrides = SvmFeatureConfig::new().disable(id);
+        assert!(!compose_feature_set(&overrides, Some(activation)).is_active(&id));
     }
 
     // Feature configuration tests

--- a/crates/sdk/src/surfnet.rs
+++ b/crates/sdk/src/surfnet.rs
@@ -194,6 +194,7 @@ impl SurfnetBuilder {
             max_profiles: surfpool_config.simnets[0].max_profiles,
             log_bytes_limit: surfpool_config.simnets[0].log_bytes_limit,
             feature_config,
+            fork_slot: surfpool_config.simnets[0].fork_slot,
             skip_blockhash_check,
         };
         let (surfnet_svm, simnet_events_rx, geyser_events_rx) = SurfnetSvm::new(svm_config)

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -856,6 +856,9 @@ pub enum StartupPlanner {
 pub struct SimnetConfig {
     pub offline_mode: bool,
     pub remote_rpc_url: Option<String>,
+    /// Finalized slot used for remote account reads. Requires an account archive RPC.
+    #[serde(default)]
+    pub fork_slot: Option<u64>,
     pub slot_time: u64,
     pub block_production_mode: BlockProductionMode,
     pub airdrop_addresses: Vec<Pubkey>,
@@ -880,6 +883,7 @@ impl Default for SimnetConfig {
         Self {
             offline_mode: false,
             remote_rpc_url: Some(DEFAULT_MAINNET_RPC_URL.to_string()),
+            fork_slot: None,
             slot_time: DEFAULT_SLOT_TIME_MS, // Default to 400ms to match CLI default
             block_production_mode: BlockProductionMode::Clock,
             airdrop_addresses: vec![],


### PR DESCRIPTION
Adds `--fork-slot <SLOT>` so the backing RPC behaves as if frozen at that slot. Local transactions and slots continue advancing normally. Behavior without the flag stays unchanged.
